### PR TITLE
start filled area from y 0 instead of bottom

### DIFF
--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -872,7 +872,13 @@ class LineGraph(Graph):
           if consecutiveNones == 0:
             self.ctx.line_to(x, y)
             if 'stacked' in series.options: #Close off and fill area before unknown interval
-              self.fillAreaAndClip(x, y, startX)
+              if self.secondYAxis:
+                if 'secondYAxis' in series.options:
+                  self.fillAreaAndClip(x, y, startX, self.getYCoord(0, "right"))
+                else:
+                  self.fillAreaAndClip(x, y, startX, self.getYCoord(0, "left"))
+              else:
+                self.fillAreaAndClip(x, y, startX, self.getYCoord(0))
 
           x += series.xStep
           consecutiveNones += 1
@@ -930,9 +936,19 @@ class LineGraph(Graph):
 
       if 'stacked' in series.options:
         if self.lineMode == 'staircase':
-          self.fillAreaAndClip(x, y, startX)
+          xPos = x 
         else:
-          self.fillAreaAndClip(x-series.xStep, y, startX)
+          xPos = x-series.xStep
+        if self.secondYAxis:
+          if 'secondYAxis' in series.options:
+            areaYFrom = self.getYCoord(0, "right")
+          else:
+            areaYFrom = self.getYCoord(0, "left")
+        else:
+          areaYFrom = self.getYCoord(0)
+
+        self.fillAreaAndClip(xPos, y, startX, areaYFrom)
+
       else:
         self.ctx.stroke()
 
@@ -943,22 +959,33 @@ class LineGraph(Graph):
         else:
           self.ctx.set_dash([],0)
 
-  def fillAreaAndClip(self, x, y, startX=None):
+  def fillAreaAndClip(self, x, y, startX=None, areaYFrom=None):
     startX = (startX or self.area['xmin'])
+    areaYFrom = (areaYFrom or self.area['ymax'])
     pattern = self.ctx.copy_path()
 
-    self.ctx.line_to(x, self.area['ymax'])                  # bottom endX
-    self.ctx.line_to(startX, self.area['ymax'])             # bottom startX
+    # fill
+    self.ctx.line_to(x, areaYFrom)                  # bottom endX
+    self.ctx.line_to(startX, areaYFrom)             # bottom startX
     self.ctx.close_path()
     self.ctx.fill()
 
+    # clip above y axis
     self.ctx.append_path(pattern)
-    self.ctx.line_to(x, self.area['ymax'])                  # bottom endX
-    self.ctx.line_to(self.area['xmax'], self.area['ymax'])  # bottom right
+    self.ctx.line_to(x, areaYFrom)                  # yZero endX
+    self.ctx.line_to(self.area['xmax'], areaYFrom)  # yZero right
     self.ctx.line_to(self.area['xmax'], self.area['ymin'])  # top right
     self.ctx.line_to(self.area['xmin'], self.area['ymin'])  # top left
+    self.ctx.line_to(self.area['xmin'], areaYFrom)  # yZero left
+    self.ctx.line_to(startX, areaYFrom)             # yZero startX
+
+    # clip below y axis
+    self.ctx.line_to(x, areaYFrom)                  # yZero endX
+    self.ctx.line_to(self.area['xmax'], areaYFrom)  # yZero right
+    self.ctx.line_to(self.area['xmax'], self.area['ymax'])  # bottom right
     self.ctx.line_to(self.area['xmin'], self.area['ymax'])  # bottom left
-    self.ctx.line_to(startX, self.area['ymax'])             # bottom startX
+    self.ctx.line_to(self.area['xmin'], areaYFrom)  # yZero left
+    self.ctx.line_to(startX, areaYFrom)             # yZero startX
     self.ctx.close_path()
     self.ctx.clip()
 


### PR DESCRIPTION
This fixes that when drawing filled area graphs with negative values the area is filled from the bottom of the graph, not from the 0 point on the y axis.

This pull reqeust is a merge/cleanup of https://github.com/graphite-project/graphite-web/pull/249 that one can be closed.

 When applying to head please check https://github.com/graphite-project/graphite-web/pull/307 which fixes a regression on areaMode=all.
