### PR TITLE
Fix missing defaults in graph templates intelligently

### DIFF
--- a/conf/graphTemplates.conf.example
+++ b/conf/graphTemplates.conf.example
@@ -3,6 +3,11 @@ background = white
 foreground = black
 minorLine = grey
 majorLine = rose
+lineColors = blue,green,red,purple,brown,yellow,aqua,grey,magenta,pink,gold,rose
+fontName = Sans
+fontSize = 10
+fontBold = False
+fontItalic = False
 
 [solarized-light]
 background = #fdf6e3

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -408,7 +408,11 @@ class Graph:
   def loadTemplate(self,template):
     conf = SafeConfigParser()
     if conf.read(settings.GRAPHTEMPLATES_CONF):
-      defaults = dict( conf.items('default') )
+      defaults = defaultGraphOptions
+      # If a graphTemplates.conf exists, read in
+      # the values from it, but make sure that
+      # all of the default values properly exist
+      defaults.update(dict(conf.items('default')))
       if template in conf.sections():
         opts = dict( conf.items(template) )
       else:


### PR DESCRIPTION
This fixes #314. This makes it so that the defaultGraphOptions are
always set as the default when a graphTemplates.conf exists and any
fields that the specific config overrides will trump the defaults.

It also updates the default profile in graphTemplates.conf to not
be missing keys. The lineColors were taken directly from glyph.py

This also prevents a LOT of this type of mess a few lines down:

``` python
    defaults.get('foo', defaultGraphOptions['foo'))
```

Tested in Chrome on Fedora 18 x86_64. Works like a champ.
