### PR TITLE
Fall back to cairocffi if pycairo is not installed

### DIFF
--- a/check-dependencies.py
+++ b/check-dependencies.py
@@ -28,13 +28,16 @@ except ImportError:
     required += 1
 
 
-# Test for pycairo
+# Test for pycairo or cairocffi
 try:
   import cairo
 except ImportError:
-  sys.stderr.write("[REQUIRED] Unable to import the 'cairo' module, do you have pycairo installed for python %s?\n" % py_version)
-  cairo = None
-  required += 1
+  try:
+    import cairocffi as cairo
+  except ImportError:
+    sys.stderr.write("[REQUIRED] Unable to import the 'cairo' module, do you have pycairo installed for python %s?\n" % py_version)
+    cairo = None
+    required += 1
 
 
 # Test that pycairo has the PNG backend

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -12,7 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-import os, cairo, math, itertools, re
+import os, math, itertools, re
+try:
+    import cairo
+except ImportError:
+    import cairocffi as cairo
+
 import StringIO
 from datetime import datetime, timedelta
 from urllib import unquote_plus


### PR DESCRIPTION
I think the dependency on pycairo makes it hard to pip-install graphite-web in a virtualenv. This patch adds a fallback option to use cairocffi (https://github.com/SimonSapin/cairocffi) if pycairo ist not installed. 
