### PR TITLE
Add functions.invert

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -522,6 +522,23 @@ def scale(requestContext, seriesList, factor):
       series[i] = safeMul(value,factor)
   return seriesList
 
+def invert(requestContext, seriesList):
+  """
+  Takes one metric or a wildcard seriesList, and inverts each datapoint (i.e. 1/x).
+
+  Example:
+
+  .. code-block:: none
+
+    &target=invert(Server.instance01.threads.busy)
+
+  """
+  for series in seriesList:
+    series.name = "invert(%s)" % (series.name)
+    for i,value in enumerate(series):
+      series[i] = safeDiv(1,value)
+  return seriesList
+
 def scaleToSeconds(requestContext, seriesList, seconds):
   """
   Takes one metric or a wildcard seriesList and returns "value per seconds" where
@@ -2511,6 +2528,7 @@ SeriesFunctions = {
 
   # Transform functions
   'scale' : scale,
+  'invert' : invert,
   'scaleToSeconds' : scaleToSeconds,
   'offset' : offset,
   'derivative' : derivative,


### PR DESCRIPTION
`invert(a)` can operate on multiple series, which isn't expressible with `divideSeries(1/a)` since the latter only accepts a single series in its denominator.
