### PR TITLE
support multiple WHISPER_DIRS

### DIFF
--- a/docs/config-local-settings.rst
+++ b/docs/config-local-settings.rst
@@ -84,7 +84,7 @@ CONF_DIR
 
 STORAGE_DIR
   `Default: GRAPHITE_ROOT/storage`
-  The base directory from which WHISPER_DIR, RRD_DIR, LOG_DIR, and INDEX_FILE default paths
+  The base directory from which WHISPER_DIRS, RRD_DIR, LOG_DIR, and INDEX_FILE default paths
   are referenced
 
 CONTENT_DIR

--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -65,7 +65,7 @@
 ## Data directories
 # NOTE: If any directory is unreadable in STANDARD_DIRS it will break metric browsing
 #CERES_DIR = '/opt/graphite/storage/ceres'
-#WHISPER_DIR = '/opt/graphite/storage/whisper'
+#WHISPER_DIRS = ['/opt/graphite/storage/whisper']
 #RRD_DIR = '/opt/graphite/storage/rrd'
 # Data directories using the "Standard" finder (i.e. not Ceres)
 #STANDARD_DIRS = [WHISPER_DIR, RRD_DIR] # Default: set from the above variables

--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -33,11 +33,12 @@ def index_json(request):
   jsonp = request.REQUEST.get('jsonp', False)
   matches = []
 
-  for root, dirs, files in os.walk(settings.WHISPER_DIR):
-    root = root.replace(settings.WHISPER_DIR, '')
-    for basename in files:
-      if fnmatch.fnmatch(basename, '*.wsp'):
-        matches.append(os.path.join(root, basename))
+  for whisper_dir in settings.WHISPER_DIRS:
+    for root, dirs, files in os.walk(whisper_dir):
+      root = root.replace(whisper_dir, '')
+      for basename in files:
+        if fnmatch.fnmatch(basename, '*.wsp'):
+          matches.append(os.path.join(root, basename))
 
   for root, dirs, files in os.walk(settings.CERES_DIR):
     root = root.replace(settings.CERES_DIR, '')

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -39,7 +39,7 @@ WHITELIST_FILE = ''
 INDEX_FILE = ''
 LOG_DIR = ''
 CERES_DIR = ''
-WHISPER_DIR = ''
+WHISPER_DIRS = []
 RRD_DIR = ''
 STANDARD_DIRS = []
 
@@ -158,8 +158,8 @@ if not INDEX_FILE:
   INDEX_FILE = join(STORAGE_DIR, 'index')
 if not LOG_DIR:
   LOG_DIR = join(STORAGE_DIR, 'log', 'webapp')
-if not WHISPER_DIR:
-  WHISPER_DIR = join(STORAGE_DIR, 'whisper/')
+if not WHISPER_DIRS:
+  WHISPER_DIRS = [join(STORAGE_DIR, 'whisper/')]
 if not CERES_DIR:
   CERES_DIR = join(STORAGE_DIR, 'ceres/')
 if not RRD_DIR:
@@ -167,8 +167,9 @@ if not RRD_DIR:
 if not STANDARD_DIRS:
   try:
     import whisper
-    if os.path.exists(WHISPER_DIR):
-      STANDARD_DIRS.append(WHISPER_DIR)
+    for path in WHISPER_DIRS:
+      if os.path.exists(path):
+        STANDARD_DIRS.append(path)
   except ImportError:
     print >> sys.stderr, "WARNING: whisper module could not be loaded, whisper support disabled"
   try:

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -167,6 +167,13 @@ if not RRD_DIR:
 if not STANDARD_DIRS:
   try:
     import whisper
+
+    # backwards compatibility for WHISPER_DIR
+    try:
+      STANDARD_DIRS.append(WHISPER_DIR)
+    except NameError:
+      pass
+
     for path in WHISPER_DIRS:
       if os.path.exists(path):
         STANDARD_DIRS.append(path)


### PR DESCRIPTION
This adds support to graphite-web for searching multiple WHISPER_DIR's by renaming the WHISPER_DIR setting to WHISPER_DIRS and to a list from a string.

Includes backwards compatibility for WHISPER_DIR setting.

example:

```
WHISPER_DIRS = ['/opt/graphite/storage/whisper/01', '/opt/graphite/storage/whisper/02']
```

I'm experimenting with a graphite install where each carbon-cache instance is configured to store its whisper DB's in its own directory to facilitate easier cluster scaling. Supporting multiple WHISPER_DIRS makes it easier to move instances to new servers, for example: `rsync -a /opt/graphite/storage/whisper/01/ newserver:/opt/graphite/storage/whisper/01/`.

/tnx to @phobos182 for the suggestion here.
