### PR TITLE
Fix backslash issue for windows

### DIFF
--- a/webapp/graphite/finders/__init__.py
+++ b/webapp/graphite/finders/__init__.py
@@ -6,7 +6,7 @@ def get_real_metric_path(absolute_path, metric_path):
   # Support symbolic links (real_metric_path ensures proper cache queries)
   if os.path.islink(absolute_path):
     real_fs_path = os.path.realpath(absolute_path)
-    relative_fs_path = metric_path.replace('.', '/')
+    relative_fs_path = metric_path.replace('.', os.sep)
     base_fs_path = absolute_path[:-len(relative_fs_path)]
     relative_real_fs_path = real_fs_path[len(base_fs_path):]
     return fs_to_metric(relative_real_fs_path)
@@ -17,7 +17,7 @@ def get_real_metric_path(absolute_path, metric_path):
 def fs_to_metric(path):
   dirpath = os.path.dirname(path)
   filename = os.path.basename(path)
-  return os.path.join(dirpath, filename.split('.')[0]).replace('/','.')
+  return os.path.join(dirpath, filename.split('.')[0]).replace(os.sep,'.')
 
 
 def _deduplicate(entries):


### PR DESCRIPTION
the fs <-> metrics naming helpers were hardcoded to use a forward slash. I have replaced the forward slashes with os.sep to support non-*nix platforms.
