### PR TITLE
guess consolidation function from whisper aggregation method or graphite aggregation functions

### DIFF
--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -158,7 +158,7 @@ class RemoteReader(object):
       for series in cached_results:
         if series['name'] == self.metric_path:
           time_info = (series['start'], series['end'], series['step'])
-          return (time_info, series['values'])
+          return (time_info, series['values'], series['consolidationFunc'])
 
     # Synchronize with other RemoteReaders using the same bulk query.
     # Despite our use of thread synchronization primitives, the common
@@ -211,7 +211,7 @@ class RemoteReader(object):
       for series in wait_for_results():
         if series['name'] == self.metric_path:
           time_info = (series['start'], series['end'], series['step'])
-          return (time_info, series['values'])
+          return (time_info, series['values'], series['consolidationFunc'])
 
     return FetchInProgress(extract_my_results)
 

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -65,7 +65,7 @@ class TimeSeries(list):
     if not usable: return None
     if self.consolidationFunc == 'sum':
       return sum(usable)
-    if self.consolidationFunc == 'average':
+    if self.consolidationFunc == 'average' or self.consolidationFunc is None:
       return float(sum(usable)) / len(usable)
     if self.consolidationFunc == 'max':
       return max(usable)
@@ -85,6 +85,7 @@ class TimeSeries(list):
       'start' : self.start,
       'end' : self.end,
       'step' : self.step,
+      'consolidationFunc' : self.consolidationFunc,
       'values' : list(self),
     }
 
@@ -109,12 +110,15 @@ def fetchData(requestContext, pathExpr):
         continue
 
       try:
-          (timeInfo, values) = results
+          (timeInfo, values, consolidationFunc) = results
       except ValueError as e:
           raise Exception("could not parse timeInfo/values from metric '%s': %s" % (node.path, e))
       (start, end, step) = timeInfo
 
-      series = TimeSeries(node.path, start, end, step, values)
+      if consolidationFunc is None:
+          series = TimeSeries(node.path, start, end, step, values)
+      else:
+          series = TimeSeries(node.path, start, end, step, values, consolidationFunc)
       series.pathExpression = pathExpr #hack to pass expressions through to render functions
       seriesList.append(series)
 

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -375,7 +375,7 @@ def minSeries(requestContext, *seriesLists):
   (seriesList, start, end, step) = normalize(seriesLists)
   name = "minSeries(%s)" % formatPathExpressions(seriesList)
   values = ( safeMin(row) for row in izip(*seriesList) )
-  series = TimeSeries(name, start, end, step, values)
+  series = TimeSeries(name, start, end, step, values, 'min')
   series.pathExpression = name
   return [series]
 
@@ -394,7 +394,7 @@ def maxSeries(requestContext, *seriesLists):
   (seriesList, start, end, step) = normalize(seriesLists)
   name = "maxSeries(%s)" % formatPathExpressions(seriesList)
   values = ( safeMax(row) for row in izip(*seriesList) )
-  series = TimeSeries(name, start, end, step, values)
+  series = TimeSeries(name, start, end, step, values, 'max')
   series.pathExpression = name
   return [series]
 


### PR DESCRIPTION
When displaying a metric defined in whisper as being aggregated by max, one expects the drawing consolidation function to be max too, whereas the default one is avg excepted if the graphite target explicitely specify consolidateBy(...,'max').

When displaying a bunch of metrics aggregated with e.g. maxSeries(), one expects the drawing consolidation function to be max too, whereas the default one is avg excepted if the graphite target explicitely specify consolidateBy(...,'max').

These commits guess consolidation function from whisper and set/override it when maxSeries() or minSeries() is used in graphite target.
