### PR TITLE
Add option for json formatted for rickshaw.

### DIFF
--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -168,6 +168,15 @@ def renderView(request):
       log.rendering('Total pickle rendering time %.6f' % (time() - start))
       return response
 
+    if format == 'rickshaw':
+      series_data = []
+      for series in data:
+        timestamps = range(series.start, series.end, series.step)
+        datapoints = [{'x':x, 'y':y} for x, y in zip(series, timestamps)]
+        series_data.append(dict(name=series.name, datapoints=datapoints))
+      response = HttpResponse(content=json.dumps(series_data), mimetype='application/json')
+      return response
+
 
   # We've got the data, now to render it
   graphOptions['data'] = data


### PR DESCRIPTION
Rickshaw graphs expect data in a certain format, and
having that format as an output option in graphite
simplifies the use of rickshaw graphs.

https://github.com/shutterstock/rickshaw

``` json
[
    {
        "color": "blue",
        "name": "New York",
        "data": [ { "x": 0, "y": 40 }, { "x": 1, "y": 49 }, { "x": 2, "y": 38 }, { "x": 3, "y": 30 }, { "x": 4, "y": 32 } ]
    }, {
        "name": "London",
        "data": [ { "x": 0, "y": 19 }, { "x": 1, "y": 22 }, { "x": 2, "y": 29 }, { "x": 3, "y": 20 }, { "x": 4, "y": 14 } ]
    }, {
        "name": "Tokyo",
        "data": [ { "x": 0, "y": 8 }, { "x": 1, "y": 12 }, { "x": 2, "y": 15 }, { "x": 3, "y": 11 }, { "x": 4, "y": 10 } ]
    }
]
```
