### PR TITLE
Move code from metrics/views.py findmatches into the respective finders

### DIFF
--- a/webapp/graphite/finders/ceres.py
+++ b/webapp/graphite/finders/ceres.py
@@ -9,6 +9,7 @@ from graphite.node import BranchNode, LeafNode
 from graphite.readers import CeresReader
 
 from . import get_real_metric_path
+import fnmatch
 
 
 class CeresFinder:
@@ -31,3 +32,18 @@ class CeresFinder:
 
       elif os.path.isdir(fs_path):
         yield BranchNode(metric_path)
+
+  def get_all_nodes(self):
+    for root, dirs, files in os.walk(settings.CERES_DIR):
+      root = root.replace(settings.CERES_DIR, '')
+      for filename in files:
+        if filename == '.ceres-node':
+          matches.append(root)
+  
+    matches = [
+      m
+      .replace('/', '.')
+      .lstrip('.')
+      for m in sorted(matches)
+    ]
+    return matches

--- a/webapp/graphite/finders/standard.py
+++ b/webapp/graphite/finders/standard.py
@@ -8,6 +8,7 @@ from graphite.readers import WhisperReader, GzippedWhisperReader, RRDReader
 from graphite.util import find_escaped_pattern_fields
 
 from . import fs_to_metric, get_real_metric_path, match_entries
+import fnmatch
 
 
 class StandardFinder:
@@ -101,3 +102,22 @@ class StandardFinder:
 
       for basename in matching_files + matching_subdirs:
         yield join(current_dir, basename)
+
+  def get_all_nodes(self):
+    matches = []
+  
+    for root, dirs, files in os.walk(settings.WHISPER_DIR):
+      root = root.replace(settings.WHISPER_DIR, '')
+      for basename in files:
+        if fnmatch.fnmatch(basename, '*.wsp'):
+          matches.append(os.path.join(root, basename))
+
+    matches = [
+      m
+      .replace('.wsp', '')
+      .replace('.rrd', '')
+      .replace('/', '.')
+      .lstrip('.')
+      for m in sorted(matches)
+    ]
+    return matches

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -136,7 +136,7 @@ def renderView(request):
         maxDataPoints = requestOptions['maxDataPoints']
         for series in data:
           numberOfDataPoints = timeRange/series.step
-          if maxDataPoints < numberOfDataPoints:
+          if maxDataPoints < numberOfDataPoints and maxDataPoints < len(series):
             valuesPerPoint = math.ceil(float(numberOfDataPoints) / float(maxDataPoints))
             secondsPerPoint = int(valuesPerPoint * series.step)
             # Nudge start over a little bit so that the consolidation bands align with each call


### PR DESCRIPTION
We use a custom finder. We noticed, that /metrics/index.json was only returning [].
Investigation showed, that the index view hard-coded only whisper, rrd and ceres backends.
This change moves this responsibility into the finder.
