### PR TITLE
Fix default location for --install-lib in docs.

### DIFF
--- a/docs/install-source.rst
+++ b/docs/install-source.rst
@@ -68,7 +68,7 @@ The following parameters influence the install location:
 
 - ``--install-lib``
 
-  Location to install Python modules (default: ``/opt/graphite/webapp``)
+  Location to install Python modules (default: ``[prefix]/webapp``)
 
 - ``--install-data``
 


### PR DESCRIPTION
I was having trouble installing to a custom location, and I noticed in setup.cfg:

prefix = /opt/graphite
install-lib = %(prefix)s/webapp

And I felt it'd probably be best to update the documentation, though I'm not sure how recent this change, so sorry if I jumped the gun on this.
