### PR TITLE
fix bug in cactiStyle (failing when no series data is available at all)

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -930,10 +930,10 @@ def cactiStyle(requestContext, seriesList, system=None):
       fmt = lambda x:"%2.f%s" % format_units(x,system=system)
   else:
       fmt = lambda x:"%2.f"%x
-  nameLen = max([len(getattr(series,"name")) for series in seriesList])
-  lastLen = max([len(fmt(int(safeLast(series) or 3))) for series in seriesList]) + 3
-  maxLen = max([len(fmt(int(safeMax(series) or 3))) for series in seriesList]) + 3
-  minLen = max([len(fmt(int(safeMin(series) or 3))) for series in seriesList]) + 3
+  nameLen = max([0] + [len(getattr(series,"name")) for series in seriesList])
+  lastLen = max([0] + [len(fmt(int(safeLast(series) or 3))) for series in seriesList]) + 3
+  maxLen = max([0] + [len(fmt(int(safeMax(series) or 3))) for series in seriesList]) + 3
+  minLen = max([0] + [len(fmt(int(safeMin(series) or 3))) for series in seriesList]) + 3
   for series in seriesList:
       name = series.name
       last = fmt(float(safeLast(series)))


### PR DESCRIPTION
When using cactiStyle on a group of serieses and none of them contains any data, cactiStyle fails:

```
Traceback (most recent call last):
  File "/home/ssmon/graphite-env/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 111, in get_response
    response = callback(request, *callback_args, **callback_kwargs)
  File "/opt/graphite/webapp/graphite/render/views.py", line 104, in renderView
    seriesList = evaluateTarget(requestContext, target)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 10, in evaluateTarget
    result = evaluateTokens(requestContext, tokens)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 21, in evaluateTokens
    return evaluateTokens(requestContext, tokens.expression)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 29, in evaluateTokens
    return func(requestContext, *args)
  File "/opt/graphite/webapp/graphite/render/functions.py", line 836, in cactiStyle
    nameLen = max([] + [len(getattr(series,"name")) for series in seriesList])
ValueError: max() arg is an empty sequence
```

The proposed pull request fixes this
