### PR TITLE
Open a socket and compare source IP with destination in is_local_interface

### DIFF
--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -74,7 +74,7 @@ def is_local_interface(host):
 
   try:
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.connect( (host, 0) )
+    sock.connect( (host, 4242) )
     local_ip = sock.getsockname()[0]
     sock.close()
   except:

--- a/webapp/tests/test_util.py
+++ b/webapp/tests/test_util.py
@@ -1,0 +1,10 @@
+from django.test import TestCase
+
+from graphite import util
+
+
+class UtilTest(TestCase):
+    def test_is_local_interface(self):
+        addresses = ['127.0.0.1', '127.0.0.1:8080', '8.8.8.8']
+        results = [ util.is_local_interface(a) for a in addresses ]
+        self.assertEqual( results, [True, True, False] )


### PR DESCRIPTION
This change fixes an issue where if /proc/sys/net/ipv4/ip_nonlocal_bind  is set to 1, remote
addresses where detected as local.

This fixes issue #222
