### PR TITLE
Fixes LP BUG#1006912

### DIFF
--- a/bin/build-index.sh
+++ b/bin/build-index.sh
@@ -14,7 +14,7 @@ fi
 WHISPER_DIR="${GRAPHITE_STORAGE_DIR}/whisper"
 CERES_DIR="${GRAPHITE_STORAGE_DIR}/ceres"
 
-if [ ! -d "$WHISPER_DIR"] || [ ! -d "$CERES_DIR" ]
+if [ ! -d "$WHISPER_DIR" ] || [ ! -d "$CERES_DIR" ]
 then
   echo "Fatal Error: neither $WHISPER_DIR nor $CERES_DIR exist."
   exit 1


### PR DESCRIPTION
there is a very little syntax error in : /opt/graphite/bin/build-index.sh

at line 17:
if [ ! -d "$WHISPER_DIR"] || [ ! -d "$CERES_DIR" ]

it should be :
if [ ! -d "$WHISPER_DIR" ] || [ ! -d "$CERES_DIR" ]

https://bugs.launchpad.net/graphite/+bug/1006912
