### PR TITLE
Remote readers locking inadequate

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ that sends loadavg data for your local machine to carbon on a minutely basis.
 
 The default storage schema stores data in one-minute intervals for 2 hours.
 This is probably not what you want so you should create a custom storage schema
-according to the docs on the graphite wiki (http://graphite.wikidot.com).
+according to the docs on the graphite wiki (http://graphite.readthedocs.org/).

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -66,6 +66,8 @@ LOG_ROTATE = True
 
 MAX_FETCH_RETRIES = 2
 
+MAX_FETCH_RETRIES = 2
+
 #Remote rendering settings
 REMOTE_RENDERING = False #if True, rendering is delegated to RENDERING_HOSTS
 RENDERING_HOSTS = []

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -66,8 +66,6 @@ LOG_ROTATE = True
 
 MAX_FETCH_RETRIES = 2
 
-MAX_FETCH_RETRIES = 2
-
 #Remote rendering settings
 REMOTE_RENDERING = False #if True, rendering is delegated to RENDERING_HOSTS
 RENDERING_HOSTS = []


### PR DESCRIPTION
In the past I was seeing failures to read when multiple requests came in for the exact same metric and the locking around the existing connections was not adequate.

I was able to reproduce it this morning on an instance running the master branch:

Tue Sep 03 14:36:26 2013 :: Error requesting http://a.b.c.d/render/?target=%2A.carbon-daemons.%2A.%7Bcache%5B0-9%5D%2Cagger%5B0-9%5D%7D.writer.cached_datapoints&format=pickle&local=1&noCache=1&from=1378215685&until=1378218985
Traceback (most recent call last):
  File "/opt/graphite/webapp/graphite/remote_storage.py", line 182, in wait_for_results
    response = connection.getresponse()
NameError: free variable 'connection' referenced before assignment in enclosing scope