### PR TITLE
Resolve right hand dip in sums because of lack of current minute in caches

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -172,6 +172,19 @@ def sumSeries(requestContext, *seriesLists):
     (seriesList,start,end,step) = normalize(seriesLists)
   except:
     return []
+
+  # trim right side of the graph to avoid dip when only part of most recent metrics has entered the system
+  for s in seriesList:
+    if (s[-1] is None) and (s[-2] is not None):
+      for sl in seriesList:
+        sl[-1] = None
+      break
+  for s in seriesList:
+    if (s[-2] is None) and (s[-3] is not None):
+      for sl in seriesList:
+        sl[-2] = None
+      break
+
   name = "sumSeries(%s)" % formatPathExpressions(seriesList)
   values = ( safeSum(row) for row in izip(*seriesList) )
   series = TimeSeries(name,start,end,step,values)


### PR DESCRIPTION
When not all data has been loaded in yet for the current minute, the right hand side of a sum can dip which causes some observers heartburn.
