### PR TITLE
Backport to 0.9.x: Log metric that produced exception

### DIFF
--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -234,7 +234,7 @@ def fetchData(requestContext, pathExpr):
         cachedResults = CarbonLink.query(dbFile.real_metric)
         results = mergeResults(dbResults, cachedResults)
       except:
-        log.exception()
+        log.exception("Failed CarbonLink query '%s'" % dbFile.real_metric)
 
     if not results:
       continue


### PR DESCRIPTION
To help diagnose issues such as those reported in
graphite-project/graphite-web#282

Backport from 80d111f8a270c5272089c280366f44a36d905eb4 on master branch.
