### PR TITLE
Documentation tweak - pickle protocol version

### DIFF
--- a/docs/feeding-carbon.rst
+++ b/docs/feeding-carbon.rst
@@ -47,11 +47,11 @@ The general idea is that the pickled data forms a list of multi-level tuples:
  
  [(path, (timestamp, value)), ...]
 
-Once you've formed a list of sufficient size (don't go too big!), send the data over a socket to Carbon's pickle receiver (by default, port 2004). You'll need to pack your pickled data into a packet containing a simple header:
+Once you've formed a list of sufficient size (don't go too big!), and pickled it (if your client is running a more recent version of python than your server, you may need to specify the protocol) send the data over a socket to Carbon's pickle receiver (by default, port 2004). You'll need to pack your pickled data into a packet containing a simple header:
 
 .. code-block:: python
 
- payload = pickle.dumps(listOfMetricTuples)
+ payload = pickle.dumps(listOfMetricTuples, protocol=2)
  header = struct.pack("!L", len(payload))
  message = header + payload
 


### PR DESCRIPTION
If the server is running with an older version of python than the client, you need to specify the protocol for pickle, to avoid the server from ignoring pickled data it can't understand.
