### PR TITLE
passing regexp to allow timezone entry in composer (LP bug #1022955)

### DIFF
--- a/webapp/content/js/composer_widgets.js
+++ b/webapp/content/js/composer_widgets.js
@@ -1096,7 +1096,7 @@ function createOptionsMenu() {
   var xAxisMenu = new Ext.menu.Menu({
     items: [
       menuInputItem("Time Format", "xFormat", "Enter the time format (see Python's datetime.strftime())", /^$/),
-      menuInputItem("Timezone", "tz", "Enter the timezone to display (e.g. UTC or America/Chicago)"),
+      menuInputItem("Timezone", "tz", "Enter the timezone to display (e.g. UTC or America/Chicago)", /^$/),
       menuInputItem("Point-width Consolidation Threshold", "minXStep", "Enter the closest number of pixels between points before consolidation")
     ]
   });


### PR DESCRIPTION
composer wasn't allowing entry of timezones like "America/Los_Angeles" under the x-axis timezone graph option
