### PR TITLE
Fix #576 -- The cache hash function now hashes the parameters for the re...

### DIFF
--- a/webapp/graphite/render/hashing.py
+++ b/webapp/graphite/render/hashing.py
@@ -19,30 +19,23 @@ from hashlib import md5
 from itertools import chain
 import bisect
 
+
 def hashRequest(request):
   # Normalize the request parameters so ensure we're deterministic
   queryParams = ["%s=%s" % (key, '&'.join(values))
                  for (key,values) in chain(request.POST.lists(), request.GET.lists())
                  if not key.startswith('_')]
 
-  normalizedParams = ','.join( sorted(queryParams) ) or 'noParam'
-  myHash = stripControlChars(normalizedParams) #memcached doesn't like unprintable characters in its keys
-
-  return compactHash(myHash)
+  normalizedParams = ','.join( sorted(queryParams) )
+  return compactHash(normalizedParams)
 
 
 def hashData(targets, startTime, endTime):
-  targetsString = ','.join(targets)
+  targetsString = ','.join(sorted(targets))
   startTimeString = startTime.strftime("%Y%m%d_%H%M")
   endTimeString = endTime.strftime("%Y%m%d_%H%M")
   myHash = targetsString + '@' + startTimeString + ':' + endTimeString
-  myHash = stripControlChars(myHash)
-
   return compactHash(myHash)
-
-
-def stripControlChars(string):
-  return filter(lambda char: ord(char) >= 33, string)
 
 
 def compactHash(string):

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -1,9 +1,10 @@
+from datetime import datetime
 import json
 import os
 import time
 import logging
 
-from graphite.render.hashing import hashRequest
+from graphite.render.hashing import hashRequest, hashData
 import whisper
 
 from django.conf import settings
@@ -92,3 +93,11 @@ class RenderTest(TestCase):
 
         self.assertEqual(hashRequest(request_params),
                         hashRequest(reverse_request_params))
+
+    def test_hash_data(self):
+        targets = ['foo=1', 'bar=2']
+        start_time = datetime.fromtimestamp(0)
+        end_time = datetime.fromtimestamp(1000)
+        self.assertEqual(hashData(targets, start_time, end_time),
+                        hashData(reversed(targets), start_time, end_time))
+


### PR DESCRIPTION
...quested method, and doesn't assume GET requests.
