### PR TITLE
Fix/log base

### DIFF
--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -157,7 +157,7 @@ class Graph:
     if self.logBase:
       if self.logBase == 'e':
         self.logBase = math.e
-      elif self.logBase <= 0:
+      elif self.logBase < 1:
         self.logBase = None
         params['logBase'] = None
       else:


### PR DESCRIPTION
Previously providing a `logBase` between zero and one would cause the `/render` handler to compute forever.

Example:

```
http://example.com/render?target=x.y.z&logBase=0.5
```
