### PR TITLE
Use Twisted==11.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@
 #
 
 Django==1.3
-Twisted==11.0.0
+Twisted==11.1.0
 python-memcached==1.47
 txAMQP==0.4
 simplejson==2.1.6


### PR DESCRIPTION
Carbon requires Twisted 11.1.0, but graphite-web has been requiring
11.0.0.  This means that, if installed on the same machine, one of the
versions will be overwritten by the other, depending on which one you
install first.  This is silly.

See: #35
