### PR TITLE
Add 'json-array' format

### DIFF
--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -173,18 +173,20 @@ def renderView(request):
           start = min(start, series.start) if start is not None else series.start
           end = max(end, series.end) if end is not None else series.end
 
-        timestamps = range(start, end, step)
         datapoints = []
 
-        iters = [iter(s) for s in data]
-        for ts in timestamps:
-          dp = [ts]
-          for i, series in enumerate(data):
-            if ts < series.start or ts >= series.end:
-              dp.append(None)
-            else:
-              dp.append(iters[i].next())
-          datapoints.append(dp)
+        if data:
+            timestamps = range(start, end, step)
+            iters = [iter(s) for s in data]
+            for ts in timestamps:
+              dp = [ts]
+              for i, series in enumerate(data):
+                if ts < series.start or ts >= series.end:
+                  dp.append(None)
+                else:
+                  dp.append(iters[i].next())
+              datapoints.append(dp)
+
         series_data = {
           'targets': [s.name for s in data],
           'datapoints': datapoints


### PR DESCRIPTION
This provides an array of (x, y1, y2) tuples
instead of multiple arrays of (x, y1), (x, y2)
tuples.  It is efficient (the timestamp
is not repeated) and convenient for use with
the dygraphs library.

It has a constraint that when querying multiple series, they must provide the same timestep.  If someone is using data which does not satisfy this requirement they should not use json-array, because it would have to munge in falsified values to fill in 'gaps' in coarser series.

This requires https://github.com/graphite-project/graphite-web/pull/523 to work reliably, because without PR 523 graphite does not choose sample resolution deterministically.

Based on 0.9.x because that's what we're using, but can submit PR for master if this patch is wanted.
