### PR TITLE
adding rearview to "tools that work with graphite"

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -235,7 +235,7 @@ output of any other cli program to Graphite.
 
 rearview
 --------
-`rearview`_ is a real-time monitoring framework that sits on top of Graphite's time series data. This allows users to create monitors that both visualize and alert on data as it streams from Graphite. The monitors themselves are simple Ruby scripts which run in a sandbox to provide additinoal security. Monitors are also configured with a crontab compatible time specification used by the scheduler. Alerts can be sent via email, pagerduty, or campfire.
+`rearview`_ is a real-time monitoring framework that sits on top of Graphite's time series data. This allows users to create monitors that both visualize and alert on data as it streams from Graphite. The monitors themselves are simple Ruby scripts which run in a sandbox to provide additional security. Monitors are also configured with a crontab compatible time specification used by the scheduler. Alerts can be sent via email, pagerduty, or campfire.
 
 
 Rocksteady


### PR DESCRIPTION
Adding LivingSocial's rearview, a real-time monitoring framework that sits on top of Graphite allowing users to visualize and alert on data, to the "tools that work with graphite" documentation.
