### PR TITLE
fix uncaught exceptions during fetch and find

### DIFF
--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -249,6 +249,9 @@
 # This should usually match the value configured in Carbon
 #REPLICATION_FACTOR = 1
 
+# How often should render.datalib.fetch() retry to get remote data
+# MAX_FETCH_RETRIES = 2
+
 #####################################
 # Additional Django Settings #
 #####################################

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -16,7 +16,7 @@ import time
 from graphite.logger import log
 from graphite.storage import STORE
 from graphite.readers import FetchInProgress
-
+from django.conf import settings
 
 class TimeSeries(list):
   def __init__(self, name, start, end, step, values, consolidate='average'):
@@ -94,40 +94,55 @@ def fetchData(requestContext, pathExpr):
   startTime = int( time.mktime( requestContext['startTime'].timetuple() ) )
   endTime   = int( time.mktime( requestContext['endTime'].timetuple() ) )
 
-  matching_nodes = STORE.find(pathExpr, startTime, endTime, local=requestContext['localOnly'])
-  fetches = [(node, node.fetch(startTime, endTime)) for node in matching_nodes if node.is_leaf]
+  def _fetchData(pathExpr,startTime, endTime, requestContext, seriesList):
+    matching_nodes = STORE.find(pathExpr, startTime, endTime, local=requestContext['localOnly'])
+    fetches = [(node, node.fetch(startTime, endTime)) for node in matching_nodes if node.is_leaf]
 
-  for node, results in fetches:
-    if isinstance(results, FetchInProgress):
-      results = results.waitForResults()
+    for node, results in fetches:
+      if isinstance(results, FetchInProgress):
+        results = results.waitForResults()
 
-    if not results:
-      log.info("render.datalib.fetchData :: no results for %s.fetch(%s, %s)" % (node, startTime, endTime))
-      continue
+      if not results:
+        log.info("render.datalib.fetchData :: no results for %s.fetch(%s, %s)" % (node, startTime, endTime))
+        continue
 
+      try:
+          (timeInfo, values) = results
+      except ValueError, e:
+          raise Exception("could not parse timeInfo/values from metric '%s': %s" % (node.path, e))
+      (start, end, step) = timeInfo
+
+      series = TimeSeries(node.path, start, end, step, values)
+      series.pathExpression = pathExpr #hack to pass expressions through to render functions
+      seriesList.append(series)
+
+    # Prune empty series with duplicate metric paths to avoid showing empty graph elements for old whisper data
+    names = set([ series.name for series in seriesList ])
+    for name in names:
+      series_with_duplicate_names = [ series for series in seriesList if series.name == name ]
+      empty_duplicates = [ series for series in series_with_duplicate_names if not nonempty(series) ]
+
+      if series_with_duplicate_names == empty_duplicates and len(empty_duplicates) > 0: # if they're all empty
+        empty_duplicates.pop() # make sure we leave one in seriesList
+
+      for series in empty_duplicates:
+        seriesList.remove(series)
+
+    return seriesList
+  
+  retries = 1 # start counting at one to make log output and settings more readable
+  while True:
     try:
-        (timeInfo, values) = results
-    except ValueError, e:
-        raise Exception("could not parse timeInfo/values from metric '%s': %s" % (node.path, e))
-    (start, end, step) = timeInfo
-
-    series = TimeSeries(node.path, start, end, step, values)
-    series.pathExpression = pathExpr #hack to pass expressions through to render functions
-    seriesList.append(series)
-
-  # Prune empty series with duplicate metric paths to avoid showing empty graph elements for old whisper data
-  names = set([ series.name for series in seriesList ])
-  for name in names:
-    series_with_duplicate_names = [ series for series in seriesList if series.name == name ]
-    empty_duplicates = [ series for series in series_with_duplicate_names if not nonempty(series) ]
-
-    if series_with_duplicate_names == empty_duplicates and len(empty_duplicates) > 0: # if they're all empty
-      empty_duplicates.pop() # make sure we leave one in seriesList
-
-    for series in empty_duplicates:
-      seriesList.remove(series)
-
-  return seriesList
+      seriesList = _fetchData(pathExpr,startTime, endTime, requestContext, seriesList)
+      return seriesList
+    except Exception, e:
+      if retries >= settings.MAX_FETCH_RETRIES:
+        log.exception("Failed after %i retry! See: %s" % (settings.MAX_FETCH_RETRIES, e))
+        raise Exception("Failed after %i retry! See: %s" % (settings.MAX_FETCH_RETRIES, e))
+      else:
+        log.exception("Got an exception when fetching data! See: %s Will do it again! Run: %i of %i" %
+                     (e, retries, settings.MAX_FETCH_RETRIES))
+        retries += 1
 
 
 def nonempty(series):

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -65,6 +65,8 @@ FIND_TOLERANCE = 2 * FIND_CACHE_DURATION
 DEFAULT_CACHE_DURATION = 60 #metric data and graphs are cached for one minute by default
 LOG_CACHE_PERFORMANCE = False
 
+MAX_FETCH_RETRIES = 2
+
 #Remote rendering settings
 REMOTE_RENDERING = False #if True, rendering is delegated to RENDERING_HOSTS
 RENDERING_HOSTS = []


### PR DESCRIPTION
We encountered several issues with graphite-web when running in a high
availability setup and when switching off a node.

This helps with the following excetpions (and maybe others):

```
  File "/opt/graphite/webapp/graphite/readers.py", line 30, in waitForResults
    return self.wait_callback()
  File "/opt/graphite/webapp/graphite/remote_storage.py", line 208, in extract_my_results
    for series in wait_for_results():
  File "/opt/graphite/webapp/graphite/remote_storage.py", line 203, in wait_for_results
    raise Exception("Passive remote fetch failed to find cached results")
Exception: Passive remote fetch failed to find cached results
```

```
  File "/opt/graphite/webapp/graphite/readers.py", line 30, in waitForResults
    return self.wait_callback()
  File "/opt/graphite/webapp/graphite/remote_storage.py", line 208, in extract_my_results
    for series in wait_for_results():
  File "/opt/graphite/webapp/graphite/remote_storage.py", line 182, in wait_for_results
    response = connection.getresponse()
NameError: free variable 'connection' referenced before assignment in enclosing scope
```

```
  File "/opt/graphite/webapp/graphite/readers.py", line 30, in waitForResults
    return self.wait_callback()
  File "/opt/graphite/webapp/graphite/remote_storage.py", line 208, in extract_my_results
    for series in wait_for_results():
  File "/opt/graphite/webapp/graphite/remote_storage.py", line 182, in wait_for_results
    response = connection.getresponse()
  File "/usr/lib64/python2.6/httplib.py", line 990, in getresponse
    response.begin()
  File "/usr/lib64/python2.6/httplib.py", line 391, in begin
    version, status, reason = self._read_status()
  File "/usr/lib64/python2.6/httplib.py", line 349, in _read_status
    line = self.fp.readline()
  File "/usr/lib64/python2.6/socket.py", line 433, in readline
    data = recv(1)
error: [Errno 104] Connection reset by peer
```

Also, this might be related to #421
