### PR TITLE
Fix #635 -- event tags creation and serialization

### DIFF
--- a/docs/releases/0_10_0.rst
+++ b/docs/releases/0_10_0.rst
@@ -35,6 +35,10 @@ Changes
   has been rewritten in Python. ``build-index.sh`` is still available but is
   just an alias to ``build-index``.
 
+* The events API now requires ``tags`` to be an array when creating tagged
+  events. Previous versions only accepted string attributes. Tags are also
+  serialized as arrays.
+
 New functions
 -------------
 

--- a/webapp/graphite/events/models.py
+++ b/webapp/graphite/events/models.py
@@ -1,4 +1,3 @@
-import time
 import os
 
 from django.db import models
@@ -46,7 +45,7 @@ class Event(models.Model):
             when=self.when,
             what=self.what,
             data=self.data,
-            tags=self.tags,
+            tags=self.tags.split(),
             id=self.id,
         )
 

--- a/webapp/graphite/events/views.py
+++ b/webapp/graphite/events/views.py
@@ -46,14 +46,20 @@ def post_event(request):
 
         values = {}
         values["what"] = event["what"]
-        values["tags"] = event.get("tags", None)
+        tags = event.get('tags')
+        if tags:
+            if not isinstance(tags, list):
+                return HttpResponse(
+                    json.dumps({'error': '"tags" must be an array'}),
+                    status=400)
+            tags = " ".join(tags)
+            values["tags"] = tags
         values["when"] = datetime.datetime.fromtimestamp(
             event.get("when", time.time()))
         if "data" in event:
             values["data"] = event["data"]
 
-        e = models.Event(**values)
-        e.save()
+        models.Event.objects.create(**values)
 
         return HttpResponse(status=200)
     else:

--- a/webapp/tests/test_events.py
+++ b/webapp/tests/test_events.py
@@ -1,0 +1,50 @@
+import json
+
+from django.test import TestCase
+from django.core.urlresolvers import reverse
+
+from graphite.events.models import Event
+
+
+class EventsTest(TestCase):
+    def test_event_tags(self):
+        url = reverse('graphite.events.views.get_data')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(json.loads(response.content)), 0)
+
+        creation_url = reverse('graphite.events.views.view_events')
+        event = {
+            'what': 'Something happened',
+            'data': 'more info',
+            'tags': ['foo', 'bar'],
+        }
+        response = self.client.post(creation_url, json.dumps(event),
+                                    content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+
+        event = Event.objects.get()
+        self.assertEqual(event.what, 'Something happened')
+        self.assertEqual(event.tags, 'foo bar')
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        events = json.loads(response.content)
+        self.assertEqual(len(events), 1)
+        event = events[0]
+        self.assertEqual(event['what'], 'Something happened')
+        self.assertEqual(event['tags'], ['foo', 'bar'])
+
+    def test_tag_as_str(self):
+        creation_url = reverse('graphite.events.views.view_events')
+        event = {
+            'what': 'Something happened',
+            'data': 'more info',
+            'tags': "other",
+        }
+        response = self.client.post(creation_url, json.dumps(event),
+                                    content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        error = json.loads(response.content)
+        self.assertEqual(error, {'error': '"tags" must be an array'})
+        self.assertEqual(Event.objects.count(), 0)


### PR DESCRIPTION
Tags were created properly with `"tags": "space-separated tags"` but not `"tags": ["actual", "array"]`. And the serialization was always wrong, returning tags as a string.

Now there are arrays everywhere, which makes more sense given "tags" is plural.