### PR TITLE
fix: areaMode=all regression, only last series was filled

### DIFF
--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -793,8 +793,9 @@ class LineGraph(Graph):
     elif self.areaMode == 'first':
       self.data[0].options['stacked'] = True
     elif self.areaMode == 'all':
-      if 'drawAsInfinite' not in series.options:
-        series.options['stacked'] = True
+      for series in self.data:
+        if 'drawAsInfinite' not in series.options:
+          series.options['stacked'] = True
 
     # apply alpha channel and create separate stroke series
     if self.params.get('areaAlpha'):


### PR DESCRIPTION
When setting areaMode=all only the area of last series was actually filled. 
The regression was introduced in commit a8dd81a37b755beedb70ab36007a6077fc0bea30
