### PR TITLE
Implementation called django-admin.py

### DIFF
--- a/bin/run-graphite-devel-server.py
+++ b/bin/run-graphite-devel-server.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 import sys, os
-import subprocess
 from optparse import OptionParser
+
+from django.core import management
 
 option_parser = OptionParser(usage='''
 %prog [options] GRAPHITE_ROOT
@@ -19,18 +20,6 @@ if not args:
 
 graphite_root = args[0]
 
-django_admin = None
-for name in ('django-admin', 'django-admin.py'):
-  process = subprocess.Popen(['which', name], stdout=subprocess.PIPE)
-  output = process.stdout.read().strip()
-  if process.wait() == 0:
-    django_admin = output
-    break
-
-if not django_admin:
-  print "Could not find a django-admin script!"
-  sys.exit(1)
-
 python_path = os.path.join(graphite_root, 'webapp')
 
 if options.libs:
@@ -41,7 +30,7 @@ if options.libs:
 print "Running Graphite from %s under django development server\n" % graphite_root
 
 command = [
-  django_admin,
+  'django-admin.py',
   'runserver',
   '--pythonpath', python_path,
   '--settings', 'graphite.settings',
@@ -52,4 +41,5 @@ if options.noreload:
   command.append('--noreload')
 
 print ' '.join(command)
-os.execvp(django_admin, command)
+
+management.execute_from_command_line(command)


### PR DESCRIPTION
In `bin/run-graphite-devel-server.py`, cost many code to find `django-admin.py`, I think can direct use django mthod : `management.execute_from_command_line(command)` , Once you've installed django, django-admin.py script does not necessarily need to also be executed
