### PR TITLE
Provide all digits for float numbers when using the raw format of render

### DIFF
--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -174,7 +174,7 @@ def renderView(request):
       response = HttpResponse(content_type='text/plain')
       for series in data:
         response.write( "%s,%d,%d,%d|" % (series.name, series.start, series.end, series.step) )
-        response.write( ','.join(map(str,series)) )
+        response.write( ','.join(map(repr,series)) )
         response.write('\n')
 
       log.rendering('Total rawData rendering time %.6f' % (time() - start))


### PR DESCRIPTION
Float numbers are currently truncated in responses from the ‘render’
url if using the ‘raw’ format. Using the json format prints out all
necessary digits for floats, so it would be nice for 'raw' to do the correct thing too.