### PR TITLE
Add sortByName() function

### DIFF
--- a/webapp/content/js/composer_widgets.js
+++ b/webapp/content/js/composer_widgets.js
@@ -958,6 +958,7 @@ function createFunctionsMenu() {
         {text: 'Maximum Value Above', handler: applyFuncToEachWithInput('maximumAbove', 'Draw all metrics whose maximum value is above ___')},
         {text: 'Maximum Value Below', handler: applyFuncToEachWithInput('maximumBelow', 'Draw all metrics whose maximum value is below ___')},
         {text: 'Minimum Value Above', handler: applyFuncToEachWithInput('minimumAbove', 'Draw all metrics whose minimum value is above ___')},
+        {text: 'sortByName', handler: applyFuncToEach('sortByName')},
         {text: 'sortByTotal', handler: applyFuncToEach('sortByTotal')},
         {text: 'sortByMaxima', handler: applyFuncToEach('sortByMaxima')},
         {text: 'sortByMinima', handler: applyFuncToEach('sortByMinima')},

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1659,6 +1659,18 @@ def limit(requestContext, seriesList, n):
   """
   return seriesList[0:n]
 
+def sortByName(requestContext, seriesList):
+  """
+  Takes one metric or a wildcard seriesList.
+
+  Sorts the list of metrics by the metric name.
+  """
+  def compare(x,y):
+    return cmp(x.name, y.name)
+
+  seriesList.sort(compare)
+  return seriesList
+
 def sortByTotal(requestContext, seriesList):
   """
   Takes one metric or a wildcard seriesList.
@@ -2904,6 +2916,7 @@ SeriesFunctions = {
   'nPercentile' : nPercentile,
   'limit' : limit,
   'sortByTotal'  : sortByTotal,
+  'sortByName' : sortByName,
   'averageOutsidePercentile' : averageOutsidePercentile,
   'removeBetweenPercentile' : removeBetweenPercentile,
   'sortByMaxima' : sortByMaxima,


### PR DESCRIPTION
Because the ordering of metrics returned by a wildcard search is not guaranteed to be consistent, a function to re-order metrics by name is required.

This implements `sortByName()` which will sort the series list returned in ascending order based on the series name.

Example before applying `sortByName()`,

![screenshot 12 10 13 12 16 pm](https://f.cloud.github.com/assets/79608/1716304/fe821302-61be-11e3-9828-61d39907aca6.png)

and after,

![screenshot 12 10 13 12 18 pm](https://f.cloud.github.com/assets/79608/1716311/1d862068-61bf-11e3-837e-061e752335ab.png)

Relates to: https://github.com/graphite-project/graphite-web/pull/474 https://github.com/graphite-project/graphite-web/issues/473 https://github.com/graphite-project/graphite-web/issues/458

Duplicates: https://github.com/graphite-project/graphite-web/pull/419
