### PR TITLE
Issue #475 - absolute time-range for a dashboard from the URL

### DIFF
--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -2402,6 +2402,24 @@ function applyState(state) {
   TimeRange.startTime = timeConfig.startTime;
   TimeRange.endDate = new Date(timeConfig.endDate);
   TimeRange.endTime = timeConfig.endTime;
+
+  if (queryString.from && queryString.until) {
+    // The URL contains a "from" and "until" parameters (format "YYYY-MM-DDThh:mm:ss") => use the timestamps as default absolute range of the dashboard
+    var from = new Date(queryString.from);
+    var until = new Date(queryString.until);
+
+    TimeRange.startDate = from;
+    TimeRange.startTime = from.format("H:m");
+    TimeRange.endDate = until;
+    TimeRange.endTime = until.format("H:m");
+    TimeRange.type = 'absolute';
+
+    state.timeConfig = TimeRange;
+
+    state.defaultGraphParams.from = from.format('H:i_Ymd');
+    state.defaultGraphParams.until = until.format('H:i_Ymd');
+  }
+
   updateTimeText();
 
 


### PR DESCRIPTION
Issue #475 - absolute time-range for a dashboard can be passed using "from" and "until" GET-parameters in the URL (http://graphite/?from=2013-10-27T22:00:00&until=2013-10-27T23:00:00#cpu - to open the CPU dashboard in the given time range). Format of the time range boundaries is "YYYY-MM-DDThh:mm:ss"