### PR TITLE
add TLS option for ldap auth

### DIFF
--- a/webapp/graphite/account/ldapBackend.py
+++ b/webapp/graphite/account/ldapBackend.py
@@ -22,6 +22,8 @@ class LDAPBackend:
     try:
       conn = ldap.initialize(settings.LDAP_URI)
       conn.protocol_version = ldap.VERSION3
+      if settings.LDAP_USE_TLS:
+        conn.start_tls_s()
       conn.simple_bind_s( settings.LDAP_BASE_USER, settings.LDAP_BASE_PASS )
     except ldap.LDAPError:
       traceback.print_exc()

--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -106,6 +106,7 @@
 #USE_LDAP_AUTH = True
 #LDAP_SERVER = "ldap.mycompany.com"
 #LDAP_PORT = 389
+#LDAP_USE_TLS = False
 #	OR
 #LDAP_URI = "ldaps://ldap.mycompany.com:636"
 #LDAP_SEARCH_BASE = "OU=users,DC=mycompany,DC=com"
@@ -118,10 +119,12 @@
 # For example:
 #
 #import ldap
-#ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_ALLOW)
+#ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_ALLOW) # Use ldap.OPT_X_TLS_DEMAND to force TLS
+#ldap.set_option(ldap.OPT_REFERRALS, 0) # Enable for Active Directory
 #ldap.set_option(ldap.OPT_X_TLS_CACERTDIR, "/etc/ssl/ca")
 #ldap.set_option(ldap.OPT_X_TLS_CERTFILE, "/etc/ssl/mycert.pem")
 #ldap.set_option(ldap.OPT_X_TLS_KEYFILE, "/etc/ssl/mykey.pem")
+#ldap.set_option(ldap.OPT_DEBUG_LEVEL, 65535) # To enable verbose debugging
 # See http://www.python-ldap.org/ for further details on these options.
 
 ## REMOTE_USER authentication. See: https://docs.djangoproject.com/en/dev/howto/auth-remote-user/

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -83,6 +83,7 @@ RRD_CF = 'AVERAGE'
 USE_LDAP_AUTH = False
 LDAP_SERVER = "" # "ldapserver.mydomain.com"
 LDAP_PORT = 389
+LDAP_USE_TLS = False
 LDAP_SEARCH_BASE = "" # "OU=users,DC=mydomain,DC=com"
 LDAP_BASE_USER = "" # "CN=some_readonly_account,DC=mydomain,DC=com"
 LDAP_BASE_PASS = "" # "my_password"


### PR DESCRIPTION
Adds an option to use TLS with ldap auth. Defaults to False since it can be a little bit hard to set up sometimes. Also adds some more ldap options in the local_settings example.
