### PR TITLE
Fix initialState var in dashboard.html

### DIFF
--- a/webapp/graphite/templates/dashboard.html
+++ b/webapp/graphite/templates/dashboard.html
@@ -23,7 +23,7 @@
     var HELP_ICON     = '/content/js/ext/resources/icons/fam/information.png';
 
     {% if initialState %}
-    var initialState = "{{ initialState|escapejs }}";
+    var initialState = JSON.parse("{{ initialState|escapejs }}");
     {% else %}
     var initialState = null;
     {% endif %}


### PR DESCRIPTION
initialState is assumed to be an object in dashboard.js, but was a string of JSON. Fix by immediately doing JSON.parse on the string.
