### PR TITLE
Fix leading dots in metrics/index.json

### DIFF
--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -64,8 +64,8 @@ def index_json(request):
 
   matches = [
     m
-    .replace('.wsp','')
-    .replace('.rrd','')
+    .replace('.wsp', '')
+    .replace('.rrd', '')
     .replace('/', '.')
     .lstrip('.')
     for m in sorted(matches)


### PR DESCRIPTION
When a user has set `WHISPER_DIR` to a value which does not end with a trailing slash (e.g. `/mnt/data/whisper` instead of `/mnt/data/whisper/`) the path munging logic in `metrics/index.json` incorrectly leaves a leading slash, which gets turned into a leading period by the function's end.

Thus, users will see metric lists that look like `['.foo.bar', '.biz.baz']` instead of `['foo.bar', 'biz.baz']`. These are not valid metrics and break applications relying on `index.json`, such as Descartes or Graph-Explorer.

This PR fixes the issue by performing an `lstrip` on the final values prior to returning them, and after the `replace('/', '.')`. I can't think of any downsides to this approach offhand - any situation where a leading period exists would be an invalid metric.

Issue #289 reports this same issue and should be closed simultaneously.

I took the liberty of reformatting the line in question so it's a bit more readable. Feel free to ignore that part of the PR if you hate freedom and puppies :dog: 
