### PR TITLE
Update webapp/graphite/render/functions.py

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1972,7 +1972,7 @@ def constantLine(requestContext, value):
   """
   start = timestamp( requestContext['startTime'] )
   end = timestamp( requestContext['endTime'] )
-  step = (end - start) / 2.0
+  step = (end - start) / 1.0
   series = TimeSeries(str(value), start, end, step, [value, value])
   return [series]
 


### PR DESCRIPTION
resolve an issue where constantLine() only draws a line that is half the width of a rendered graph.

Here is a screenshot showing a sample metric with lineMode=staircase and this proposed fix.
<img src="https://dl.dropbox.com/u/12944066/Screen%20Shot%202012-09-24%20at%205.56.53%20PM.png">
