### PR TITLE
Graceful fail on missing remote cache

### DIFF
--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -111,7 +111,12 @@ class FindRequest(object):
         reader = RemoteReader(self.store, node_info, bulk_query=self.query.pattern)
         node = LeafNode(node_info['path'], reader)
       else:
-        node = BranchNode(node_info['path'])
+        try:
+          node = BranchNode(node_info['path'])
+        except:
+          log.exception("FindRequest.get_results(host=%s, query=%s) branch node did not respond" % (self.store.host, self.query))
+          self.store.fail()
+          return
 
       node.local = False
       yield node


### PR DESCRIPTION
We should handle a non-responsive branch node gracefully rather than letting the webapp crash. This at least gives us the data from the caches that responded, rather than an empty tree.