### PR TITLE
Bug fix remote connection multithread issues between sending and receivi...

### DIFF
--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -162,27 +162,18 @@ class RemoteReader(object):
     # Despite our use of thread synchronization primitives, the common
     # case is for synchronizing asynchronous fetch operations within
     # a single thread.
-    (request_lock, wait_lock, completion_event) = self.get_request_locks(url)
+    (request_lock, completion_event) = self.get_request_locks(url)
 
-    if request_lock.acquire(False): # we only send the request the first time we're called
-      try:
-        log.info("RemoteReader.request_data :: requesting %s" % url)
-        connection = HTTPConnectionWithTimeout(self.store.host)
-        connection.timeout = settings.REMOTE_FETCH_TIMEOUT
-        connection.request('GET', urlpath)
-      except:
-        completion_event.set()
-        self.store.fail()
-        log.exception("Error requesting %s" % url)
-        raise
-
-    def wait_for_results():
-      if wait_lock.acquire(False): # the FetchInProgress that gets waited on waits for the actual completion
+    def request_series():
+      if request_lock.acquire(False): # the FetchInProgress that gets waited on waits for the actual completion
         try:
+          log.info("RemoteReader.request_data :: requesting %s" % url)
+          connection = HTTPConnectionWithTimeout(self.store.host)
+          connection.timeout = settings.REMOTE_FETCH_TIMEOUT
+          connection.request('GET', urlpath)
           response = connection.getresponse()
           if response.status != 200:
             raise Exception("Error response %d %s from %s" % (response.status, response.reason, url))
-
           pickled_response = response.read()
           results = unpickle.loads(pickled_response)
           self.cache_lock.acquire()
@@ -205,7 +196,7 @@ class RemoteReader(object):
           return cached_results
 
     def extract_my_results():
-      for series in wait_for_results():
+      for series in request_series():
         if series['name'] == self.metric_path:
           time_info = (series['start'], series['end'], series['step'])
           return (time_info, series['values'])


### PR DESCRIPTION
This is and simplification to fix the problem of sending and receiving queries to discover metrics in a graphite cluster as implemented in remote_storage.py.

I have documented some of my findings in the issues #592 and #582. The problem centered in the sending and parsing of the request to discover those metrics not locally present in graphite server. The gist of the issue was that the GET request and parsing of that request response was not done in the same thread.

The request is handle by the _connection_ variable defined by the first thread to reach fetch function. That created the issue that _connection_ might not even define by the time another thread was trying to read the response of the request. For all the problematic cases I saw, the assignment of _connection_ was successful before leaving fetch function, but after another thread tried to read the response, triggering the exception as documented in #582.

My first two solutions were to try to add a lock and later an event in an attempt to make sure the request is read after it was sent and responded. For reason it not clear to me this did not worked out. I was fooled a few times by this bug as to be fixed because of its sporadic nature.

Therefore I decided to simplify the code by reducing the number of locks and events. For this the thread that sends the request is the the same that waits for the response and parses it. This eliminated the need for synchronizing the send/receiving and parsing of the request by different threads. This also eliminated the need for a thread for sending/receiving and another thread for parsing the request.

I have being heavily testing this new code and at the moment worked in all the cases.
