### PR TITLE
Improve expansion of metrics

### DIFF
--- a/webapp/graphite/finders.py
+++ b/webapp/graphite/finders.py
@@ -18,7 +18,7 @@ class CeresFinder:
     self.tree = CeresTree(directory)
 
   def find_nodes(self, query):
-    for fs_path in glob( self.tree.getFilesystemPath(query.pattern) ):
+    for fs_path in glob_entries( self.tree.getFilesystemPath(query.pattern) ):
       metric_path = self.tree.getNodePath(fs_path)
 
       if CeresNode.isNodeDir(fs_path):
@@ -168,3 +168,10 @@ def match_entries(entries, pattern):
     matching = fnmatch.filter(entries, pattern)
     matching.sort()
     return matching
+
+def glob_entries(pattern):
+  """Expands pattern to entries list."""
+  if pattern.endswith('/**'):
+    return [ entry[0] for directory in glob(pattern[:-3]) for entry in os.walk(directory) ]
+
+  return glob(pattern)

--- a/webapp/graphite/finders.py
+++ b/webapp/graphite/finders.py
@@ -152,23 +152,13 @@ def _deduplicate(entries):
 
 def match_entries(entries, pattern):
   """A drop-in replacement for fnmatch.filter that supports pattern
-  variants (ie. {foo,bar}baz = foobaz or barbaz)."""
-  v1, v2 = pattern.find('{'), pattern.find('}')
+  variants (ie. {foo{1,2},bar}baz = foo1baz or foo2baz or barbaz)."""
+  matching = []
 
-  if v1 > -1 and v2 > v1:
-    variations = pattern[v1+1:v2].split(',')
-    variants = [ pattern[:v1] + v + pattern[v2+1:] for v in variations ]
-    matching = []
+  for variant in expand_braces(pattern):
+    matching.extend( fnmatch.filter(entries, variant) )
 
-    for variant in variants:
-      matching.extend( fnmatch.filter(entries, variant) )
-
-    return list( _deduplicate(matching) ) #remove dupes without changing order
-
-  else:
-    matching = fnmatch.filter(entries, pattern)
-    matching.sort()
-    return matching
+  return list( _deduplicate(matching) ) #remove dupes without changing order
 
 braces_pattern = re.compile(r'.*(\{.+?[^\\]\})')
 


### PR DESCRIPTION
This patchset adds few improvements into metrics matching:

* Extends fnmatch by double asterisk '**'. This special case allows you to match all metrics in depth.
* Allows curly brace expansion for both backends (StandardFinder, CeresFinder).

In addition this patchset will help to solve: https://github.com/vimeo/graph-explorer/issues/60
