### PR TITLE
Fix browser header display on Internet Explorer

### DIFF
--- a/webapp/graphite/templates/browser.html
+++ b/webapp/graphite/templates/browser.html
@@ -1,3 +1,4 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" "http://www.w3.org/TR/html4/frameset.dtd">
 <!-- Copyright 2008 Orbitz WorldWide
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +19,7 @@ limitations under the License. -->
   <head>
     <title>Graphite Browser</title>
   </head>
-        
+
 
 <frameset rows="60,*" frameborder="1" border="1">
   <frame src="/browser/header/" name="Header" id='header' scrolling="no" noresize="true" />

--- a/webapp/graphite/templates/browserHeader.html
+++ b/webapp/graphite/templates/browserHeader.html
@@ -1,3 +1,4 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <!-- Copyright 2008 Orbitz WorldWide
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +19,7 @@ limitations under the License. -->
     <style>
       body {
         background-color: #000;
-        background: url('/content/img/carbon-fiber.png');
+        background: #000 url('/content/img/carbon-fiber.png');
         background: url('/content/img/carbon-fiber.png'), -webkit-linear-gradient(top, #000 55%, #333);
         background: url('/content/img/carbon-fiber.png'),    -moz-linear-gradient(top, #000, #000);
         background: url('/content/img/carbon-fiber.png'),     -ms-linear-gradient(top, #000 55%, #333);


### PR DESCRIPTION
The browser header is blank on IE.

I added doctype declaration to get out of quirks mode and if fixed the background color (was white instead of black).

Tested on IE8 & IE10.
