### PR TITLE
enable special character support

### DIFF
--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -22,6 +22,8 @@ from graphite.storage import STORE
 from graphite.metrics.search import searcher
 from graphite.carbonlink import CarbonLink
 import fnmatch, os
+from urllib import unquote
+
 
 try:
   import cPickle as pickle
@@ -257,7 +259,7 @@ def tree_json(nodes, base_path, wildcards=False):
 
     found.add(node.name)
     resultNode = {
-      'text' : str(node.name),
+      'text' : unquote(str(node.name)),
       'id' : base_path + str(node.name),
     }
 

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -20,6 +20,7 @@ from ConfigParser import SafeConfigParser
 from django.conf import settings
 from graphite.render.datalib import TimeSeries
 from graphite.util import json
+from urllib import unquote
 
 
 try: # See if there is a system installation of pytz first
@@ -627,7 +628,7 @@ class LineGraph(Graph):
     self.setFont()
 
     if not params.get('hideLegend', len(self.data) > settings.LEGEND_MAX_ITEMS):
-      elements = [ (series.name,series.color,series.options.get('secondYAxis')) for series in self.data if series.name ]
+      elements = [ (unquote(series.name),series.color,series.options.get('secondYAxis')) for series in self.data if series.name ]
       self.drawLegend(elements, params.get('uniqueLegend', False))
 
     #Setup axes, labels, and grid


### PR DESCRIPTION
allow user to send URLEncoded metric name to Graphite and display correctly, it won't break any existing data, but if user want some thing not allowed before, ex "server/name/test", if they URLEncode it, this change will allow Graphite to display/show metric name correctly.