### PR TITLE
Improving the robustness of cactiStyle()

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -881,6 +881,8 @@ def cactiStyle(requestContext, seriesList):
     &target=cactiStyle(ganglia.*.net.bytes_out)
 
   """
+  if 0 == len(seriesList):
+      return seriesList
   nameLen = max([len(getattr(series,"name")) for series in seriesList])
   lastLen = max([len(repr(int(safeLast(series) or 3))) for series in seriesList]) + 3
   maxLen = max([len(repr(int(safeMax(series) or 3))) for series in seriesList]) + 3


### PR DESCRIPTION
Using cactiStyle() with filters can cause problems when filters filter all data series, for example;

cactiStyle(currentAbove(sin("test", 2),3))

Causes a ValueError: max() arg is an empty sequence, as an empty seriesList is passed into the function.
