### PR TITLE
JSON.parse the escaped JSON for initialState.

### DIFF
--- a/webapp/graphite/templates/dashboard.html
+++ b/webapp/graphite/templates/dashboard.html
@@ -23,13 +23,13 @@
     var HELP_ICON     = '/content/js/ext/resources/icons/fam/information.png';
 
     {% if initialState %}
-    var initialState = "{{ initialState|escapejs }}";
+    var initialState = JSON.parse('{{ initialState|escapejs }}');
     {% else %}
     var initialState = null;
     {% endif %}
 
     {% if initialError %}
-    var initialError = "{{ initialError|escapejs }}";
+    var initialError = '{{ initialError|escapejs }}';
     {% else %}
     var initialError = null;
     {% endif %}


### PR DESCRIPTION
This resolves the issue of dashboards not loading when passed as /dashboard/<name>.

Patch by @cbowman0 . Fixes #411. In my 0.9.12 installation dashboards didn't load as they did in 0.9.10 until I applied this patch.
