### PR TITLE
Include curly braces in removeOuterCall conditionals

### DIFF
--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -3209,7 +3209,9 @@ function removeOuterCall() { // blatantly repurposed from composer_widgets.js (d
     for (i = 0; i < argString.length; i++) {
       switch (argString.charAt(i)) {
         case '(': depth += 1; break;
+        case '{': depth += 1; break;
         case ')': depth -= 1; break;
+        case '}': depth -= 1; break;
         case ',':
           if (depth > 0) { continue; }
           if (depth < 0) { Ext.Msg.alert("Malformed target, cannot remove outer call."); return; }


### PR DESCRIPTION
Remove outer call would fail to work properly if curly braces were used in inner calls.