### PR TITLE
When using functions like removeBelowValue, data series might be empty. ...

### DIFF
--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -638,7 +638,7 @@ class LineGraph(Graph):
     self.setFont()
 
     if not params.get('hideLegend', len(self.data) > settings.LEGEND_MAX_ITEMS):
-      elements = [ (series.name,series.color,series.options.get('secondYAxis')) for series in self.data if series.name ]
+      elements = [ (series.name,series.color,series.options.get('secondYAxis')) for series in self.data if series.name and not all(v is None for v in series) ]
       self.drawLegend(elements, params.get('uniqueLegend', False))
 
     #Setup axes, labels, and grid


### PR DESCRIPTION
When using functions like removeBelowValue, data series might be empty. Legends of such empty series are still shown, which is not so perfect especially when the number of legends are not small. Added check for such condition so such legends are ignored automatically.