### PR TITLE
Remove superfluous grid line for log scale.

### DIFF
--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1419,8 +1419,6 @@ class LineGraph(Graph):
       labels = self.yLabelValuesL
     else:
       labels = self.yLabelValues
-    if self.logBase:
-      labels.append(self.logBase * max(labels))
 
     for i, value in enumerate(labels):
       self.ctx.set_line_width(0.4)


### PR DESCRIPTION
The code removed in this change added an additional entry to the list of
labels, causing the top of the graph to be extended by self.logBase. As
the corresponding labels have already been drawn, the result is a
graph with n+1 gridlines for n labels. Removing this addition resolves
the issue.

Fixes #235.
