### PR TITLE
added graphite-module to pythonpath

### DIFF
--- a/bin/build-index.sh
+++ b/bin/build-index.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+export PYTHONPATH=/opt/graphite/webapp/
 ./build-index


### PR DESCRIPTION
Running build-index failed importing python module. It is not in python path by default, so I would propose to add default path before execution.
