### PR TITLE
modified to ensure compatibility with python2.6

### DIFF
--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -230,6 +230,6 @@ def build_index(base_path, extension, fd):
         metric = metric[:-extension_len]
       else:
         continue
-      line = "{}.{}\n".format(path, metric)
+      line = "{0}.{1}\n".format(path, metric)
       fd.write(line)
   fd.flush()


### PR DESCRIPTION
Following the python doc at http://docs.python.org/2/library/string.html (7.1.3.2. Format examples), {}.{}\n,format() is available since python 2.7. To ensure compatibility with python2.6, i added tuple-indexes.
