### PR TITLE
Graphlot - legend jQuery styling bugfix (0.9.x)

### DIFF
--- a/webapp/content/js/jquery.graphite.js
+++ b/webapp/content/js/jquery.graphite.js
@@ -232,7 +232,6 @@
                     } else {
                         legends.eq(i).text(series.label);
                     }
-                    legends.eq(i).css('width', legends.eq(i).width());
                 }
             }
 


### PR DESCRIPTION
This is old code (2010) that causes styling issues for modern browsers (truncates some legend labels). Have tested without it in recent versions of Chrome and Firefox without any negative side-effects. I'm not sure what the original intention was, but it was possibly a workaround for a dodgy browser. If it is required for some old or edge-case browser it should be reintroduced with a condition.
