### PR TITLE
Fix 'now' handling in render queries

### DIFF
--- a/webapp/graphite/render/attime.py
+++ b/webapp/graphite/render/attime.py
@@ -25,9 +25,12 @@ except ImportError: # Otherwise we fall back to Graphite's bundled version
 months = ['jan','feb','mar','apr','may','jun','jul','aug','sep','oct','nov','dec']
 weekdays = ['sun','mon','tue','wed','thu','fri','sat']
 
-def parseATTime(s, tzinfo=None):
+def parseATTime(s, tzinfo=None, now=None):
   if tzinfo is None:
     tzinfo = pytz.timezone(settings.TIME_ZONE)
+  if now is None:
+    now = datetime.now(tz=tzinfo)
+
   s = s.strip().lower().replace('_','').replace(',','').replace(' ','')
   if s.isdigit():
     if len(s) == 8 and int(s[:4]) > 1900 and int(s[4:6]) < 13 and int(s[6:]) < 32:
@@ -44,12 +47,12 @@ def parseATTime(s, tzinfo=None):
     offset = '-' + offset
   else:
     ref,offset = s,''
-  return tzinfo.localize(parseTimeReference(ref), daylight) + parseTimeOffset(offset)
+
+  return parseTimeReference(ref, now) + parseTimeOffset(offset)
 
 
-def parseTimeReference(ref):
-  if not ref or ref == 'now': return datetime.now()
-
+def parseTimeReference(ref, now):
+  if not ref or ref == 'now': return now
   #Time-of-day reference
   i = ref.find(':')
   hour,min = 0,0
@@ -71,7 +74,7 @@ def parseTimeReference(ref):
     hour,min = 16,0
     ref = ref[7:]
 
-  refDate = datetime.now().replace(hour=hour,minute=min,second=0)
+  refDate = now.replace(hour=hour,minute=min,second=0)
 
   #Day reference
   if ref in ('yesterday','today','tomorrow'): #yesterday, today, tomorrow

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -218,6 +218,7 @@ def fetchData(requestContext, pathExpr):
   seriesList = []
   startTime = requestContext['startTime']
   endTime = requestContext['endTime']
+  now = requestContext['now']
 
   if requestContext['localOnly']:
     store = LOCAL_STORE
@@ -226,7 +227,7 @@ def fetchData(requestContext, pathExpr):
 
   for dbFile in store.find(pathExpr):
     log.metric_access(dbFile.metric_path)
-    dbResults = dbFile.fetch( timestamp(startTime), timestamp(endTime) )
+    dbResults = dbFile.fetch( timestamp(startTime), timestamp(endTime), timestamp(now))
     results = dbResults
 
     if dbFile.isLocal():

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -55,6 +55,7 @@ def renderView(request):
   requestContext = {
     'startTime' : requestOptions['startTime'],
     'endTime' : requestOptions['endTime'],
+    'now': requestOptions['now'],
     'localOnly' : requestOptions['localOnly'],
     'data' : []
   }
@@ -284,14 +285,21 @@ def parseOptions(request):
 
   # Get the time interval for time-oriented graph types
   if graphType == 'line' or graphType == 'pie':
+    if 'now' in queryParams:
+        now = parseATTime(queryParams['now'])
+    else:
+        now = datetime.now()
+
     if 'until' in queryParams:
-      untilTime = parseATTime(queryParams['until'], tzinfo)
+      untilTime = parseATTime(queryParams['until'], tzinfo, now)
     else:
-      untilTime = parseATTime('now', tzinfo)
+      untilTime = now
     if 'from' in queryParams:
-      fromTime = parseATTime(queryParams['from'], tzinfo)
+      fromTime = parseATTime(queryParams['from'], tzinfo, now)
     else:
-      fromTime = parseATTime('-1d', tzinfo)
+      fromTime = parseATTime('-1d', tzinfo, now)
+
+
 
     startTime = min(fromTime, untilTime)
     endTime = max(fromTime, untilTime)
@@ -299,6 +307,7 @@ def parseOptions(request):
 
     requestOptions['startTime'] = startTime
     requestOptions['endTime'] = endTime
+    requestOptions['now'] = now
 
   return (graphOptions, requestOptions)
 

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -304,8 +304,8 @@ class WhisperFile(Leaf):
     end = max( os.stat(self.fs_path).st_mtime, start )
     return [ (start, end) ]
 
-  def fetch(self, startTime, endTime):
-    return whisper.fetch(self.fs_path, startTime, endTime)
+  def fetch(self, startTime, endTime, now=None):
+    return whisper.fetch(self.fs_path, startTime, endTime, now)
 
   @property
   def context(self):
@@ -336,13 +336,13 @@ class WhisperFile(Leaf):
 class GzippedWhisperFile(WhisperFile):
   extension = '.wsp.gz'
 
-  def fetch(self, startTime, endTime):
+  def fetch(self, startTime, endTime, now=None):
     if not gzip:
       raise Exception("gzip module not available, GzippedWhisperFile not supported")
 
     fh = gzip.GzipFile(self.fs_path, 'rb')
     try:
-      return whisper.file_fetch(fh, startTime, endTime)
+      return whisper.file_fetch(fh, startTime, endTime, now)
     finally:
       fh.close()
 
@@ -400,7 +400,8 @@ class RRDDataSource(Leaf):
     end = max( os.stat(self.rrd_file.fs_path).st_mtime, start )
     return [ (start, end) ]
 
-  def fetch(self, startTime, endTime):
+  def fetch(self, startTime, endTime, now=None):
+    # 'now' parameter is meaningful for whisper but not RRD
     startString = time.strftime("%H:%M_%Y%m%d+%Ss", time.localtime(startTime))
     endString = time.strftime("%H:%M_%Y%m%d+%Ss", time.localtime(endTime))
 


### PR DESCRIPTION
Previously, datetime.now() was called more than once
when rendering data.  This led to non-deterministic
selection of sample resolution.  For example, if
the schema is 60s:1d,300s:7d, and a request for
'-1d'->'now' came in, one would sometimes get
the 300s data and sometimes the 60s data, depending
on the length of time between the call to now() in
render.views and the call to now() in whisper.fetch.

Related: https://github.com/graphite-project/whisper/pull/56
