### PR TITLE
Fix the required Django version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ prefix = /opt/graphite
 install-lib = %(prefix)s/webapp
 
 [bdist_rpm]
-requires = Django => 1.1.4
+requires = Django => 1.4
            django-tagging
            carbon
            whisper


### PR DESCRIPTION
Since the commit fc3f018544c19b90cc63797d18970a4cc27ef2ad graphite-web requires Django > 1.4
