### PR TITLE
Add support for kwargs in function calls

### DIFF
--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -24,9 +24,11 @@ def evaluateTokens(requestContext, tokens):
     return fetchData(requestContext, tokens.pathExpression)
 
   elif tokens.call:
-    func = SeriesFunctions[tokens.call.func]
+    func = SeriesFunctions[tokens.call.funcname]
     args = [evaluateTokens(requestContext, arg) for arg in tokens.call.args]
-    return func(requestContext, *args)
+    kwargs = dict([(kwarg.argname, evaluateTokens(requestContext, kwarg.args[0]))
+                   for kwarg in tokens.call.kwargs])
+    return func(requestContext, *args, **kwargs)
 
   elif tokens.number:
     if tokens.number.integer:

--- a/webapp/graphite/render/grammar.py
+++ b/webapp/graphite/render/grammar.py
@@ -33,19 +33,34 @@ boolean = Group(
   CaselessKeyword("false")
 )('boolean')
 
+argname = Word(alphas + '_', alphanums + '_')('argname')
+funcname = Word(alphas + '_', alphanums + '_')('funcname')
+
+## Symbols
+leftParen = Literal('(').suppress()
+rightParen = Literal(')').suppress()
+comma = Literal(',').suppress()
+equal = Literal('=').suppress()
+
 # Function calls
 arg = Group(
   boolean |
   number |
   aString |
   expression
-)
-args = delimitedList(arg)('args')
+)('args*')
+kwarg = Group(argname + equal + arg)('kwargs*')
 
-func = Word(alphas+'_', alphanums+'_')('func')
+args = delimitedList(~kwarg + arg)  # lookahead to prevent failing on equals
+kwargs = delimitedList(kwarg)
+
 call = Group(
-  func + Literal('(').suppress() +
-  args + Literal(')').suppress()
+  funcname + leftParen +
+  Optional(
+    args + Optional(
+      comma + kwargs
+    )
+  ) + rightParen
 )('call')
 
 # Metric pattern (aka. pathExpression)


### PR DESCRIPTION
Pulled this from some grammar experimentation I've been doing on and off.

This is pretty straightforward - adds parsing of functions to include keyword arguments. This allows one to call functions with a lot of options like summarize() a little simpler:
summarize(my.metric, "1hour", alignToFrom=true)

It also allows one to use the argument name to make a function call more descriptive to read (as you might do in python:
aliasSub(my.metric, search="^my", replace="")
