### PR TITLE
Handle a bit of fallout from merging the grep() function

### DIFF
--- a/webapp/content/js/composer_widgets.js
+++ b/webapp/content/js/composer_widgets.js
@@ -958,7 +958,7 @@ function createFunctionsMenu() {
         {text: 'sortByMaxima', handler: applyFuncToEach('sortByMaxima')},
         {text: 'sortByMinima', handler: applyFuncToEach('sortByMinima')},
         {text: 'limit', handler: applyFuncToEachWithInput('limit', 'Limit to first ___ of a list of metrics')},
-        {text: 'Exclude', handler: applyFuncToEachWithInput('exclude', 'Exclude metrics that match a regular expression')}
+        {text: 'Exclude', handler: applyFuncToEachWithInput('exclude', 'Exclude metrics that match a regular expression')},
         {text: 'Grep', handler: applyFuncToEachWithInput('grep', 'Exclude metrics that don\'t match a regular expression')}
       ]
     }, {


### PR DESCRIPTION
There was a missing comma at the end of the line in `composer_widgets.js` that @mjulian and I worked out via IRC. I asked him to file a bug so it is tracked and now I'm fixing it. Please accept :)

Tested in Chrome on Fedora 18 and verified it fixed the bugs via the web inspector.
