### PR TITLE
Don't mess up the target list in the dashboard

### DIFF
--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -1999,9 +1999,8 @@ function breakoutGraph(record) {
 }
 
 function mailGraph(record) {
-  mygraphParams = record.get('params');
-  mygraphParams['target'] = record.data['target'];
-  newparams = Ext.encode(Ext.apply(mygraphParams, defaultGraphParams));
+  var mygraphParams = record.get('params');
+  var newparams = Ext.encode(Ext.apply(mygraphParams, defaultGraphParams));
 
   var fromField = new Ext.form.TextField({
     fieldLabel: "From",


### PR DESCRIPTION
How to reproduce?

Reproduce with #390. Also, merge 2 graphs together in the dashboard composer, bring up the email compose dialog, then cancel it. Verify the floating graph options bar looks correct.

Verified to fix the bug with Chromium and Firefox on Fedora 18.
