### PR TITLE
Adding a connection lock to remote_storage.py

### DIFF
--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -162,14 +162,16 @@ class RemoteReader(object):
     # Despite our use of thread synchronization primitives, the common
     # case is for synchronizing asynchronous fetch operations within
     # a single thread.
-    (request_lock, wait_lock, completion_event) = self.get_request_locks(url)
+    (request_lock, connection_lock, wait_lock, completion_event) = self.get_request_locks(url)
 
     if request_lock.acquire(False): # we only send the request the first time we're called
       try:
         log.info("RemoteReader.request_data :: requesting %s" % url)
+        connection_lock.acquire()
         connection = HTTPConnectionWithTimeout(self.store.host)
         connection.timeout = settings.REMOTE_FETCH_TIMEOUT
         connection.request('GET', urlpath)
+        connection_lock.release()
       except:
         completion_event.set()
         self.store.fail()
@@ -179,7 +181,11 @@ class RemoteReader(object):
     def wait_for_results():
       if wait_lock.acquire(False): # the FetchInProgress that gets waited on waits for the actual completion
         try:
+          # Connection lock needed to be sure connection is
+          # ready to get a response.
+          connection_lock.acquire()
           response = connection.getresponse()
+          connection_lock.release()
           if response.status != 200:
             raise Exception("Error response %d %s from %s" % (response.status, response.reason, url))
 
@@ -232,7 +238,7 @@ class RemoteReader(object):
     self.cache_lock.acquire()
     try:
       if url not in self.request_locks:
-        self.request_locks[url] = (Lock(), Lock(), Event())
+        self.request_locks[url] = (Lock(), Lock(), Lock(), Event())
         self.request_times[url] = time.time()
       return self.request_locks[url]
     finally:


### PR DESCRIPTION
This is to fix a problem when using distributed rendering in our graphite cluster. The problem was that there were instances where the connection to fetch metrics was not ready before trying to get the response.
## This created an exception such as 

``` python
Mon Jan 13 11:57:51 2014 :: Error requesting URL
Traceback (most recent call last):
  File "/opt/graphite/webapp/graphite/remote_storage.py", line 182, in wait_for_results
    response = connection.getresponse()
NameError: free variable 'connection' referenced before assignment in enclosing scope
```

---

failing rendering some plots when render metrics from remote servers.

I added a connection_lock to be sure the connection and GET operation is successful before trying to parse it. I hate to be using a code with so many locks but this seems to be working for me.

I find this feature very annoying that is why I took some time to debug it and report it as pull request.

Regards.
Victor
