### PR TITLE
Docs/tools: add pipe-to-graphite

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -222,6 +222,11 @@ Pencil
 `Pencil`_ is a monitoring frontend for graphite. It runs a webserver that dishes out pretty Graphite
 URLs in interesting and intuitive layouts.
 
+pipe-to-graphite
+----------------
+
+`pipe-to-graphite`_ is a small shell script that makes it easy to report the
+output of any other cli program to Graphite.
 
 Rocksteady
 ----------
@@ -323,6 +328,7 @@ annotated events, etc). Supports Graphite, flot, rickshaw and anthracite.
 .. _metrics-sampler: https://github.com/dimovelev/metrics-sampler
 .. _New Relic: https://newrelic.com/platform
 .. _Pencil: https://github.com/fetep/pencil
+.. _pipe-to-graphite: https://github.com/iFixit/pipe-to-graphite
 .. _RabbitMQ: http://www.rabbitmq.com/
 .. _Rickshaw: http://code.shutterstock.com/rickshaw/
 .. _Rocksteady: http://code.google.com/p/rocksteady/


### PR DESCRIPTION
We wrote [pipe-to-graphite](https://github.com/iFixit/pipe-to-graphite)
a while ago to make it easy to record the output from the status
commands of gearmand, memcached, varnish, etc.  I don't know why we
never added it to the list of tools, so here it is.
