### PR TITLE
Add mapSeries and reduceSeries render functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 install:
   - pip install https://github.com/graphite-project/ceres/tarball/master
   - pip install $REQUIREMENTS
-  - pip install whisper django-tagging pytz pyparsing==1.5.7 http://cairographics.org/releases/py2cairo-1.8.10.tar.gz
+  - pip install whisper django-tagging pytz pyparsing==1.5.7 mock http://cairographics.org/releases/py2cairo-1.8.10.tar.gz
 
 script:
   - PYTHONPATH=. python manage.py test --settings=tests.settings


### PR DESCRIPTION
Currently, graphite has no way to map-reduce disparate series together
which is desirable for series that come from collectd and others
where calculations need to be performed on two or more related series.

This commit adds two new render functions: mapSeries and reduceSeries.
This is a generic way of mapping several related series together and
reducing them with another function.
- Add mapSeries function which takes a seriesList and maps it to a
  list of sub-seriesList. Each sub-seriesList has the given mapNode
  in common.
- Add reduceSeries function which takes a list of seriesLists and
  reduces it to a list of series by means of the reduceFunction.
- Add mock module to .travis.yml
- Add tests for mapSeries and reduceSeries
