### PR TITLE
Adding Orion to the list of third party tools.

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -199,6 +199,10 @@ It is ideal for visualizing trends of events that are occurring in your applicat
 logs. For example, you might use logster to graph the number of occurrences of HTTP response
 code that appears in your web server logs.
 
+Orion
+-------
+`Orion`_ is powerful tool to create, view and manage dashboards for your Graphite data. It allows easy implementation of custom authentication to manage access to the dashboard.
+
 metrics-sampler
 ---------------
 `metrics-sampler`_ is a java program which regularly queries metrics from a configured set of inputs, 
@@ -301,6 +305,7 @@ annotated events, etc). Supports Graphite, flot, rickshaw and anthracite.
 .. _jmxtrans: http://code.google.com/p/jmxtrans/
 .. _Ledbetter: https://github.com/github/ledbetter
 .. _Logster: https://github.com/etsy/logster
+.. _Orion: https://github.com/gree/Orion
 .. _metrics-sampler: https://github.com/dimovelev/metrics-sampler
 .. _New Relic: https://newrelic.com/platform
 .. _Pencil: https://github.com/fetep/pencil


### PR DESCRIPTION
A request to add [Orion](https://github.com/gree/Orion) to list of tools. Its a tool we developed internally at Gree/Funzio for managing dashboards for our graphite data which is open sourced.

![Orion Screenshot](https://f.cloud.github.com/assets/443145/809451/e7d934c2-ee88-11e2-86ad-d46f78716cd5.png)
