### PR TITLE
fixed test for ceres dependency

### DIFF
--- a/check-dependencies.py
+++ b/check-dependencies.py
@@ -23,7 +23,7 @@ except:
 
 # Test for ceres
 try:
-  import whisper
+  import ceres
 except:
   print "[FATAL] Unable to import the 'ceres' module, please download this package from the Graphite project page and install it."
   fatal += 1


### PR DESCRIPTION
The check imports the whisper module instead of ceres. I'm installing graphite for the first time so the check_dependencies.py script is very useful, but it failed to deted that I missed that module.
