### PR TITLE
Add Support for JSON POST requests

### DIFF
--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -194,7 +194,7 @@ def renderView(request):
 def parseOptions(request):
   content_type = request.META.get('CONTENT_TYPE', '')
   if content_type.startswith('application/json'):
-    queryParams = json.loads(request.raw_post_data)
+    queryParams = json.loads(request.raw_post_data.strip('\n'))
   else:
     queryParams = request.REQUEST
 


### PR DESCRIPTION
Wanted a way to send a JSON POST request to the render API.

I've done some brief tests with different types of metrics and functions and they passed but haven't done a unit test to ensure all functions work with this change but it should be safe enough.
