### PR TITLE
Python 2.6 on Lucid doesn't like '{}.{}'.format(v1,v2)

### DIFF
--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -232,7 +232,7 @@ def build_index(base_path, extension, fd):
         metric = metric[:-extension_len]
       else:
         continue
-      line = "{}.{}\n".format(path, metric)
+      line = "{0}.{1}\n".format(path, metric)
       total_entries += 1
       fd.write(line)
   fd.flush()


### PR DESCRIPTION
Replaced with '{0}.{1}'.format(v1,v2)
