### PR TITLE
Make asPercent/divideSeries accept multiple series as total/divisor

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -484,16 +484,21 @@ def divideSeries(requestContext, dividendSeriesList, divisorSeriesList):
   .. code-block:: none
 
     &target=divideSeries(Series.dividends,Series.divisors)
+    &target=divideSeries(Server*.connections.{failed,succeeded}, Server*.connections.attempted)
 
 
   """
-  if len(divisorSeriesList) != 1:
-    raise ValueError("divideSeries second argument must reference exactly 1 series")
 
-  divisorSeries = divisorSeriesList[0]
+  if len(divisorSeriesList) != 1 and len(divisorSeriesList) != len(dividendSeriesList):
+    raise ValueError("divideSeries first and second arguments must have the same number of series (%s != %s)" %
+        (len(dividendSeriesList), len(divisorSeriesList)))
+
+  if len(divisorSeriesList) == 1:
+    divisorSeriesList = repeat(divisorSeriesList[0], len(dividendSeriesList))
+
   results = []
 
-  for dividendSeries in dividendSeriesList:
+  for dividendSeries, divisorSeries in izip(dividendSeriesList, divisorSeriesList):
     name = "divideSeries(%s,%s)" % (dividendSeries.name, divisorSeries.name)
     bothSeries = (dividendSeries, divisorSeries)
     step = reduce(lcm,[s.step for s in bothSeries])


### PR DESCRIPTION
If multiple series as used as total for asPercent, the length of the
total series must match the length of the seriesList, and they will be
matched together to calculate the percentage of the individual values.

Also remove the current limitation of divisorSeriesList to have only one
series and accept multiple series. In this case the number of divisor
series must match the number of dividend series, and they are matched so
each dividend series get divided by the corresponding divisor.

The old behaviour when only one series is used is retained, so this is
only an extension.

Fixes #207.