### PR TITLE
added units to cactistyle function

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1115,7 +1115,7 @@ def alias(requestContext, seriesList, newName):
       series.name = newName
   return seriesList
 
-def cactiStyle(requestContext, seriesList, system=None):
+def cactiStyle(requestContext, seriesList, system=None, units=None):
   """
   Takes a series list and modifies the aliases to provide column aligned
   output with Current, Max, and Min values in the style of cacti. Optonally
@@ -1131,9 +1131,15 @@ def cactiStyle(requestContext, seriesList, system=None):
   if 0 == len(seriesList):
       return seriesList
   if system:
-      fmt = lambda x:"%.2f%s" % format_units(x,system=system)
+      if units:
+          fmt = lambda x:"%.2f %s" % format_units(x,system=system,units=units)
+      else:
+          fmt = lambda x:"%.2f%s" % format_units(x,system=system)
   else:
-      fmt = lambda x:"%.2f"%x
+      if units:
+          fmt = lambda x:"%.2f %s"%(x,units)
+      else:
+          fmt = lambda x:"%.2f"%x
   nameLen = max([0] + [len(getattr(series,"name")) for series in seriesList])
   lastLen = max([0] + [len(fmt(int(safeLast(series) or 3))) for series in seriesList]) + 3
   maxLen = max([0] + [len(fmt(int(safeMax(series) or 3))) for series in seriesList]) + 3

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -114,7 +114,6 @@ xAxisConfigs = (
   dict(seconds=100000,minorGridUnit=DAY,  minorGridStep=60, majorGridUnit=DAY,  majorGridStep=120,labelUnit=DAY,  labelStep=120, format="%m/%d %Y"),
   dict(seconds=120000,minorGridUnit=DAY,  minorGridStep=120,majorGridUnit=DAY,  majorGridStep=240,labelUnit=DAY,  labelStep=240, format="%m/%d %Y"),
 )
-
 UnitSystems = {
   'binary': (
     ('Pi', 1024.0**5),
@@ -130,6 +129,22 @@ UnitSystems = {
     ('K', 1000.0   )),
   'none' : [],
 }
+UnitSystemsExt = {
+  'binary': (
+    ('P%s', 1024.0**5),
+    ('T%s', 1024.0**4),
+    ('G%s', 1024.0**3),
+    ('M%s', 1024.0**2),
+    ('K%s', 1024.0   )),
+  'si': (
+    ('P%s', 1000.0**5),
+    ('T%s', 1000.0**4),
+    ('G%s', 1000.0**3),
+    ('M%s', 1000.0**2),
+    ('K%s', 1000.0   )),
+  'none' : [],
+}
+
 
 
 class GraphError(Exception):
@@ -1667,7 +1682,7 @@ def sort_stacked(series_list):
   not_stacked = [s for s in series_list if 'stacked' not in s.options]
   return stacked + not_stacked
 
-def format_units(v, step=None, system="si"):
+def format_units(v, step=None, system="si",units=None):
   """Format the given value in standardized units.
 
   ``system`` is either 'binary' or 'si'
@@ -1682,16 +1697,27 @@ def format_units(v, step=None, system="si"):
   else:
     condition = lambda size: abs(v) >= size and step >= size
 
-  for prefix, size in UnitSystems[system]:
+  for prefix, size in UnitSystemsExt[system]:
     if condition(size):
       v2 = v / size
       if (v2 - math.floor(v2)) < 0.00000000001 and v > 1:
         v2 = math.floor(v2)
-      return v2, prefix
+      if units:
+        prefix_string=prefix % units
+      else:
+        if system == "binary":
+          prefix_string=prefix % "i"
+        else:
+          prefix_string=prefix % " "
+      return v2, prefix_string
 
   if (v - math.floor(v)) < 0.00000000001 and v > 1 :
     v = math.floor(v)
-  return v, ""
+  if units:
+    prefix_string=units
+  else:
+    prefix_string=""
+  return v, prefix_string
 
 
 def find_x_times(start_dt, unit, step):


### PR DESCRIPTION
This pull request is made in response on the issue 

https://github.com/graphite-project/graphite-web/issues/671

I've implemented an easy way to indicate units and perhaps we will improve a lot the look&Feel by adding a "unit" parameter to the cactiStile() function to avoid a "M/G/K" or "Mi/Gi/Ki" that has no sense without units.

So this graph

```
cactiStyle( "some*memory*metric","binary") 
```
![image](https://cloud.githubusercontent.com/assets/5883405/2655478/ba09f7ea-bfe6-11e3-93cb-39420f5c4ebb.png)

Can now be as follow by adding a "b" as unit parameter.

```
cactiStyle( "some*memory*metric","binary", "b" ) 
```


![image](https://cloud.githubusercontent.com/assets/5883405/2655466/a6391156-bfe6-11e3-8e2d-d6e9569bf617.png)

or 

```
cactiStyle( "some*memory*metric","binary", "bytes" ) 
```

![image](https://cloud.githubusercontent.com/assets/5883405/2655513/3a65fae2-bfe7-11e3-9d8f-2abdcb3224ef.png)
