### PR TITLE
browser, composer: escape target/queryString template variables

### DIFF
--- a/webapp/graphite/templates/browser.html
+++ b/webapp/graphite/templates/browser.html
@@ -23,9 +23,9 @@ limitations under the License. -->
 <frameset rows="60,*" frameborder="1" border="1">
   <frame src="/browser/header/" name="Header" id='header' scrolling="no" noresize="true" />
   {% if target %}
-    <frame src="/composer/?showTarget={{target}}&{{queryString}}" name="content" id="composerFrame"/>
+    <frame src="/composer/?showTarget={{target|urlencode|escape}}&amp;{{queryString|escape}}" name="content" id="composerFrame"/>
   {% else %}
-    <frame src="/composer/?{{queryString}}" name="content" id="composerFrame"/>
+    <frame src="/composer/?{{queryString|escape}}" name="content" id="composerFrame"/>
   {% endif %}
   </frameset>
 </html>

--- a/webapp/graphite/templates/composer.html
+++ b/webapp/graphite/templates/composer.html
@@ -118,7 +118,7 @@ limitations under the License. -->
         Composer.window.show();
 
         /* Direct graph loading */
-        if ("{{queryString}}") {
+        if ("{{queryString|escapejs}}") {
           Composer.loadURL("?{{queryString|escapejs}}");
         }
         /* Automatic tree expansion */


### PR DESCRIPTION
This fixes:
- XSS
  
  e.g. `?target="/><script>...</script><!--`
- Targets with special characters, like double quotes
  
  e.g. `?target=summarize(foo.bar,"1hr")`
