### PR TITLE
fix regression caused by #606

### DIFF
--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -18,7 +18,7 @@ import socket
 import errno
 import time
 import sys
-from os.path import splitext, basename
+from os.path import splitext, basename, relpath
 from shutil import move
 from tempfile import mkstemp
 try:
@@ -216,7 +216,7 @@ def build_index(base_path, extension, fd):
   contents = os.walk(base_path, followlinks=True)
   extension_len = len(extension)
   for (dirpath, dirnames, filenames) in contents:
-    path = dirpath[len(base_path):].replace('/', '.').lstrip('.')
+    path = relpath(dirpath, base_path).replace('/', '.')
     for metric in filenames:
       if metric.endswith(extension):
         metric = metric[:-extension_len]


### PR DESCRIPTION
If WHISPER_DIR is specified w/o a trailing slash all metrics will contain a
leading period. This patch makes sure any leading period is removed from the
metric name.

See #606 for more details.
