### PR TITLE
Allow a metric(s) to be hidden from the legend

### DIFF
--- a/webapp/content/js/composer_widgets.js
+++ b/webapp/content/js/composer_widgets.js
@@ -987,6 +987,7 @@ function createFunctionsMenu() {
                         {text: "Min", handler: applyFuncToEach('consolidateBy', '"min"')}
                       ]},
         {text: 'Draw non-zero As Infinite', handler: applyFuncToEach('drawAsInfinite')},
+        {text: 'Hide from Legend', handler: applyFuncToEach('hideFromLegend')},
         {text: 'Line Width', handler: applyFuncToEachWithInput('lineWidth', 'Please enter a line width for this graph target')},
         {text: 'Dashed Line', handler: applyFuncToEach('dashed')},
         {text: 'Keep Last Value', handler: applyFuncToEach('keepLastValue')},

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1855,6 +1855,23 @@ def drawAsInfinite(requestContext, seriesList):
     series.name = 'drawAsInfinite(%s)' % series.name
   return seriesList
 
+def hideFromLegend(requestContext, seriesList):
+  """
+  Takes one metric or a wildcard seriesList.
+  It will not draw the metric on the legend.
+
+  Example:
+
+  .. code-block:: none
+
+    &target=hideFromLegend(server01.instance01.memory.free,5)
+
+  """
+  for series in seriesList:
+    series.options['hideFromLegend'] = True
+    series.name = 'hideFromLegend(%s)' % series.name
+  return seriesList
+
 def lineWidth(requestContext, seriesList, width):
   """
   Takes one metric or a wildcard seriesList, followed by a float F.
@@ -2571,6 +2588,7 @@ SeriesFunctions = {
   'consolidateBy' : consolidateBy,
   'keepLastValue' : keepLastValue,
   'drawAsInfinite' : drawAsInfinite,
+  'hideFromLegend' : hideFromLegend,
   'secondYAxis': secondYAxis,
   'lineWidth' : lineWidth,
   'dashed' : dashed,

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -316,7 +316,7 @@ class Graph:
       lineHeight = extents['maxHeight'] + 1
       labelWidth = extents['width'] + 2 * (boxSize + padding)
       columns = max(1, math.floor( (self.width - self.area['xmin']) / labelWidth ))
-      numRight = len([name for (name,color,rightSide) in elements if rightSide])
+      numRight = len([name for (name,color,rightSide,hideFromLegend) in elements if rightSide])
       numberOfLines = max(len(elements) - numRight, numRight)
       columns = math.floor(columns / 2.0) 
       if columns < 1: columns = 1
@@ -329,7 +329,7 @@ class Graph:
       xRight = self.area['xmax'] - self.area['xmin']
       yRight = y
       nRight = 0
-      for (name,color,rightSide) in elements:
+      for (name,color,rightSide,hideFromLegend) in elements:
         self.setColor( color )
         if rightSide:
           nRight += 1 
@@ -366,7 +366,7 @@ class Graph:
       self.ctx.set_line_width(1.0)
       x = self.area['xmin']
       y = self.area['ymax'] + (2 * padding)
-      for i,(name,color,rightSide) in enumerate(elements):
+      for i,(name,color,rightSide,hideFromLegend) in enumerate(elements):
         if rightSide:
           self.setColor( color )
           self.drawRectangle(x + labelWidth + padding,y,boxSize,boxSize)
@@ -624,7 +624,7 @@ class LineGraph(Graph):
     self.setFont()
 
     if not params.get('hideLegend', len(self.data) > settings.LEGEND_MAX_ITEMS):
-      elements = [ (series.name,series.color,series.options.get('secondYAxis')) for series in self.data if series.name ]
+      elements = [ (series.name,series.color,series.options.get('secondYAxis'), series.options.get('hideFromLegend')) for series in self.data if series.name ]
       self.drawLegend(elements, params.get('uniqueLegend', False))
 
     #Setup axes, labels, and grid


### PR DESCRIPTION
This will allow a metric to be hidden from the legend. Our use case is
we want to plot deploys but not show the metric name in the legend
since a vertical line is assumed as a deploy.
