### PR TITLE
Need to pass tzinfo to datetime.now() so that the result is not "naive"

### DIFF
--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -289,7 +289,7 @@ def parseOptions(request):
     if 'now' in queryParams:
         now = parseATTime(queryParams['now'])
     else:
-        now = datetime.now()
+        now = datetime.now(tzinfo)
 
     if 'until' in queryParams:
       untilTime = parseATTime(queryParams['until'], tzinfo, now)


### PR DESCRIPTION
Fix for: TypeError: can't compare offset-naive and offset-aware datetimes.
