### PR TITLE
Add manage-graphite script, not everyone is using virtualenv

### DIFF
--- a/bin/manage-graphite.py
+++ b/bin/manage-graphite.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+from django.core.management import execute_manager
+try:
+    import graphite.settings as settings
+except ImportError:
+    import sys
+    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % settings.__file__)
+    sys.exit(1)
+
+if __name__ == "__main__":
+    execute_manager(settings)


### PR DESCRIPTION
I saw in many distrost, they are patching manage.py script to have it avalible as tool for managment after installation, i say, why not patch it upstream.
