### PR TITLE
Fixed graphlot metrics finder

### DIFF
--- a/webapp/graphite/graphlot/views.py
+++ b/webapp/graphite/graphlot/views.py
@@ -64,7 +64,7 @@ def find_metric(request):
             content="Missing required parameter 'q'", mimetype="text/plain")
 
     matches = list( STORE.find(query+"*") )
-    content = "\n".join([node.metric_path for node in matches ])
+    content = "\n".join([node.path for node in matches ])
     response = HttpResponse(content, mimetype='text/plain')
 
     return response


### PR DESCRIPTION
Seems like the metric finder from graphlot was not adapted to the new node system. Had to replace metric_path with path in the `graphlot.views.find_metric` method 
