### PR TITLE
Correcting Variable reference

### DIFF
--- a/docs/config-local-settings.rst
+++ b/docs/config-local-settings.rst
@@ -178,12 +178,12 @@ USE_LDAP_AUTH
 LDAP_SERVER
   `Default: ''`
 
-  Set the LDAP server here or alternativly in ``LDAP_URL``
+  Set the LDAP server here or alternativly in ``LDAP_URI``
 
 LDAP_PORT
   `Default: 389`
 
-  Set the LDAP server port here or alternativly in ``LDAP_URL``
+  Set the LDAP server port here or alternativly in ``LDAP_URI``
 
 LDAP_URI
   `Default: None`


### PR DESCRIPTION
LDAP_URL does not seem to exist. I am assuming this is meant to be LDAP_URI.
