### PR TITLE
pyparsing version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,6 @@ simplejson==2.1.6
 django-tagging==0.3.1
 gunicorn
 pytz
-pyparsing
+pyparsing==1.5.7
 http://cairographics.org/releases/py2cairo-1.8.10.tar.gz
 git+git://github.com/graphite-project/whisper.git#egg=whisper


### PR DESCRIPTION
According to http://pyparsing.wikispaces.com/ 1.5.7 is the latest python 2 compatible version. This patch set version for pyparsing in requirements.txt 
