### PR TITLE
Added constantMaxLineSeries function.

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2927,6 +2927,7 @@ SeriesFunctions = {
   'sortByMinima' : sortByMinima,
   'useSeriesAbove': useSeriesAbove,
   'exclude' : exclude,
+  'constantMaxLineSeries' : constantMaxLineSeries,
 
   # Data Filter functions
   'removeAbovePercentile' : removeAbovePercentile,


### PR DESCRIPTION
We have been patching this function into our graphite installs for a while so I figured we should commit it back as it may be useful to others. 

This function enables you to plot a horizontal line across the graph at the max value from a series or series list.

I have been able to get this to work with summarize, however we have to adjust the bucketing time frame if we scale the graph which get's annoying if your using the built in dashboard.
