### PR TITLE
Fix IndentationError in check-dependencies.py

### DIFF
--- a/check-dependencies.py
+++ b/check-dependencies.py
@@ -177,7 +177,7 @@ try:
   import cylowess
 except ImportError:
   sys.stderr.write("[OPTIONAL] Unable to import 'cylowess', do you have cylowess installed for python %s? This allows for faster lowess processing (locallly weighted scatterplot smoothing) than the standard version, espcially for large datasets. You can install from here: https://github.com/livingsocial/cylowess\n" % py_version)
-    optional += 1
+  optional += 1
 
 if optional:
   sys.stderr.write("%d optional dependencies not met. Please consider the optional items before proceeding.\n" % optional)


### PR DESCRIPTION
There is a syntax error in `check-dependencies.py`, in the `cylowess` case.

This PR fixes it by removing two spaces.
