### PR TITLE
Cosmetic Dashboard Fix displaying relative times

### DIFF
--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -1086,7 +1086,7 @@ var TimeRange = {
 function getTimeText() {
   if (TimeRange.type == 'relative') {
     var text = "Now showing the past " + TimeRange.relativeStartQuantity + " " + TimeRange.relativeStartUnits;
-    if (TimeRange.relativeUntilUnits != 'now') {
+    if (TimeRange.relativeUntilUnits !== 'now' && TimeRange.relativeUntilUnits !== '') {
       text = text + " until " + TimeRange.relativeUntilQuantity + " " + TimeRange.relativeUntilUnits + " ago";
     }
     return text;
@@ -2294,15 +2294,17 @@ function applyState(state) {
   //state.timeConfig = {type, quantity, units, untilQuantity, untilUnits, startDate, startTime, endDate, endTime}
   var timeConfig = state.timeConfig
   TimeRange.type = timeConfig.type;
-  TimeRange.relativeStartQuantity = timeConfig.quantity;
-  TimeRange.relativeStartUnits = timeConfig.units;
-  TimeRange.relativeUntilQuantity = timeConfig.untilQuantity;
-  TimeRange.relativeUntilUnits = timeConfig.untilUnits;
+  TimeRange.relativeStartQuantity = timeConfig.relativeStartQuantity;
+  TimeRange.relativeStartUnits = timeConfig.relativeStartUnits;
+  TimeRange.relativeUntilQuantity = timeConfig.relativeUntilQuantity;
+  TimeRange.relativeUntilUnits = timeConfig.relativeUntilUnits;
   TimeRange.startDate = new Date(timeConfig.startDate);
   TimeRange.startTime = timeConfig.startTime;
   TimeRange.endDate = new Date(timeConfig.endDate);
   TimeRange.endTime = timeConfig.endTime;
   updateTimeText();
+
+
 
   //state.refreshConfig = {enabled, interval}
   var refreshConfig = state.refreshConfig;


### PR DESCRIPTION
Displaying relative times on a loaded dashboard occasionally displays as "Now showing undefined undefined through undefined undefined". This ensures that it displays the correct relative and absolute times in the dashboard summary.
