### PR TITLE
Python 2.4 simplejson fix

### DIFF
--- a/webapp/graphite/dashboard/views.py
+++ b/webapp/graphite/dashboard/views.py
@@ -1,6 +1,11 @@
 import re
 import errno
-import json
+
+try:
+  import json
+except ImportError:
+  import simplejson as json
+
 from os.path import getmtime, join, exists
 from urllib import urlencode
 from ConfigParser import ConfigParser


### PR DESCRIPTION
Dashboard part of the site doesn't check for simplejson as a fall back for json like the rest of the site.  This causes saving/loading dashboards on Python 2.4 to fail with a json parse error.
