### PR TITLE
adding groupByNodes() function, same as groupByNode() w/ several nodes

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2596,9 +2596,12 @@ def groupByNodes(requestContext, seriesList, callback, *nodes):
     if key not in metaSeries.keys():
       keys.append(key)
       metaSeries[key] = [series]
-      metaSeries[key] = SeriesFunctions[callback](requestContext,
+    else:
+      metaSeries[key].append(series)
+  for key in metaSeries.keys():
+    metaSeries[key] = SeriesFunctions[callback](requestContext,
           metaSeries[key])[0]
-      metaSeries[key].name = key
+    metaSeries[key].name = key
   return [ metaSeries[key] for key in keys ]
 
 def exclude(requestContext, seriesList, pattern):

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2572,6 +2572,35 @@ def groupByNode(requestContext, seriesList, nodeNum, callback):
     metaSeries[key].name = key
   return [ metaSeries[key] for key in keys ]
 
+def groupByNodes(requestContext, seriesList, callback, *nodes):
+  """
+  Takes a serieslist and maps a callback to subgroups within as defined by one or more node
+
+  .. code-block:: none
+
+    &target=groupByNodes(ganglia.by-function.*.*.cpu.load4,"sumSeries",2,3)
+
+    Would return multiple series which are each the result of applying the "sumSeries" function
+    to groups joined on the second and third node (0 indexed) resulting in a list of targets like
+    sumSeries(ganglia.by-function.server1.*.cpu.load5),sumSeries(ganglia.by-function.server2.*.cpu.load5),...
+
+  """
+  metaSeries = {}
+  keys = []
+  if type(nodes) is int:
+    nodes=[nodes]
+  for series in seriesList:
+    metric_pieces = re.search('(?:.*\()?(?P<name>[-\w*\.]+)(?:,|\)?.*)?',series.name).groups()[0].split('.')
+    series.name = '.'.join(metric_pieces[n] for n in nodes)
+    key = series.name
+    if key not in metaSeries.keys():
+      keys.append(key)
+      metaSeries[key] = [series]
+      metaSeries[key] = SeriesFunctions[callback](requestContext,
+          metaSeries[key])[0]
+      metaSeries[key].name = key
+  return [ metaSeries[key] for key in keys ]
+
 def exclude(requestContext, seriesList, pattern):
   """
   Takes a metric or a wildcard seriesList, followed by a regular expression
@@ -3113,6 +3142,7 @@ SeriesFunctions = {
   'map': mapSeries,
   'reduce': reduceSeries,
   'groupByNode' : groupByNode,
+  'groupByNodes' : groupByNodes,
   'constantLine' : constantLine,
   'stacked' : stacked,
   'areaBetween' : areaBetween,


### PR DESCRIPTION
This make it possible to draw such targets:
groupByNodes(metrics.server*.database.*.*.*,'sum',1,4,5)
Whereas groupByNode can only group by one node.

Actualy, it was already possible to do that with groupByNode, but this required to use such ugly patterns:
aliasSub(groupByNode(aliasSub(aliasByNode(metrics.server*.database.*.*.*,1,4,5),'\\.','_'),0,'sum'),'_','.')