### PR TITLE
Add optional 'now' parameter to fetch

### DIFF
--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -103,9 +103,12 @@ class RemoteNode:
     self.__isLeaf = isLeaf
 
 
-  def fetch(self, startTime, endTime):
+  def fetch(self, startTime, endTime, now=None):
     if not self.__isLeaf:
       return []
+
+    now = now or int(time.time())
+    endTime = endTime or now
 
     query_params = [
       ('target', self.metric_path),


### PR DESCRIPTION
Recent changes made to whisper added a 'now' parameter:

master:

https://github.com/graphite-project/whisper/commit/a6e2176eb624f0c09df399b4f8464a5a08789bd6

0.9.x:

https://github.com/graphite-project/whisper/commit/7f8d43dd7987d1103aba04996466ce2174b7ff7d

Apparently, this needs to be added to the RemoteNode too.

This implementation uses a slightly shorter -- but less common -- syntax with
'or':

In [1]: a = 1

In [2]: b = None

In [3]: c = a or b

In [4]: c
Out[4]: 1

In [5]: c = b or a

In [6]: c
Out[6]: 1
