### PR TITLE
Get docs building for master again

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,9 @@ os.environ['DJANGO_SETTINGS_MODULE'] = "graphite.settings"
 from graphite import settings
 settings.LOG_DIR = os.path.abspath('.')
 
+# Bring in the new ReadTheDocs sphinx theme
+import sphinx_rtd_theme
+
 # Define a custom autodoc documenter for the render.functions module
 # This will remove the requestContext parameter which doesnt make sense in the context of the docs
 import re
@@ -123,7 +126,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  Major themes that come with
 # Sphinx are currently 'default' and 'sphinxdoc'.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -131,7 +134,7 @@ html_theme = 'default'
 #html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,7 @@
 Django==1.3
 django-tagging==0.3.1
 sphinx
+sphinx_rtd_theme
 pytz
 numpy
 git+git://github.com/graphite-project/whisper.git#egg=whisper


### PR DESCRIPTION
The [latest function docs](http://graphite.readthedocs.org/en/latest/functions.html) were failing to build due to the introduction of the numpy dependency in #538. Add this and Sphinx deps for local builds.

Oh, and a small release bump in `docs/conf.py`.
