### PR TITLE
fix TypeError rendering threshold with format=json

### DIFF
--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -154,6 +154,7 @@ def renderView(request):
           series_data.append(dict(target=series.name, datapoints=datapoints))
       else:
         for series in data:
+          series.start, series.end, series.step = map(int, [series.start, series.end, series.step])
           timestamps = range(series.start, series.end, series.step)
           datapoints = zip(series, timestamps)
           series_data.append(dict(target=series.name, datapoints=datapoints))


### PR DESCRIPTION
naive implementation of fix proposed in #375
When using format=json on a target with the threshold or constantLine function, an exception is raised : 
TypeError: range() integer end argument expected, got float.
This fix transforms the range() parameters into integers before they are passed to the function.
the threshold target is then displayed as a single point with a -1day timestamp.
