### PR TITLE
Require pyparsing<2.0.0 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,6 @@ simplejson==2.1.6
 django-tagging==0.3.1
 gunicorn
 pytz
-pyparsing
+pyparsing<2.0.0
 http://cairographics.org/releases/py2cairo-1.8.10.tar.gz
 git+git://github.com/graphite-project/whisper.git#egg=whisper


### PR DESCRIPTION
pyparsing 2.0.0 only supports Python 3.x, and trying to install it on
Python 2.x fails with an error:

  Traceback (most recent call last):
    [...]
    File "pyparsing.py", line 629
      nonlocal limit,foundArity
                   ^
  SyntaxError: invalid syntax

See http://sourceforge.net/projects/pyparsing/forums/forum/337293/topic/6481050
