### PR TITLE
enable get all metrics in CLUSTER_SERVERS

### DIFF
--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -31,28 +31,39 @@ except ImportError:
 
 def index_json(request):
   jsonp = request.REQUEST.get('jsonp', False)
+  cluster = request.REQUEST.get('cluster', False)
+
+  def find_matches():
+    matches = []
+  
+    for root, dirs, files in os.walk(settings.WHISPER_DIR):
+      root = root.replace(settings.WHISPER_DIR, '')
+      for basename in files:
+        if fnmatch.fnmatch(basename, '*.wsp'):
+          matches.append(os.path.join(root, basename))
+  
+    for root, dirs, files in os.walk(settings.CERES_DIR):
+      root = root.replace(settings.CERES_DIR, '')
+      for filename in files:
+        if filename == '.ceres-node':
+          matches.append(root)
+  
+    matches = [
+      m
+      .replace('.wsp', '')
+      .replace('.rrd', '')
+      .replace('/', '.')
+      .lstrip('.')
+      for m in sorted(matches)
+    ]
+    return matches
   matches = []
-
-  for root, dirs, files in os.walk(settings.WHISPER_DIR):
-    root = root.replace(settings.WHISPER_DIR, '')
-    for basename in files:
-      if fnmatch.fnmatch(basename, '*.wsp'):
-        matches.append(os.path.join(root, basename))
-
-  for root, dirs, files in os.walk(settings.CERES_DIR):
-    root = root.replace(settings.CERES_DIR, '')
-    for filename in files:
-      if filename == '.ceres-node':
-        matches.append(root)
-
-  matches = [
-    m
-    .replace('.wsp', '')
-    .replace('.rrd', '')
-    .replace('/', '.')
-    .lstrip('.')
-    for m in sorted(matches)
-  ]
+  if cluster and len(settings.CLUSTER_SERVERS) > 1:
+    matches = reduce( lambda x, y: list(set(x + y)), \
+        [json.loads(urlopen("http://" + cluster_server + "/metrics/index.json").read()) \
+        for cluster_server in settings.CLUSTER_SERVERS])
+  else:
+    matches = find_matches()
   return json_response_for(request, matches, jsonp=jsonp)
 
 


### PR DESCRIPTION
Enable:
"/metrics/index.json?cluster=True"
or
"/metrics/index.json?cluster=1"
styles to get all metrics in a cluster not only a single backend.

If "cluster=True" is provided, it will iterate all servers in this cluster to "GET /metrics/index.json", and merge all json response.
