### PR TITLE
Updated check-dependencies.py to check for both ceres and whisper. 

### DIFF
--- a/check-dependencies.py
+++ b/check-dependencies.py
@@ -23,7 +23,7 @@ except:
 
 # Test for ceres
 try:
-  import whisper
+  import ceres
 except:
   print "[FATAL] Unable to import the 'ceres' module, please download this package from the Graphite project page and install it."
   fatal += 1


### PR DESCRIPTION
check-dependencies.py was importing whisper twice, instead of both whisper and ceres.  Changed second whisper check to check ceres.  Comments now align with code.  Left ceres as a FATAL dependency.

Committer: penland365
