### PR TITLE
Add -q0 option to nc in docs

### DIFF
--- a/docs/feeding-carbon.rst
+++ b/docs/feeding-carbon.rst
@@ -25,8 +25,9 @@ On Unix, the ``nc`` program can be used to create a socket and send data to Carb
 
  PORT=2003
  SERVER=graphite.your.org
- echo "local.random.diceroll 4 `date +%s`" | nc ${SERVER} ${PORT};
+ echo "local.random.diceroll 4 `date +%s`" | nc -q0 ${SERVER} ${PORT}
 
+The ``-q0`` parameter instructs ``nc`` to close socket once data is sent. Without this option, some ``nc`` versions would keep the connection open.
 
 The pickle protocol
 -------------------


### PR DESCRIPTION
With some versions of nc, the connection is kept open after all data is sent. Using -q0 parameter will make nc quit immediatly after EOF on stdin.

Debian has two debian packages for nc: netcat-traditional and netcat-openbsd. The former hangs after EOF on stdin, whereas the latter quits. I assume the expected behavior is to quit nc after sending the metric data.
