### PR TITLE
Django 1.5 compatibility updates

### DIFF
--- a/webapp/graphite/app_settings.py
+++ b/webapp/graphite/app_settings.py
@@ -48,9 +48,6 @@ MEDIA_URL = ''
 # Examples: "http://foo.com/media/", "/media/".
 ADMIN_MEDIA_PREFIX = '/media/'
 
-# Make this unique, and don't share it with anybody.
-SECRET_KEY = ''
-
 # List of callables that know how to import templates from various sources.
 #XXX Compatibility for Django 1.1. To be removed after 0.9.10
 if DJANGO_VERSION < (1,2):

--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -6,6 +6,17 @@
 #####################################
 # General Configuration #
 #####################################
+# Set this to a long, random unique string to use as a secret key for this
+# install. This key is used for salting of hashes used in auth tokens,
+# CRSF middleware, cookie storage, etc. This should be set identically among
+# instances if used behind a load balancer.
+#SECRET_KEY = 'UNSAFE_DEFAULT'
+
+# In Django 1.5+ set this to the list of hosts your graphite instances is
+# accessible as. See:
+# https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-ALLOWED_HOSTS
+#ALLOWED_HOSTS = [ '*' ]
+
 # Set your local timezone (Django's default is America/Chicago)
 # If your graphs appear to be offset by a couple hours then this probably
 # needs to be explicitly set to your local timezone.

--- a/webapp/graphite/manage.py
+++ b/webapp/graphite/manage.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
-from django.core.management import execute_manager
-try:
-    import settings # Assumed to be in the same directory.
-except ImportError:
-    import sys
-    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)
-    sys.exit(1)
+import os
+import sys
+
+from django.core.management import execute_from_command_line
+
 
 if __name__ == "__main__":
-    execute_manager(settings)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -16,6 +16,7 @@ limitations under the License."""
 import sys, os
 from django import VERSION as DJANGO_VERSION
 from os.path import abspath, dirname, join
+from warnings import warn
 
 try:
   import rrdtool
@@ -91,6 +92,12 @@ LDAP_URI = None
 
 #Set this to True to delegate authentication to the web server
 USE_REMOTE_USER_AUTHENTICATION = False
+
+# Django 1.5 requires this so we set a default but warn the user
+SECRET_KEY = 'UNSAFE_DEFAULT'
+
+# Django 1.5 requires this to be set. Here we default to prior behavior and allow all
+ALLOWED_HOSTS = [ '*' ]
 
 # Override to link a different URL for login (e.g. for django_openid_auth)
 LOGIN_URL = '/account/login'
@@ -169,3 +176,5 @@ if USE_REMOTE_USER_AUTHENTICATION:
 if USE_LDAP_AUTH:
   AUTHENTICATION_BACKENDS.insert(0,'graphite.account.ldapBackend.LDAPBackend')
 
+if SECRET_KEY == 'UNSAFE_DEFAULT':
+  warn('SECRET_KEY is set to an unsafe default. This should be set in local_settings.py for better security')


### PR DESCRIPTION
- Allow SECRET_KEY to be set and warn if not
- Add new (and required) ALLOWED_HOSTS setting
- Use alternate style manage.py which is the only supported style in 1.5
