### PR TITLE
Support Django 1.4 database engine changes transparently

### DIFF
--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -93,13 +93,26 @@ USE_REMOTE_USER_AUTHENTICATION = False
 # Override to link a different URL for login (e.g. for django_openid_auth)
 LOGIN_URL = '/account/login'
 
-#Initialize database settings - Old style (pre 1.2)
-DATABASE_ENGINE = 'django.db.backends.sqlite3'	# 'postgresql', 'mysql', 'sqlite3' or 'ado_mssql'.
-DATABASE_NAME = ''				# Or path to database file if using sqlite3.
-DATABASE_USER = ''				# Not used with sqlite3.
-DATABASE_PASSWORD = ''				# Not used with sqlite3.
-DATABASE_HOST = ''				# Set to empty string for localhost. Not used with sqlite3.
-DATABASE_PORT = ''				# Set to empty string for default. Not used with sqlite3.
+if DJANGO_VERSION < (1,4):
+  #Initialize database settings - Old style (pre 1.2)
+  DATABASE_ENGINE = 'django.db.backends.sqlite3'	# 'postgresql', 'mysql', 'sqlite3' or 'ado_mssql'.
+  DATABASE_NAME = ''				# Or path to database file if using sqlite3.
+  DATABASE_USER = ''				# Not used with sqlite3.
+  DATABASE_PASSWORD = ''				# Not used with sqlite3.
+  DATABASE_HOST = ''				# Set to empty string for localhost. Not used with sqlite3.
+  DATABASE_PORT = ''				# Set to empty string for default. Not used with sqlite3.
+else:
+  DATABASES = {
+    'default': {
+      'NAME': '/opt/graphite/storage/graphite.db',
+      'ENGINE': 'django.db.backends.sqlite3',
+      'USER': '',
+      'PASSWORD': '',
+      'HOST': '',
+      'PORT': ''
+  }
+}
+
 
 # If using rrdcached, set to the address or socket of the daemon
 FLUSHRRDCACHED = ''
@@ -158,9 +171,14 @@ if not STANDARD_DIRS:
 
 # Default sqlite db file
 # This is set here so that a user-set STORAGE_DIR is available
-if 'sqlite3' in DATABASE_ENGINE \
-    and not DATABASE_NAME:
-  DATABASE_NAME = join(STORAGE_DIR, 'graphite.db')
+if DJANGO_VERSION < (1,4):
+  if 'sqlite3' in DATABASE_ENGINE \
+      and not DATABASE_NAME:
+    DATABASE_NAME = join(STORAGE_DIR, 'graphite.db')
+else:
+  if 'sqlite3' in DATABASES.get('default',{}).get('ENGINE','') \
+      and not DATABASES.get('default',{}).get('NAME'):
+    DATABASES['default']['NAME'] = join(STORAGE_DIR, 'graphite.db')
 
 # Caching shortcuts
 if MEMCACHE_HOSTS:


### PR DESCRIPTION
Minor change to support both Django Database Engine types transparently.

Allows < 1.4 and 1.4+ versions of Django to work without burdening the administrator.
