### PR TITLE
Fix TypeError with sum() function

### DIFF
--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -270,7 +270,7 @@ class Node:
 
 class Branch(Node):
   "Node with children"
-  def fetch(self, startTime, endTime):
+  def fetch(self, startTime, endTime, now=None):
     "No-op to make all Node's fetch-able"
     return []
 


### PR DESCRIPTION
Hi

I am using graphite-web 0.9.x and whisper 0.9.x.

I have several metrics of this form:
- name.foo1.bar1
- name.foo1.bar2
- name.foo2.bar1
- name.foo2.bar2

When I call /render/ with this parameter:

```
target=sum(name.*)
```

I get this error:

```
Traceback (most recent call last):
  File "/opt/python/lib/python2.7/site-packages/django/core/handlers/base.py", line 112, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/graphite/webapp/graphite/render/views.py", line 113, in renderView
    seriesList = evaluateTarget(requestContext, target)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 10, in evaluateTarget
    result = evaluateTokens(requestContext, tokens)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 21, in evaluateTokens
    return evaluateTokens(requestContext, tokens.expression)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 28, in evaluateTokens
    args = [evaluateTokens(requestContext, arg) for arg in tokens.call.args]
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 21, in evaluateTokens
    return evaluateTokens(requestContext, tokens.expression)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 24, in evaluateTokens
    return fetchData(requestContext, tokens.pathExpression)
  File "/opt/graphite/webapp/graphite/render/datalib.py", line 230, in fetchData
    dbResults = dbFile.fetch( timestamp(startTime), timestamp(endTime), timestamp(now))
TypeError: fetch() takes exactly 3 arguments (4 given)
```

To see what I want, I need to call it this way:

```
target=sum(foo.*.*)
```

However, I guess I should obtain the "no data"  image instead of this error.
The attached commit fixes that.

Thanks
