### PR TITLE
adding callbackToNode() function which is a kind of groupByNode() usable with non-commutative aggregation functions

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2607,7 +2607,7 @@ def callbackToNode(requestContext, seriesList, nodeNum, callback, twoArgumentsFo
         sub = node[(node.find("{")+1):node.find("}")]
         for path in sub.split(","):
           real_paths.append(node.replace("{"+sub+"}",key+"."+path))
-        seriesList = sorted(seriesList, key=lambda x : real_paths.index(".".join(x.name.split(".")[0:nodeNum+1])))
+        seriesList.sort(key=lambda x : real_paths.index(".".join(x.name.split(".")[0:nodeNum+1])))
       length = len(seriesList)
       if length == 1:
         seriePatch = constantLine(requestContext, 0)


### PR DESCRIPTION
If we have e.g. thise series:
- sys.server1.filesystems.root.used
- sys.server1.filesystems.root.total
- sys.server2.filesystems.root.used
- sys.server2.filesystems.root.total
- sys.server2.filesystems.home.used
- sys.server2.filesystems.home.total

Then groupByNode is able of computing the grant total of used or total bytes, but it is not able to get usage percentage for every filesystem.

The new callbackToNode() function can:

> callbackToNode(sys.server_.filesystems._.{used,total},4,'asPercent',true)

This target is a dynamic equivalent of those targets:
- asPercent(sys.server1.filesystems.root.{used,total})
- asPercent(sys.server2.filesystems.root.{used,total})
- asPercent(sys.server2.filesystems.home.{used,total})
