### PR TITLE
Forcing colorList to be a string

### DIFF
--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -172,7 +172,7 @@ class Graph:
     self.drawRectangle( 0, 0, self.width, self.height )
 
     if 'colorList' in params:
-      colorList = unquote_plus( params['colorList'] ).split(',')
+      colorList = unquote_plus( str(params['colorList']) ).split(',')
     else:
       colorList = self.defaultColorList
     self.colors = itertools.cycle( colorList )


### PR DESCRIPTION
When you pass a single color to colorList that is an integer (ex 646464),
it was giving the error "'int' object has no attribute 'replace'"
