### PR TITLE
pin whisper to the 0.9.x branch from github

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,4 +38,4 @@ django-tagging==0.3.1
 gunicorn
 pytz
 http://cairographics.org/releases/py2cairo-1.8.10.tar.gz
-git+git://github.com/graphite-project/whisper.git#egg=whisper
+git+git://github.com/graphite-project/whisper.git@0.9.x#egg=whisper


### PR DESCRIPTION
With the following merge:

https://github.com/graphite-project/whisper/pull/80

The 0.9.x branch of graphite-web _should_ be able to use the 0.9.x branch of
whisper now again.
