### PR TITLE
Add functions resample() and smooth()

### DIFF
--- a/webapp/content/js/composer_widgets.js
+++ b/webapp/content/js/composer_widgets.js
@@ -917,7 +917,8 @@ function createFunctionsMenu() {
         {text: 'Absolute Value', handler: applyFuncToEach('absolute')},
         {text: 'timeShift', handler: applyFuncToEachWithInput('timeShift', 'Shift this metric ___ back in time (examples: 10min, 7d, 2w)', {quote: true})},
         {text: 'Summarize', handler: applyFuncToEachWithInput('summarize', 'Please enter a summary interval (examples: 10min, 1h, 7d)', {quote: true})},
-        {text: 'Hit Count', handler: applyFuncToEachWithInput('hitcount', 'Please enter a summary interval (examples: 10min, 1h, 7d)', {quote: true})}
+        {text: 'Hit Count', handler: applyFuncToEachWithInput('hitcount', 'Please enter a summary interval (examples: 10min, 1h, 7d)', {quote: true})},
+        {text: 'Smooth', handler: applyFuncToEachWithInput('smooth', 'Please enter the number of pixels to average for each potin')}
       ]
     }, {
       text: 'Calculate',
@@ -930,7 +931,8 @@ function createFunctionsMenu() {
         {text: 'Holt-Winters Aberration', handler: applyFuncToEach('holtWintersAberration')},
         {text: 'As Percent', handler: applyFuncToEachWithInput('asPercent', 'Please enter the value that corresponds to 100% or leave blank to use the total', {allowBlank: true})},
         {text: 'Difference (of 2 series)', handler: applyFuncToAll('diffSeries')},
-        {text: 'Ratio (of 2 series)', handler: applyFuncToAll('divideSeries')}
+        {text: 'Ratio (of 2 series)', handler: applyFuncToAll('divideSeries')},
+        {text: 'Resample', handler: applyFuncToEachWithInput('resample', 'Please enter the desired points-per-pixel for the new resolution')}
       ]
     }, {
       text: 'Filter',

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -49,6 +49,8 @@ def renderView(request):
     'startTime' : requestOptions['startTime'],
     'endTime' : requestOptions['endTime'],
     'localOnly' : requestOptions['localOnly'],
+    'width' : graphOptions['width'],
+    'height' : graphOptions['height'],
     'data' : []
   }
   data = requestContext['data']


### PR DESCRIPTION
Functions: add resample() for performance and sanity
* Drastically speeds up further calcuations on the returned series
* Makes it much easier to have a consistent datapoints / pixels ratio
  for movingAverage() and friends.

Functions: add smooth() as a movingAverage over pixels
* Internally does a movingAverage(resample()).
* Provides consistent smoothing over a given number of graph pixels,
  instead of a number of datapoints of arbitrary time width.
* Still provides consistent smoothing when there are fewer datapoints
  than pixels.