### PR TITLE
Fix legendHeight when rendering secondYAxis (0.9.x)

### DIFF
--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -330,7 +330,7 @@ class Graph:
       numberOfLines = max(len(elements) - numRight, numRight)
       columns = math.floor(columns / 2.0)
       if columns < 1: columns = 1
-      legendHeight = numberOfLines * (lineHeight + padding)
+      legendHeight = (numberOfLines / columns) * (lineHeight + padding)
       self.area['ymax'] -= legendHeight #scoot the drawing area up to fit the legend
       self.ctx.set_line_width(1.0)
       x = self.area['xmin']


### PR DESCRIPTION
We need to divide `numberOfLines` by `columns` when calculating our `lineHeight` for graphs using `secondYAxis`.

Before:
![render](https://f.cloud.github.com/assets/494338/334110/f9d00b02-9c6b-11e2-9f7a-a45c0bfaccd6.png)

After:
![render2](https://f.cloud.github.com/assets/494338/334112/fd6f9598-9c6b-11e2-9d29-c6baa05d8c40.png)

See #253 for discussion.
