### PR TITLE
Check for empty result from remote node

### DIFF
--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -124,7 +124,7 @@ class RemoteNode:
 
     seriesList = unpickle.loads(rawData)
 
-    if type(seriesList) is list and len(seriesList) == 0:
+    if seriesList == []:
       return None
 
     assert len(seriesList) == 1, "Invalid result: seriesList=%s" % str(seriesList)


### PR DESCRIPTION
Here's a possible fix for https://github.com/graphite-project/graphite-web/issues/756 .

Whisper returns None when no results are found so remote storage should do the same.  Not sure if I could have used a better conditional - open to suggestions.
