### PR TITLE
Enable usage of constantLine function without any other target in the graph

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2712,8 +2712,8 @@ def constantLine(requestContext, value):
   name = "constantLine(%s)" % str(value)
   start = int(epoch( requestContext['startTime'] ) )
   end = int(epoch( requestContext['endTime'] ) )
-  step = (end - start) / 1.0
-  series = TimeSeries(str(value), start, end, step, [value, value])
+  step = int((end - start) / 2.0)
+  series = TimeSeries(str(value), start, end, step, [value, value, value])
   series.pathExpression = name
   return [series]
 

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -6,7 +6,7 @@ from fnmatch import fnmatch
 from django.test import TestCase
 from django.conf import settings
 from mock import patch, call, MagicMock
-from datetime import datetime, tzinfo, timedelta
+from datetime import datetime
 
 from graphite.render.datalib import TimeSeries
 from graphite.render import functions
@@ -285,22 +285,7 @@ class FunctionsTest(TestCase):
             self.assertEqual(series.color, color)
 
     def test_constantLine(self):
-        class GMT1(tzinfo):
-            def utcoffset(self, dt):
-                return timedelta(hours=1) + self.dst(dt)
-            def dst(self, dt):
-                # DST starts last Sunday in March
-                d = datetime(dt.year, 4, 1)   # ends last Sunday in October
-                self.dston = d - timedelta(days=d.weekday() + 1)
-                d = datetime(dt.year, 11, 1)
-                self.dstoff = d - timedelta(days=d.weekday() + 1)
-                if self.dston <=  dt.replace(tzinfo=None) < self.dstoff:
-                    return timedelta(hours=1)
-                else:
-                    return timedelta(0)
-            def tzname(self,dt):
-                return "GMT +1"
-        requestContext = {'startTime':datetime(2014,3,12,2,0,0,2,GMT1()), 'endTime':datetime(2014,3,12,3,0,0,2,GMT1())}
+        requestContext = {'startTime': datetime(2014,3,12,2,0,0,2,pytz.timezone(settings.TIME_ZONE)), 'endTime':datetime(2014,3,12,3,0,0,2,pytz.timezone(settings.TIME_ZONE))}
         results = functions.constantLine(requestContext, [1])
 
     def test_scale(self):

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -6,7 +6,7 @@ from fnmatch import fnmatch
 from django.test import TestCase
 from django.conf import settings
 from mock import patch, call, MagicMock
-from datetime import datetime
+from datetime import datetime, tzinfo, timedelta
 
 from graphite.render.datalib import TimeSeries
 from graphite.render import functions
@@ -283,6 +283,25 @@ class FunctionsTest(TestCase):
                 "The original seriesList shouldn't have a 'color' attribute",
             )
             self.assertEqual(series.color, color)
+
+    def test_constantLine(self):
+        class GMT1(tzinfo):
+            def utcoffset(self, dt):
+                return timedelta(hours=1) + self.dst(dt)
+            def dst(self, dt):
+                # DST starts last Sunday in March
+                d = datetime(dt.year, 4, 1)   # ends last Sunday in October
+                self.dston = d - timedelta(days=d.weekday() + 1)
+                d = datetime(dt.year, 11, 1)
+                self.dstoff = d - timedelta(days=d.weekday() + 1)
+                if self.dston <=  dt.replace(tzinfo=None) < self.dstoff:
+                    return timedelta(hours=1)
+                else:
+                    return timedelta(0)
+            def tzname(self,dt):
+                return "GMT +1"
+        requestContext = {'startTime':datetime(2014,3,12,2,0,0,2,GMT1()), 'endTime':datetime(2014,3,12,3,0,0,2,GMT1())}
+        results = functions.constantLine(requestContext, [1])
 
     def test_scale(self):
         seriesList = self._generate_series_list()

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -169,7 +169,7 @@ class RenderTest(TestCase):
         })
         data = json.loads(response.content)[0]['datapoints']
         # all the from/until/tz combinations lead to the same window
-        expected = [[12, 1393398060], [12, 1393401660]]
+        expected = [[12, 1393398060], [12, 1393399860], [12, 1393401660]]
         self.assertEqual(data, expected)
 
         url = reverse('graphite.render.views.renderView')
@@ -181,7 +181,7 @@ class RenderTest(TestCase):
         })
         data = json.loads(response.content)[0]['datapoints']
         # all the from/until/tz combinations lead to the same window
-        expected = [[12, 1393398060], [12, 1393401660]]
+        expected = [[12, 1393398060], [12, 1393399860], [12, 1393401660]]
         self.assertEqual(data, expected)
 
         url = reverse('graphite.render.views.renderView')
@@ -194,7 +194,7 @@ class RenderTest(TestCase):
         })
         data = json.loads(response.content)[0]['datapoints']
         # all the from/until/tz combinations lead to the same window
-        expected = [[12, 1393398060], [12, 1393401660]]
+        expected = [[12, 1393398060], [12, 1393399860], [12, 1393401660]]
         self.assertEqual(data, expected)
 
     def test_template_string_variables(self):

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -144,7 +144,7 @@ class RenderTest(TestCase):
         })
         data = json.loads(response.content)[0]['datapoints']
         # all the from/until/tz combinations lead to the same window
-        expected = [[12, 1393398060], [12, 1393401660]]
+        expected = [[12, 1393398060], [12, 1393399860], [12, 1393401660]]
         self.assertEqual(data, expected)
 
         response = self.client.get(url, {
@@ -156,7 +156,7 @@ class RenderTest(TestCase):
         })
         data = json.loads(response.content)[0]['datapoints']
         # all the from/until/tz combinations lead to the same window
-        expected = [[12, 1393398060], [12, 1393401660]]
+        expected = [[12, 1393398060], [12, 1393399860], [12, 1393401660]]
         self.assertEqual(data, expected)
 
     def test_template_numeric_variables(self):


### PR DESCRIPTION
When we wanted to draw a graph with just a constantLine,
it raised a ZeroDivisionError.
This patch corrects this error.