### PR TITLE
Link to tools from feeding-carbon and add entry for txCarbonClient to tools

### DIFF
--- a/docs/client-apis.rst
+++ b/docs/client-apis.rst
@@ -1,0 +1,31 @@
+Client APIs
+=============================
+
+Cubism.js
+---------
+`Cubism.js`_ is a D3 plugin for visualizing time series data in real time, and can pull data from Graphite.
+
+Graphitejs
+----------
+`Graphitejs`_ is a jQuery plugin for easily making and displaying graphs and updating them on
+the fly using the Graphite URL api.
+
+Scales
+------
+`Scales`_ is a Python server state and statistics library that can output its data to Graphite.
+
+Structured Metrics
+------------------
+`structured_metrics`_ is a lightweight python library that uses plugins to read in
+Graphite's list of metric names and convert it into a multi-dimensional tag space of clear, sanitized targets.
+
+txCarbonClient
+--------------
+`txCarbonClient`_ is a simple Twisted API for reporting metrics to Carbon.
+
+
+.. _Cubism.js: http://square.github.io/cubism/
+.. _Graphitejs: https://github.com/prestontimmons/graphitejs
+.. _Scales: https://github.com/Cue/scales
+.. _structured_metrics: https://github.com/vimeo/graph-explorer/tree/master/structured_metrics
+.. _txCarbonClient: https://github.com/fdChasm/txCarbonClient

--- a/docs/feeding-carbon.rst
+++ b/docs/feeding-carbon.rst
@@ -6,11 +6,19 @@ It's worth noting that data sent to Graphite is actually sent to the :doc:`Carbo
 
 Choosing the right transfer method for you is dependent on how you want to build your application or script to send data:
 
+* There are some tools and APIs which can help you get your data into Carbon.
+
 * For a singular script, or for test data, the plaintext protocol is the most straightforward method.
 
 * For sending large amounts of data, you'll want to batch this data up and send it to Carbon's pickle receiver.
 
 * Finally, Carbon can listen to a message bus, via AMQP.
+
+
+Existing tools and APIs
+-----------------------
+* :doc:`client daemons and tools </tools>`
+* :doc:`client APIs </client-apis>`
 
 
 The plaintext protocol

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Graphite Documentation
    carbon-daemons
    config-carbon
    feeding-carbon
+   admin-carbon
    config-local-settings
    config-webapp
    admin-webapp
@@ -21,6 +22,7 @@ Graphite Documentation
    storage-backends
    terminology
    tools
+   client-apis
    who-is-using
    releases
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -115,8 +115,8 @@ Several installation options exist:
 Initial Configuration
 ---------------------
 .. toctree::
-   configure-webapp
-   configure-carbon
+   config-webapp
+   config-carbon
 
 
 Help! It didn't work!

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -42,10 +42,6 @@ Charcoal
 service which can generate images directly from a URL. Charcoal configuration is driven by a YAML
 config file.
 
-Cubism.js
----------
-`Cubism.js`_ is a D3 plugin for visualizing time series data in real time, and can pull data from Graphite.
-
 Descartes
 ---------
 `Descartes`_ is a Sinatra-based dashboard that allows users to correlate multiple metrics in a single chart, review long-term trends across one or more charts, and to collaborate with other users through a combination of shared dashboards and rich layouts.
@@ -115,7 +111,7 @@ Graphite-Newrelic
 
 
 Graphite-Observer
----------------
+-----------------
 `Graphite-Observer`_ is a real-time monitor dashboard for Graphite.
 
 
@@ -144,12 +140,6 @@ on an Android device.
 Graphios
 --------
 `Graphios`_ is a small Python daemon to send Nagios performance data (perfdata) to Graphite.
-
-
-Graphitejs
-----------
-`Graphitejs`_ is a jQuery plugin for easily making and displaying graphs and updating them on
-the fly using the Graphite URL api.
 
 
 Graphsky
@@ -245,11 +235,6 @@ AdMob (who was then bought by Google), this was released by Google as open sourc
 (http://google-opensource.blogspot.com/2010/09/get-ready-to-rocksteady.html).
 
 
-Scales
-------
-`Scales`_ is a Python server state and statistics library that can output its data to Graphite.
-
-
 Sensu
 -----
 `Sensu`_ is a monitoring framework that can route metrics to Graphite. Servers subscribe to sets of checks, so getting metrics from a new server to Graphite is as simple as installing the Sensu client and subscribing.
@@ -278,12 +263,6 @@ statsd
 `statsd`_ is a simple daemon for easy stats aggregation, developed by the folks at Etsy.
 A list of forks and alternative implementations can be found at <http://joemiller.me/2011/09/21/list-of-statsd-server-implementations/>
 
-
-Structured Metrics
-------------------
-`structured_metrics`_ is a lightweight python library that uses plugins to read in
-Graphite's list of metric names and convert it into a multi-dimensional tag space of clear, sanitized targets.
-
 Tasseo
 ------
 `Tasseo`_ is a lightweight, easily configurable, real-time dashboard for Graphite metrics.
@@ -307,7 +286,6 @@ annotated events, etc). Supports Graphite, flot, rickshaw and anthracite.
 .. _collectd-graphite: https://github.com/joemiller/collectd-graphite
 .. _collectd-to-graphite: https://github.com/loggly/collectd-to-graphite
 .. _Collectl: http://collectl.sourceforge.net/
-.. _Cubism.js: http://square.github.io/cubism/
 .. _D3.js: http://mbostock.github.com/d3/
 .. _Descartes: https://github.com/obfuscurity/descartes
 .. _Diamond: http://opensource.brightcove.com/project/Diamond/
@@ -325,7 +303,6 @@ annotated events, etc). Supports Graphite, flot, rickshaw and anthracite.
 .. _Graphite-Newrelic: https://github.com/gingerlime/graphite-newrelic
 .. _Graphite-Observer: https://github.com/huoxy/graphite-observer
 .. _Graphite-relay: https://github.com/markchadwick/graphite-relay
-.. _Graphitejs: https://github.com/prestontimmons/graphitejs
 .. _Graphiti: https://github.com/paperlesspost/graphiti
 .. _graphitius: https://github.com/erezmazor/graphitus
 .. _Graphitoid: https://market.android.com/details?id=com.tnc.android.graphite
@@ -353,7 +330,6 @@ annotated events, etc). Supports Graphite, flot, rickshaw and anthracite.
 .. _SqlToGraphite: https://github.com/perryofpeek/SqlToGraphite/
 .. _SSC Serv: https://ssc-serv.com/
 .. _statsd: https://github.com/etsy/statsd
-.. _structured_metrics: https://github.com/vimeo/graph-explorer/tree/master/structured_metrics
 .. _Tasseo: https://github.com/obfuscurity/tasseo
 .. _Therry: https://github.com/obfuscurity/therry
 .. _TimeseriesWidget: https://github.com/Dieterbe/timeserieswidget


### PR DESCRIPTION
Added link to the tools list from the feeding-carbon documentation because that is another great way to get metrics into Carbon. Added entry for txCarbonClient to the tools list.
