### PR TITLE
bugfix in perSecond():  if the series has null data, diff the existing d...

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -927,9 +927,12 @@ def perSecond(requestContext, seriesList, maxValue=None):
     prev = None
     for val in series:
       step = series.step
-      if None in (prev,val):
+      if prev == None:
         newValues.append(None)
         prev = val
+        continue
+      if val == None:
+        newValues.append(None)
         continue
 
       diff = val - prev


### PR DESCRIPTION
...ata.

        Consider a series that looks like this:
            X1,null,X2,null,X3,null,...
        In the current implmenentation, perSecond() will return all nulls
        for this series.  With this bugfix, perSecond will return instead:
            (x2-x1)/step,null,(x3-x2)/step,null,...