### PR TITLE
make parse Errors more clear

### DIFF
--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -105,7 +105,10 @@ def fetchData(requestContext, pathExpr):
       log.info("render.datalib.fetchData :: no results for %s.fetch(%s, %s)" % (node, startTime, endTime))
       continue
 
-    (timeInfo, values) = results
+    try:
+        (timeInfo, values) = results
+    except ValueError, e:
+        raise Exception("could not parse timeInfo/values from metric '%s': %s" % (node.path, e))
     (start, end, step) = timeInfo
 
     series = TimeSeries(node.path, start, end, step, values)


### PR DESCRIPTION
makes errors at this point look like "Exception: could not parse timeInfo/values from metric 'stats.dfvimeocliapp1.process_prune_source_files.queue_delete': need more than 1 value to unpack"

instead of just "ValueError: need more than 1 value to unpack"
