### PR TITLE
Fix issue #617: handle TIME_ZONE=None

### DIFF
--- a/webapp/graphite/events/views.py
+++ b/webapp/graphite/events/views.py
@@ -1,7 +1,7 @@
 import datetime
 import time
 
-from django.conf import settings
+from django.utils.timezone import get_current_timezone
 from django.core.urlresolvers import get_script_prefix
 from django.http import HttpResponse
 from django.shortcuts import render_to_response, get_object_or_404
@@ -75,7 +75,10 @@ def get_data(request):
 def fetch(request):
     #XXX we need to move to USE_TZ=True to get rid of naive-time conversions
     def make_naive(dt):
-      tz = timezone(request.GET.get('tz', settings.TIME_ZONE))
+      if 'tz' in request.GET:
+        tz = timezone(request.GET['tz'])
+      else:
+        tz = get_current_timezone()
       local_dt = dt.astimezone(tz)
       if hasattr(local_dt, 'normalize'):
         local_dt = local_dt.normalize()

--- a/webapp/graphite/render/attime.py
+++ b/webapp/graphite/render/attime.py
@@ -14,7 +14,7 @@ limitations under the License."""
 
 from datetime import datetime,timedelta
 from time import daylight
-from django.conf import settings
+from django.utils.timezone import get_current_timezone
 
 try: # See if there is a system installation of pytz first
   import pytz
@@ -27,7 +27,7 @@ weekdays = ['sun','mon','tue','wed','thu','fri','sat']
 
 def parseATTime(s, tzinfo=None, now=None):
   if tzinfo is None:
-    tzinfo = pytz.timezone(settings.TIME_ZONE)
+    tzinfo = get_current_timezone()
   if now is None:
     now = datetime.now(tz=tzinfo)
 

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -18,6 +18,7 @@ from datetime import datetime, timedelta
 from urllib import unquote_plus
 from ConfigParser import SafeConfigParser
 from django.conf import settings
+from django.utils.timezone import get_current_timezone
 from graphite.render.datalib import TimeSeries
 from graphite.util import json
 
@@ -1329,7 +1330,7 @@ class LineGraph(Graph):
     if self.userTimeZone:
       tzinfo = pytz.timezone(self.userTimeZone)
     else:
-      tzinfo = pytz.timezone(settings.TIME_ZONE)
+      tzinfo = get_current_timezone()
 
     self.start_dt = datetime.fromtimestamp(self.startTime, tzinfo)
     self.end_dt = datetime.fromtimestamp(self.endTime, tzinfo)

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -45,6 +45,7 @@ from django.template import Context, loader
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
+from django.utils.timezone import get_current_timezone
 
 
 def renderView(request):
@@ -275,7 +276,7 @@ def parseOptions(request):
         continue
       graphOptions[opt] = val
 
-  tzinfo = pytz.timezone(settings.TIME_ZONE)
+  tzinfo = get_current_timezone()
   if 'tz' in queryParams:
     try:
       tzinfo = pytz.timezone(queryParams['tz'])


### PR DESCRIPTION
Fortunately Django is kind enough to give us
a method to get the current timezone, there
is no need to access settings.TIME_ZONE
directly.
