### PR TITLE
Make it possible to mix formats of "from" and "until"

### DIFF
--- a/webapp/graphite/render/attime.py
+++ b/webapp/graphite/render/attime.py
@@ -31,7 +31,7 @@ def parseATTime(s, tzinfo=None):
     else:
       return datetime.fromtimestamp(int(s),tzinfo)
   elif ':' in s and len(s) == 11:
-    return datetime.strptime(s,'%H:%M%Y%m%d')
+    return tzinfo.localize(datetime.strptime(s,'%H:%M%Y%m%d'), daylight)
   if '+' in s:
     ref,offset = s.split('+',1)
     offset = '+' + offset

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -15,7 +15,7 @@ import csv
 import math
 import pytz
 from datetime import datetime
-from time import time
+from time import time, mktime
 from random import shuffle
 from httplib import CannotSendRequest
 from urllib import urlencode


### PR DESCRIPTION
When one was defined with "-2d" and the other with "HH:mm_YYYYMMDD"
a error occured because the datetime objects produced weren't comparable.
This patch make them comparable whatever their format
