### PR TITLE
added get-node function to get all existing values in a node position

### DIFF
--- a/webapp/graphite/metrics/urls.py
+++ b/webapp/graphite/metrics/urls.py
@@ -25,5 +25,6 @@ urlpatterns = patterns(
         name='metrics_get_metadata'),
     url('^set-metadata/?$', views.set_metadata_view,
         name='metrics_set_metadata'),
+    url('^get-node/?$', views.get_nodelist_data,name='metrics_get_node'),
     url('', views.find_view, name='metrics'),
 )

--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -324,15 +324,22 @@ def json_response_for(request, data, content_type='application/json',
 
 def get_nodelist_data(request):
   try:
+    local_only = int( request.REQUEST.get('local', 0) )
     node_num = int(request.REQUEST.get('node',0 ))
     query = request.REQUEST.get('query')
   except:
     node_num = 0
     query= ""
-
+  #check for lehgth
+  max_nodes=len(query.split('.'))
+  if node_num > max_nodes:
+    response = json_response_for(request,{ 'nodes' : '' })
+    response['Pragma'] = 'no-cache'
+    response['Cache-Control'] = 'no-cache'
+    return response
   results = []
   final = []
-  for node in STORE.find(query):
+  for node in STORE.find(query,local=local_only):
     if node.is_leaf:
        result_parts = node.path.split('.')
        results.append(result_parts[node_num])
@@ -346,6 +353,3 @@ def get_nodelist_data(request):
   response['Pragma'] = 'no-cache'
   response['Cache-Control'] = 'no-cache'
   return response
-
-
-

--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -83,7 +83,6 @@ def search_view(request):
   results = sorted(searcher.search(**search_request))
   return json_response_for(request, dict(metrics=results))
 
-
 def find_view(request):
   "View for finding metrics matching a given pattern"
   profile = getProfile(request)
@@ -322,3 +321,31 @@ def json_response_for(request, data, content_type='application/json',
     content_type += ';charset=utf-8'
 
   return HttpResponse(content, content_type=content_type, **kwargs)
+
+def get_nodelist_data(request):
+  try:
+    node_num = int(request.REQUEST.get('node',0 ))
+    query = request.REQUEST.get('query')
+  except:
+    node_num = 0
+    query= ""
+
+  results = []
+  final = []
+  for node in STORE.find(query):
+    if node.is_leaf:
+       result_parts = node.path.split('.')
+       results.append(result_parts[node_num])
+  results = sorted(set(results));
+  for r in results:
+    log.info('get_nodelist_data r=%s ' % r )
+    final.append({'name': r})
+
+  log.info('get_nodelist_data query=%s node=%s matches=%d' % (query,node_num, len(final)))
+  response = json_response_for(request,{ 'nodes' : final })
+  response['Pragma'] = 'no-cache'
+  response['Cache-Control'] = 'no-cache'
+  return response
+
+
+


### PR DESCRIPTION
I've added a new function usefull to get a list of existing values under a selected node position given a metric pattern, i json format

__parameters:__
* query: metric pattern 
* node: portion/s of the target name. Node indices are 0 indexed.

example:

`http://graphite_url/metrics/get-node/?query=*.bbdds.sys*.system.*&node=2`

give us

`{"nodes": [{"name": "system00"}, {"name": "system01"}]}`

this will be useful for external dashboards  to build dinamically combo boxes  to select a substring for a complete metric name. 
