### PR TITLE
add support for countSeries (master)

### DIFF
--- a/webapp/content/js/composer_widgets.js
+++ b/webapp/content/js/composer_widgets.js
@@ -900,7 +900,8 @@ function createFunctionsMenu() {
         {text: 'Min Values', handler: applyFuncToAll('minSeries')},
         {text: 'Max Values', handler: applyFuncToAll('maxSeries')},
         {text: 'Group', handler: applyFuncToAll('group')},
-        {text: 'Range', handler: applyFuncToAll('rangeOfSeries')}
+        {text: 'Range', handler: applyFuncToAll('rangeOfSeries')},
+        {text: 'Count', handler: applyFuncToEach('countSeries')}
       ]
     }, {
       text: 'Transform',

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2044,6 +2044,22 @@ def transformNull(requestContext, seriesList, default=0):
     del series[:len(values)]
   return seriesList
 
+def countSeries(requestContext, *seriesLists):
+  """
+  Draws a horizontal line representing the number of nodes found in the seriesList.
+
+  .. code-block:: none
+
+    &target=countSeries(carbon.agents.*.*)
+
+  """
+  (seriesList,start,end,step) = normalize(seriesLists)
+  name = "countSeries(%s)" % ','.join(set([s.pathExpression for s in seriesList]))
+  values = ( int(len(row)) for row in izip(*seriesList) )
+  series = TimeSeries(name,start,end,step,values)
+  series.pathExpression = name
+  return [series]
+
 def group(requestContext, *seriesLists):
   """
   Takes an arbitrary number of seriesLists and adds them to a single seriesList. This is used
@@ -2525,6 +2541,7 @@ SeriesFunctions = {
   'maxSeries' : maxSeries,
   'rangeOfSeries': rangeOfSeries,
   'percentileOfSeries': percentileOfSeries,
+  'countSeries': countSeries,
 
   # Transform functions
   'scale' : scale,


### PR DESCRIPTION
Originally requested by @jib this adds a new function `countSeries()` which returns a series of the number of nodes represented by a wildcard seriesList. This can in turn be passed to other functions like `scale()`.

The original use case was to be able to calculate an aggregate threshold based on the number of nodes existing in their system at any point in time. Example:

```
scale(countSeries(graphite-foobar-com.*.cpu-system.value),6)
```
