### PR TITLE
Add optional 'now' parameter to remote node fetch (0.9.x)

### DIFF
--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -103,7 +103,7 @@ class RemoteNode:
     self.__isLeaf = isLeaf
 
 
-  def fetch(self, startTime, endTime):
+  def fetch(self, startTime, endTime, now=None):
     if not self.__isLeaf:
       return []
 
@@ -113,6 +113,8 @@ class RemoteNode:
       ('from', str( int(startTime) )),
       ('until', str( int(endTime) ))
     ]
+    if now is not None:
+      query_params.append(('now', str( int(now) )))
     query_string = urlencode(query_params)
 
     connection = HTTPConnectionWithTimeout(self.store.host)


### PR DESCRIPTION
Recent changes made to whisper added a 'now' parameter:

master:

https://github.com/graphite-project/whisper/commit/a6e2176eb624f0c09df399b4f8464a5a08789bd6

0.9.x:

https://github.com/graphite-project/whisper/commit/7f8d43dd7987d1103aba04996466ce2174b7ff7d

Apparently, this needs to be added to the RemoteNode too.
