### PR TITLE
Fix search tab in composer to match all (not any) entered patterns

### DIFF
--- a/webapp/graphite/browser/views.py
+++ b/webapp/graphite/browser/views.py
@@ -62,9 +62,9 @@ def search(request):
   regexes = [re.compile(p,re.I) for p in patterns]
   def matches(s):
     for regex in regexes:
-      if regex.search(s):
-        return True
-    return False
+      if not regex.search(s):
+        return False
+    return True
 
   results = []
 


### PR DESCRIPTION
Currently, the search tab in the Composer treats a line in the index file as matching if it matches ANY of the patterns in the search box, but the help text suggests that the only lines that match are those that match ALL entered patterns.

This fix causes the search tool to demonstrate the behavior documented in the help text.