### PR TITLE
graphite-web has a dependency to ceres modules, not reflected here right...

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ requires = Django => 1.1.4
            django-tagging
            carbon
            whisper
+           ceres
            mod_wsgi
            pycairo
            pycairo-devel


### PR DESCRIPTION
After installing graphite-web from rpm build by setup.py bdist_rpm, it comes up with an error message pointing to failing imports for ceres modules. To reflect this dependency also on package level, I would like to add it as rpm requirement.
