### PR TITLE
Tiny: Fix bug in metric names in index file (first character stripped off)

### DIFF
--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -226,7 +226,7 @@ def build_index(base_path, extension, fd):
   contents = os.walk(base_path, followlinks=True)
   extension_len = len(extension)
   for (dirpath, dirnames, filenames) in contents:
-    path = dirpath[len(base_path) + 1:].replace('/', '.')
+    path = dirpath[len(base_path):].replace('/', '.')
     for metric in filenames:
       if metric.endswith(extension):
         metric = metric[:-extension_len]


### PR DESCRIPTION
I noticed that the metric names in index file were missing the first character. Here's an example. 

In [8]: dirpath='/opt/graphite/storage/whisper/systems/u/ubuntu'

In [9]: base='/opt/graphite/storage/whisper/'

In [10]: print(dirpath[len(base) + 1:])
ystems/u/ubuntu

In [11]: print(dirpath[len(base):])
systems/u/ubuntu
