### PR TITLE
Sort dashboard names in the Finder alphabetically and without case sensitivity.

### DIFF
--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -2561,12 +2561,22 @@ function showDashboardFinder() {
     url: "/dashboard/find/",
     method: 'GET',
     params: {query: "e"},
-    fields: ['name'],
+    fields: [{
+      name: 'name',
+      sortType: function(value) {
+	// Make sorting case-insensitive
+        return value.toLowerCase();
+      }
+    }],
     root: 'dashboards',
+    sortInfo: {
+      field: 'name',
+      direction: 'DESC'
+    },
     listeners: {
       beforeload: function (store) {
                     store.setBaseParam('query', queryField.getValue());
-                  }
+      }
     }
   });
 


### PR DESCRIPTION
My organisation has adopted Graphite + statsd.net as their primary metrics gathering system, and they're using the Dashboard as the graphing platform. We have about 50 dashboards at the moment and having them sorted alphabetically will make finding a dashboard much simpler.

Plus, this is my first Github pull request - yeah!
