### PR TITLE
Fix "global name 'i' is not defined" exception caused by typo.

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -133,7 +133,7 @@ def normalize(seriesLists):
 def formatPathExpressions(seriesList):
    # remove duplicates
    pathExpressions = []
-   [pathExpressions.append(s.pathExpression) for s in seriesList if not pathExpressions.count(i.pathExpression)]
+   [pathExpressions.append(s.pathExpression) for s in seriesList if not pathExpressions.count(s.pathExpression)]
    return ','.join(pathExpressions)
 
 # Series Functions


### PR DESCRIPTION
Commit 2d710e0c introduced this simple typo that results in:
  NameError: global name 'i' is not defined
