### PR TITLE
Allow timeShift() to show values in the future

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1878,7 +1878,7 @@ def dashed(requestContext, *seriesList):
   return seriesList[0]
 
 
-def timeShift(requestContext, seriesList, timeShift):
+def timeShift(requestContext, seriesList, timeShift, resetEnd=True):
   """
   Takes one metric or a wildcard seriesList, followed by a quoted string with the
   length of time (See ``from / until`` in the render\_api_ for examples of time formats).
@@ -1886,6 +1886,12 @@ def timeShift(requestContext, seriesList, timeShift):
   Draws the selected metrics shifted in time. If no sign is given, a minus sign ( - ) is
   implied which will shift the metric back in time. If a plus sign ( + ) is given, the
   metric will be shifted forward in time.
+
+  Will reset the end date range automatically to the end of the base stat unless
+  resetEnd is False. Example case is when you timeshift to last week and have the graph
+  date range set to include a time in the future, will limit this timeshift to pretend
+  ending at the current time. If resetEnd is False, will instead draw full range including
+  future time.
 
   Useful for comparing a metric against itself at a past periods or correcting data
   stored at an offset.
@@ -1911,8 +1917,11 @@ def timeShift(requestContext, seriesList, timeShift):
 
   for shiftedSeries in evaluateTarget(myContext, series.pathExpression):
     shiftedSeries.name = 'timeShift(%s, %s)' % (shiftedSeries.name, timeShift)
+    if resetEnd:
+      shiftedSeries.end = series.end
+    else:
+      shiftedSeries.end = shiftedSeries.end - shiftedSeries.start + series.start
     shiftedSeries.start = series.start
-    shiftedSeries.end = series.end
     results.append(shiftedSeries)
 
   return results


### PR DESCRIPTION
Often times, I would like to show trending lines on a graph to help predict where a current metric is heading. But timeShift() will force end a metric early not letting me see data that is occurring in the future. Sample metric that is handy but unable to be display (assuming "now" is like Noon on 2012-06-18):

?target=integral(timeShift(site.visitors,"1w",False))
&target=integral(site.visitors)
&from=00%3A00_20120618
&until=23%3A59_20120618

This will allow the timeShifted record of one week ago to display the full days worth of values on a graph, from midnight to midnight. Before, this would only show until the current time.
