### PR TITLE
add verticalLine() url function

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2271,7 +2271,7 @@ def verticalLine(requestContext, ts, label=None, color=None):
 
   .. code-block:: none
 
-    &target=verticalLine(12:3420131108,'event','blue')
+    &target=verticalLine("12:3420131108","event","blue")
 
   """
   ts = timestamp( parseATTime(ts, requestContext['tzinfo']) )

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2306,7 +2306,7 @@ def threshold(requestContext, value, label=None, color=None):
 
   .. code-block:: none
 
-    &target=threshold(123.456, "omgwtfbbq", red)
+    &target=threshold(123.456, "omgwtfbbq", "red")
 
   """
   series = constantLine(requestContext, value)[0]

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -56,6 +56,7 @@ def renderView(request):
     'startTime' : requestOptions['startTime'],
     'endTime' : requestOptions['endTime'],
     'localOnly' : requestOptions['localOnly'],
+    'tzinfo' : requestOptions['tzinfo'],
     'data' : []
   }
   data = requestContext['data']


### PR DESCRIPTION
hi. i've written a verticalLine() function for graphite's url api
which draws a vertical line on the graph at a specific
timestamp specified by the first argument function, 
in the same time formats as &from= and &until=, e.g.

&target=verticalLine("12:3420131108","event","blue")

this will be handy for quickly marking ad-hoc events 
on graphs without having to think of where it belongs
in the namespace and cluttering the database.

it seems like at least one other person wanted this functionality:
https://answers.launchpad.net/graphite/+question/187677