### PR TITLE
Optionally bind using credentials passed in by the user

### DIFF
--- a/webapp/graphite/account/ldapBackend.py
+++ b/webapp/graphite/account/ldapBackend.py
@@ -22,7 +22,10 @@ class LDAPBackend:
     try:
       conn = ldap.initialize(settings.LDAP_URI)
       conn.protocol_version = ldap.VERSION3
-      conn.simple_bind_s( settings.LDAP_BASE_USER, settings.LDAP_BASE_PASS )
+      conn.start_tls_s()
+      bind_user = settings.LDAP_BASE_USER % username if "%s" in settings.LDAP_BASE_USER else settings.LDAP_BASE_USER
+      bind_pass = settings.LDAP_BASE_PASS % password if "%s" in settings.LDAP_BASE_PASS else settings.LDAP_BASE_PASS
+      conn.bind_s( bind_user, bind_pass )
     except ldap.LDAPError:
       traceback.print_exc()
       return None


### PR DESCRIPTION
This patch allows you to configure a bind user/pass that contains a "%s" to allow for binding with the username and password passed in. Some LDAP servers are tightly shut so you cannot bind anonymously, and binding with a fixed username/password is frowned upon by a lot of admins. So this patch allows a locked-down LDAP server to be accessed, using the credentials of whoever is trying to log in. 

Example usage in local_settings.py:

LDAP_BASE_USER = "uid=%s,ou=People,ou=department,o=company"
LDAP_BASE_PASS = "%s"

(I don't see a direct use case for the %s expansion in LDAP_BASE_PASS, but it didn't hurt to put it in either).

The patch also executes a start_tls, which afaik is good practice and won't hurt.