### PR TITLE
add an isNonNull function

### DIFF
--- a/webapp/content/js/composer_widgets.js
+++ b/webapp/content/js/composer_widgets.js
@@ -1126,6 +1126,7 @@ function createFunctionsMenu() {
         {text: 'Dashed Line', handler: applyFuncToEach('dashed')},
         {text: 'Keep Last Value', handler: applyFuncToEachWithInput('keepLastValue', 'Please enter the maximum number of "None" datapoints to overwrite, or leave empty for no limit. (default: empty)', {allowBlank: true})},
         {text: 'Transform Nulls', handler: applyFuncToEachWithInput('transformNull', 'Please enter the value to transform null values to')},
+        {text: 'Count non-nulls', handler: applyFuncToAll('isNonNull')},
         {text: 'Substring', handler: applyFuncToEachWithInput('substr', 'Enter a starting position')},
         {text: 'Group', handler: applyFuncToAll('group')},
         {text: 'Area Between', handler: applyFuncToEach('areaBetween')},

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2338,6 +2338,35 @@ def transformNull(requestContext, seriesList, default=0):
     del series[:len(values)]
   return seriesList
 
+def isNonNull(requestContext, seriesList):
+  """
+  Takes a metric or wild card seriesList and counts up how many
+  non-null values are specified. This is useful for understanding
+  which metrics have data at a given point in time (ie, to count
+  which servers are alive).
+
+  Example:
+
+  .. code-block:: none
+
+    &target=isNonNull(webapp.pages.*.views)
+
+  Returns a seriesList where 1 is specified for non-null values, and
+  0 is specified for null values.
+  """
+
+  def transform(v):
+    if v is None: return 0
+    else: return 1
+
+  for series in seriesList:
+    series.name = "isNonNull(%s)" % (series.name)
+    series.pathExpression = series.name
+    values = [transform(v) for v in series]
+    series.extend(values)
+    del series[:len(values)]
+  return seriesList
+
 def identity(requestContext, name):
   """
   Identity function:
@@ -2962,6 +2991,7 @@ SeriesFunctions = {
   'areaBetween' : areaBetween,
   'threshold' : threshold,
   'transformNull' : transformNull,
+  'isNonNull' : isNonNull,
   'identity': identity,
   'aggregateLine' : aggregateLine,
 


### PR DESCRIPTION
This is a variation on the transformNull function

In a pool where I have a flexible number of nodes, I need to be able to
determine how many nodes were alive at a particular time. (Well technically
the closest I can get is how many nodes were reporting metrics at a
particular time.)

This is a function that just returns whether a metric is non-null for each
measurement. You can create a 'nodes alive' graph with something like:

sumSeries(isNonNull(server*.cpu-1.cpu-idle))
