### PR TITLE
jerry-rig events to strip timezone before reading from db

### DIFF
--- a/webapp/graphite/events/views.py
+++ b/webapp/graphite/events/views.py
@@ -3,7 +3,7 @@ import time
 
 from django.http import HttpResponse
 from django.shortcuts import render_to_response, get_object_or_404
-
+from django.utils.timezone import localtime, now
 from graphite.util import json
 from graphite.events import models
 from graphite.render.attime import parseATTime
@@ -72,15 +72,16 @@ def get_data(request):
     return response
 
 def fetch(request):
+    #XXX we need to move to USE_TZ=True to get rid of localtime() conversions
     if request.GET.get("from", None) is not None:
-        time_from = parseATTime(request.GET["from"])
+        time_from = localtime(parseATTime(request.GET["from"])).replace(tzinfo=None)
     else:
         time_from = datetime.datetime.fromtimestamp(0)
 
     if request.GET.get("until", None) is not None:
-        time_until = parseATTime(request.GET["until"])
+        time_until = localtime(parseATTime(request.GET["until"])).replace(tzinfo=None)
     else:
-        time_until = datetime.datetime.now()
+        time_until = now()
 
     tags = request.GET.get("tags", None)
     if tags is not None:


### PR DESCRIPTION
I'm not crazy about this fix but to fix this correctly we'll need to start using USE_TZ=True in settings which will involve data migrations to convert stored datetime data with non-Postgres backends. For now, we can do the conversion to localtime ourselves. This should resolve #101 and #65
