### PR TITLE
Fix bug where SVG output would sometimes have extra </g> tag

### DIFF
--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -495,10 +495,12 @@ class Graph:
         for char in re.findall(r'L -(\d+) -\d+', match.group(1)):
           name += chr(int(char))
         return '</g><g data-header="true" class="%s">' % name
-      svgData = re.sub(r'<path.+?d="M -88 -88 (.+?)"/>', onHeaderPath, svgData)
+      (svgData, subsMade) = re.subn(r'<path.+?d="M -88 -88 (.+?)"/>', onHeaderPath, svgData)
 
       # Replace the first </g><g> with <g>, and close out the last </g> at the end
-      svgData = svgData.replace('</g><g data-header','<g data-header',1) + "</g>"
+      svgData = svgData.replace('</g><g data-header','<g data-header',1)
+      if subsMade > 0:
+        svgData += "</g>"
       svgData = svgData.replace(' data-header="true"','')
 
       fileObj.write(svgData)


### PR DESCRIPTION
When generating SVG images, if there is no "</g><g data-header" present in svgData by line 501 to replace, the resulting SVG file encounters errors because of the unconditionally added "</g>" tag:

![image](https://f.cloud.github.com/assets/2461496/1043861/0c045c42-1007-11e3-8b0c-e4e3e559cbb6.png)

This fix adds the "</g>" tag only if the regex in line 498 finds at least one match (if onHeaderPath is called at least once, which would give line 501 something to replace).
