### PR TITLE
fix #552: using rrdtool causes TypeError

### DIFF
--- a/webapp/graphite/readers.py
+++ b/webapp/graphite/readers.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 from graphite.node import LeafNode, BranchNode
 from graphite.intervals import Interval, IntervalSet
@@ -209,8 +210,14 @@ class GzippedWhisperReader(WhisperReader):
 class RRDReader:
   supported = bool(rrdtool)
 
+  @staticmethod
+  def _convert_fs_path (fs_path):
+    if isinstance(fs_path, unicode):
+      fs_path = fs_path.encode(sys.getfilesystemencoding())
+    return fs_path
+
   def __init__(self, fs_path, datasource_name):
-    self.fs_path = fs_path
+    self.fs_path = RRDReader._convert_fs_path(fs_path)
     self.datasource_name = datasource_name
 
   def get_intervals(self):
@@ -234,7 +241,7 @@ class RRDReader:
 
   @staticmethod
   def get_datasources(fs_path):
-    info = rrdtool.info(fs_path)
+    info = rrdtool.info(RRDReader._convert_fs_path(fs_path))
 
     if 'ds' in info:
       return [datasource_name for datasource_name in info['ds']]
@@ -245,7 +252,7 @@ class RRDReader:
 
   @staticmethod
   def get_retention(fs_path):
-    info = rrdtool.info(fs_path)
+    info = rrdtool.info(RRDReader._convert_fs_path(fs_path))
     if 'rra' in info:
       rras = info['rra']
     else:


### PR DESCRIPTION
The native Python wrappers for RRDTool reject Unicode filesystem paths.
Ensure paths passed to RRDTool are converted to use the file system
encoding.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>