### PR TITLE
Handle UTF-8 data in metrics views

### DIFF
--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -300,9 +300,6 @@ def any(iterable): #python2.4 compatibility
       return True
   return False
 
-def dumps(obj, ensure_ascii=False, **kwargs):
-  """Wrap json.dumps, but don't ensure_ascii by default."""
-  return json.dumps(obj, ensure_ascii=ensure_ascii, **kwargs)
 def json_response_for(request, data, mimetype='application/json', jsonp=False, **kwargs):
   accept = request.META.get('HTTP_ACCEPT', 'application/json')
   ensure_ascii = accept == 'application/json'


### PR DESCRIPTION
With `ensure_ascii` (the default), we observed the following in our
graphite installation when calling the /metrics/index.json resource:

```
    UnicodeDecodeError: 'utf8' codec can't decode byte 0x8a in position 81: invalid start byte
```
