### PR TITLE
Fixing TypeCast errors for time based functions.

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2587,8 +2587,8 @@ def timeFunction(requestContext, name):
     when += delta
 
   series = TimeSeries(name,
-            time.mktime(requestContext["startTime"].timetuple()),
-            time.mktime(requestContext["endTime"].timetuple()),
+            int(time.mktime(requestContext["startTime"].timetuple())),
+            int(time.mktime(requestContext["endTime"].timetuple())),
             step, values)
   series.pathExpression = name
 
@@ -2619,8 +2619,8 @@ def sinFunction(requestContext, name, amplitude=1):
     when += delta
 
   return [TimeSeries(name,
-            time.mktime(requestContext["startTime"].timetuple()),
-            time.mktime(requestContext["endTime"].timetuple()),
+            int(time.mktime(requestContext["startTime"].timetuple())),
+            int(time.mktime(requestContext["endTime"].timetuple())),
             step, values)]
 
 def randomWalkFunction(requestContext, name):
@@ -2650,8 +2650,8 @@ def randomWalkFunction(requestContext, name):
     when += delta
 
   return [TimeSeries(name,
-            time.mktime(requestContext["startTime"].timetuple()),
-            time.mktime(requestContext["endTime"].timetuple()),
+            int(time.mktime(requestContext["startTime"].timetuple())),
+            int(time.mktime(requestContext["endTime"].timetuple())),
             step, values)]
 
 def events(requestContext, *tags):


### PR DESCRIPTION
Several functions were returning floating point startTime and endTime.

As a result, urls like the following would fail.

/render/?target=keepLastValue(sin("sin"))&from=-5minutes&format=json

The resulting error stack looks like...

Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/django/core/handlers/base.py",
line 111, in get_response
    response = callback(request, _callback_args, *_callback_kwargs)
  File "/opt/graphite/webapp/graphite/render/views.py", line 126, in
renderView
    timestamps = range(series.start, series.end, series.step)
TypeError: range() integer end argument expected, got float.
