### PR TITLE
Fix legendHeight for one numberOfLines and secondYAxis

### DIFF
--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -330,7 +330,7 @@ class Graph:
       numberOfLines = max(len(elements) - numRight, numRight)
       columns = math.floor(columns / 2.0)
       if columns < 1: columns = 1
-      legendHeight = (numberOfLines / columns) * (lineHeight + padding)
+      legendHeight = max(1, (numberOfLines / columns)) * (lineHeight + padding)
       self.area['ymax'] -= legendHeight #scoot the drawing area up to fit the legend
       self.ctx.set_line_width(1.0)
       x = self.area['xmin']


### PR DESCRIPTION
Need to make sure that `numberOfLines / columns` is never less than 1 or the legend gets cut off. Duh.
