### PR TITLE
Fix various DeprecationWarnings discovered with tox

### DIFF
--- a/webapp/graphite/cli/parser.py
+++ b/webapp/graphite/cli/parser.py
@@ -48,7 +48,7 @@ gpath = Word(alphanums + '._-+*?[]#:')
 fcall = Forward()
 expr = Word( printables.replace('(','').replace(')','').replace(',','') )
 arg = fcall | expr
-fcall << Combine( Word(alphas) + Literal('(') + arg + ZeroOrMore(',' + arg) + Literal(')') )
+fcall <<= Combine( Word(alphas) + Literal('(') + arg + ZeroOrMore(',' + arg) + Literal(')') )
 target = fcall | gpath
 targetList = delimitedList(target).setResultsName('targets')
 _from = Literal('from') + Word(printables).setResultsName('_from')
@@ -127,7 +127,7 @@ logout_cmd = Keyword('logout').setResultsName('command')
 id_cmd = Keyword('id').setResultsName('command')
 whoami_cmd = Keyword('whoami').setResultsName('command')
 
-grammar << ( set_cmd | unset_cmd | add_cmd | remove_cmd | \
+grammar <<= ( set_cmd | unset_cmd | add_cmd | remove_cmd | \
              draw_cmd | echo_cmd | vars_cmd | clear_cmd | \
              create_cmd | code_cmd | redraw_cmd | email_cmd | doemail_cmd | \
              url_cmd | change_cmd | help_cmd | find_cmd | save_cmd | \

--- a/webapp/graphite/render/grammar.py
+++ b/webapp/graphite/render/grammar.py
@@ -95,8 +95,8 @@ pathElement = Combine(
 )
 pathExpression = delimitedList(pathElement, delim='.', combine=True)('pathExpression')
 
-expression << Group(call | pathExpression)('expression')
-grammar << expression
+expression <<= Group(call | pathExpression)('expression')
+grammar <<= expression
 
 
 def enableDebug():


### PR DESCRIPTION
data/home/vhaenel/git-working/graphite-web/webapp/graphite/render/grammar.py:98: DeprecationWarning: Operator '<<' is deprecated, use '<<=' instead
  expression << Group(call | pathExpression)('expression')
/data/home/vhaenel/git-working/graphite-web/webapp/graphite/render/grammar.py:99: DeprecationWarning: Operator '<<' is deprecated, use '<<=' instead
  grammar << expression
Creating test database for alias 'default'...
2014-03-21 11:48:21.773028-05:00
/data/home/vhaenel/git-working/graphite-web/webapp/graphite/cli/parser.py:51: DeprecationWarning: Operator '<<' is deprecated, use '<<=' instead
  fcall << Combine( Word(alphas) + Literal('(') + arg + ZeroOrMore(',' + arg) + Literal(')') )
/data/home/vhaenel/git-working/graphite-web/webapp/graphite/cli/parser.py:136: DeprecationWarning: Operator '<<' is deprecated, use '<<=' instead
  gsave_cmd | dogsave_cmd | gload_cmd | graphs_cmd | rmgraph_cmd | Empty() \
.No handlers could be found for logger "cache"
