### PR TITLE
Update safeDiff and safeSum

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -46,12 +46,12 @@ INF = float('inf')
 #Utility functions
 def safeSum(values):
   safeValues = [v for v in values if v is not None]
-  if safeValues:
+  if safeValues and len(safeValues) > 1:
     return sum(safeValues)
 
 def safeDiff(values):
   safeValues = [v for v in values if v is not None]
-  if safeValues:
+  if safeValues and len(safeValues) > 1:
     values = map(lambda x: x*-1, safeValues[1:])
     values.insert(0, safeValues[0])
     return sum(values)


### PR DESCRIPTION
Graphite usually treats 'None' values as missing data which results in breaks in the lines of the graph. However, the sum and diff functions will basically treat them as a 0 value which can make the graph inaccurate when adding or diffing 2 series. This update checks to make sure that there are at least 2 values to be summed or diffed and if not will not do the diff/sum. This falls more in line with the way that graphite handles 'None' values IMHO.
