### PR TITLE
added pathExpression to timeFunction to allow calculations

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2449,11 +2449,13 @@ def timeFunction(requestContext, name):
     values.append(time.mktime(when.timetuple()))
     when += delta
 
-  return [TimeSeries(name,
+  series = TimeSeries(name,
             time.mktime(requestContext["startTime"].timetuple()),
             time.mktime(requestContext["endTime"].timetuple()),
-            step, values)]
+            step, values)
+  series.pathExpression = name
 
+  return [series]
 
 def sinFunction(requestContext, name, amplitude=1):
   """


### PR DESCRIPTION
timeFunction is missing pathExpression and unusable in series calculations. eg. diffSeries(time("time.series"),server.boottime)
