### PR TITLE
Update config-local-settings.rst

### DIFF
--- a/docs/config-local-settings.rst
+++ b/docs/config-local-settings.rst
@@ -214,7 +214,7 @@ LDAP_USER_QUERY
 
 Other Authentications
 ^^^^^^^^^^^^^^^^^^^^^
-REMOTE_USER_AUTHENTICATION
+USE_REMOTE_USER_AUTHENTICATION
   `Default: False`
 
   Enables the use of the Django `RemoteUserBackend` authentication backend. See the


### PR DESCRIPTION
The docs are incorrect compared to the code:

```
$ grep -nri REMOTE_USER_AUTHENTICATION .
./webapp/graphite/local_settings.py.example:131:#USE_REMOTE_USER_AUTHENTICATION = True
./webapp/graphite/settings.py:94:USE_REMOTE_USER_AUTHENTICATION = False
./webapp/graphite/settings.py:209:if USE_REMOTE_USER_AUTHENTICATION:
./docs/config-local-settings.rst:217:REMOTE_USER_AUTHENTICATION
```
