### PR TITLE
Support backslash escape of grammar characters

### DIFF
--- a/webapp/graphite/render/grammar.py
+++ b/webapp/graphite/render/grammar.py
@@ -76,7 +76,7 @@ matchEnum = Combine(
 
 pathElement = Combine(
   Group(partialPathElem | matchEnum) +
-  Optional(matchEnum | partialPathElem)
+  ZeroOrMore(matchEnum | partialPathElem)
 )
 pathExpression = delimitedList(pathElement, delim='.', combine=True)('pathExpression')
 


### PR DESCRIPTION
... except for dots ( . ) and braces ( {} ) which will require work in evaluator.py at least

This allows for metrics with special characters such as parenthesis and commas e.g.:

```
averageSeries(servers.www01.loadAvg\({5,10,15}min\))
servers.www01.cpu0\,1\,2\,3.user
```
