### PR TITLE
Pin pyparsing to 1.5.7 since 2.0.0 doesn't support python <3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,6 @@ simplejson==2.1.6
 django-tagging==0.3.1
 gunicorn
 pytz
-pyparsing
+pyparsing==1.5.7
 http://cairographics.org/releases/py2cairo-1.8.10.tar.gz
 git+git://github.com/graphite-project/whisper.git#egg=whisper


### PR DESCRIPTION
Pyparsing 2.0.0 only works for python 3.0.  Pin to 1.5.7 to keep the installer from blowing up.
