### PR TITLE
Fix `functions._getPercentile` by ignoring None values

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1503,7 +1503,7 @@ def _getPercentile(points, n, interpolate=False):
   Statistics Handbook:
   http://www.itl.nist.gov/div898/handbook/prc/section2/prc252.htm
   """
-  sortedPoints = sorted([ p for p in points if points is not None])
+  sortedPoints = sorted([ p for p in points if p is not None])
   if len(sortedPoints) == 0:
     return None
   fractionalRank = (n/100.0) * (len(sortedPoints) + 1)

--- a/webapp/graphite/render/functions_test.py
+++ b/webapp/graphite/render/functions_test.py
@@ -49,7 +49,7 @@ class FunctionsTest(unittest.TestCase):
 
     def testGetPercentile(self):
       seriesList = [
-        ([15, 20, 35, 40, 50], 20),
+        ([None, None, 15, 20, 35, 40, 50], 20),
         (range(100), 30),
         (range(200), 60),
         (range(300), 90),


### PR DESCRIPTION
`functions._getPercentile` was not ignoring `None` values. This patch fixes it.
