### PR TITLE
When doing a * query order the returned metrics alphabetically by name

### DIFF
--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -1,5 +1,6 @@
 import datetime
 import time
+from operator import attrgetter
 from django.conf import settings
 from graphite.render.grammar import grammar
 from graphite.render.datalib import fetchData, TimeSeries
@@ -8,6 +9,7 @@ from graphite.render.datalib import fetchData, TimeSeries
 def evaluateTarget(requestContext, target):
   tokens = grammar.parseString(target)
   result = evaluateTokens(requestContext, tokens)
+  result.sort(key=attrgetter('name'))
 
   if type(result) is TimeSeries:
     return [result] #we have to return a list of TimeSeries objects


### PR DESCRIPTION
Seems that when target metrics are retrieved from whisper using a *
operator.  The ordering seems to differ depending on the time span of
the data.

For example if a query targets nectar.*.instance_count  then depending 
on the time frame of the query the ordering of the results differ.
