### PR TITLE
Fix for unnecessary rendering while loading a saved graph

### DIFF
--- a/webapp/content/js/composer.js
+++ b/webapp/content/js/composer.js
@@ -24,9 +24,14 @@ function GraphiteComposer () {
 }
 
 GraphiteComposer.prototype = {
-  toggleTarget: function (target) {
+  toggleTargetWithoutUpdate: function(target) {
+   this.toggleTarget(target, false); 
+  },
+
+  toggleTarget: function (target, updateImage) {
     /* Add the given target to the graph if it does not exist,
-     * otherwise remove it. */
+     * otherwise remove it. 
+     * Optionally reload the image. (default = do update) */
     var record = getTargetRecord(target);
 
     if (record) {
@@ -35,7 +40,11 @@ GraphiteComposer.prototype = {
       addTarget(target);
     }
     this.syncTargetList();
-    this.updateImage();
+
+    // If the updateImage parameter is unspecified or true, reload the image.
+    if(undefined == updateImage || true == updateImage) {
+      this.updateImage();
+    }
   },
 
   loadMyGraph: function (name, url) {
@@ -51,7 +60,11 @@ GraphiteComposer.prototype = {
     var targets = tempUrl.getParamList('target');
     tempUrl.removeParam('target');
     this.url.setQueryString(tempUrl.queryString);
-    Ext.each(targets, this.toggleTarget, this);
+
+    /* Use ...WithoutUpdate here to avoid loading the image too soon. If
+     * there are lots of targets, each modification would cause an extra
+     * render. */
+    Ext.each(targets, this.toggleTargetWithoutUpdate, this);
 
     // Fit the image into the window
     this.url.setParam('width', this.window.getInnerWidth());


### PR DESCRIPTION
When loading a saved graph, `toggleTarget` is called several times, once for each target being added or removed. This causes lots, potentially dozens, of unnecessary and expensive calls to `/render`, all separated by a few milliseconds, and the user never sees any benefit. Instead, the user is kept waiting while all these unwanted charts are rendered.

This change adds an optional parameter to `toggleTarget` to turn off graph updating, a new wrapper function for `toggleTarget` called `toggleTargetWithoutUpdate`, and graph loading uses it.
