### PR TITLE
Apache vhost example: Remove mod_python'ism.

### DIFF
--- a/examples/example-graphite-vhost.conf
+++ b/examples/example-graphite-vhost.conf
@@ -34,21 +34,15 @@ WSGISocketPrefix run/wsgi
 
         # XXX You will need to create this file! There is a graphite.wsgi.example
         # file in this directory that you can safely use, just copy it to graphite.wgsi
-        WSGIScriptAlias / /opt/graphite/conf/graphite.wsgi 
+        WSGIScriptAlias / /opt/graphite/conf/graphite.wsgi
 
         Alias /content/ /opt/graphite/webapp/content/
-        <Location "/content/">
-                SetHandler None
-        </Location>
 
         # XXX In order for the django admin site media to work you
         # must change @DJANGO_ROOT@ to be the path to your django
         # installation, which is probably something like:
         # /usr/lib/python2.6/site-packages/django
         Alias /media/ "@DJANGO_ROOT@/contrib/admin/media/"
-        <Location "/media/">
-                SetHandler None
-        </Location>
 
         # The graphite.wsgi file has to be accessible by apache. It won't
         # be visible to clients because of the DocumentRoot though.


### PR DESCRIPTION
Specifying `SetHandler None` for the static content FS paths isn't
needed when using mod_wsgi.
