### PR TITLE
Update dashboard.js refresh interval bug fix

### DIFF
--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -680,7 +680,9 @@ function initDashboard () {
       change: function (field, newValue) { updateAutoRefresh(newValue); },
       specialkey: function (field, e) {
                     if (e.getKey() == e.ENTER) {
-                      updateAutoRefresh( field.getValue() );
+                      if (field.getValue() >= 1) {
+                        updateAutoRefresh( field.getValue() );
+                      }
                     }
                   }
     }


### PR DESCRIPTION
Tinkering with the input box I set refresh interval to 0 and various negative numbers.  This would cause cpu load to spike, and the graphs would never load.  The time in the upper right would tick off every second, though I suspect it was ticking much faster but it only has 1-second resolution.  The first time I did this Firefox stopped behaving for ~2-3 minutes but eventually let me change it. I repeated this test using firebug and confirmed it was essentially refreshing the UI as fast as it could spawn new requests.  This diff ensures the refresh interval is a positive number greater than or equal to '1'.  I originally set it to '>0' but then decided to see what would happen if I fed '0.1' via the UI and the bug came back.  This diff appears to work for me.
