### PR TITLE
Make _APP_SETTINGS_LOADED trick work.

### DIFF
--- a/webapp/graphite/app_settings.py
+++ b/webapp/graphite/app_settings.py
@@ -92,4 +92,4 @@ INSTALLED_APPS = (
 
 AUTHENTICATION_BACKENDS = ['django.contrib.auth.backends.ModelBackend']
 
-_APP_SETTINGS_LOADED = True
+GRAPHITE_WEB_APP_SETTINGS_LOADED = True

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -18,7 +18,7 @@ from django import VERSION as DJANGO_VERSION
 from os.path import abspath, dirname, join
 
 
-_APP_SETTINGS_LOADED = False
+GRAPHITE_WEB_APP_SETTINGS_LOADED = False
 WEBAPP_VERSION = '0.10.0-alpha'
 DEBUG = False
 JAVASCRIPT_DEBUG = False
@@ -114,7 +114,7 @@ except ImportError:
   print >> sys.stderr, "Could not import graphite.local_settings, using defaults!"
 
 ## Load Django settings if they werent picked up in local_settings
-if not _APP_SETTINGS_LOADED:
+if not GRAPHITE_WEB_APP_SETTINGS_LOADED:
   from graphite.app_settings import *
 
 ## Set config dependent on flags set in local_settings


### PR DESCRIPTION
"from … import *" doesn't import private variables
so _APP_SETTINGS_LOADED trick doesn't work
and there is no way to override app_settings from
local_settings. This is fixed by changing the option
name to GRAPHITE_WEB_APP_SETTINGS_LOADED.
