### PR TITLE
RFC: Add a history button to the dashboard kind of like Cacti

### DIFF
--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -1724,11 +1724,11 @@ function graphClicked(graphView, graphIndex, element, evt) {
     }
   });
 
-  var buttonWidth = 110;
+  var buttonWidth = 150;
   var rowHeight = 21;
   var maxRows = 6;
   var frameHeight = 5;
-  var gridWidth = (buttonWidth * 4) + 2;
+  var gridWidth = (buttonWidth * 3) + 2;
   var gridHeight = (rowHeight * Math.min(targets.length, maxRows)) + frameHeight;
 
   targetGrid = new Ext.grid.EditorGridPanel({
@@ -1850,19 +1850,16 @@ function graphClicked(graphView, graphIndex, element, evt) {
           ]
         });
         win.show();
-      }
-    }]
-  });
-
-    var additionalActionsMenu = new Ext.menu.Menu({
-      allowOtherMenus: true,
-      items: [{
+      },
+    }, {
         xtype: 'button',
         text: 'History',
         width: 100,
         handler: function () { menu.destroy(); historyGraph(record);}
-      },]
-    });
+      }
+    ]
+  });
+
   var buttons = [functionsButton];
 
   buttons.push({
@@ -1895,21 +1892,6 @@ function graphClicked(graphView, graphIndex, element, evt) {
              }
   });
 
-  buttons.push({
-    xtype: 'button',
-    text: "Cacti",
-    width: buttonWidth,
-    handler: function (thisButton) {
-            if (additionalActionsMenu.isVisible()){
-                additionalActionsMenu.doHide(); // private method... yuck (no other way to hide w/out trigging hide event handler)
-            } else {
-                operationsMenu.hide();
-                functionsMenu.hide();
-                additionalActionsMenu.show(thisButton.getEl());
-            }
-        }
-  });
-
   menuItems.push({
     xtype: 'panel',
     layout: 'hbox',
@@ -1938,7 +1920,6 @@ function graphClicked(graphView, graphIndex, element, evt) {
                        optionsMenu.destroy();
                        operationsMenu.destroy();
                        functionsMenu.destroy();
-                       additionalActionsMenu.destroy();
                      }
   );
 }
@@ -2077,7 +2058,6 @@ function mailGraph(record) {
                url: '/dashboard/email',
                waitMsg: 'Processing Request',
                success: function (contactForm, response) {
-         console.log(response.result);
                  win.close();
                }
              });
@@ -2153,7 +2133,7 @@ function historyGraph(record){
 
     var props = getProps(record);
     var title = '';
-    title = props.params.title;
+    title = (props.params.title != undefined) ? props.params.title : '';
 
     props = getProps(record);
     props.params.title = title + ' 1 hour';
@@ -2200,8 +2180,6 @@ function historyGraph(record){
             params.title = params.target[0];
           }
 
-          console.log(params.title);
-
           if (!params.uniq === undefined) {
               delete params["uniq"];
           }
@@ -2232,7 +2210,6 @@ function historyGraph(record){
       layout: 'fit',
       items: graphHistoryView
     });
-    console.log(record);
     win.show();
 
 }


### PR DESCRIPTION
This pull request should supercede #123.

@spellik: Please do look over [this commit](https://github.com/SEJeff/graphite-web/commit/1c0b97f3d16c7276b69d547545f6034d670cac75). I manually squashed your 3 commits in the previous pull request and removed all of the bonzai bits while keeping your name as the author so you get credit.

I then fixed a bug in that commit where graphs without title names would show up as `undefined 1 hour`, `undefined 1 day`, etc using a fancy javascript ternary operator. Since zoom support was removed, it didn't make much sense to keep the "Cacti" button, so I removed that as well and put the History button under "Graph Operations".

@nleskiw, @mleinart, and/or @obfuscurity please do give this a shot and merge if you like it. It certainly works well in master.
