### PR TITLE
JSON[P] Render Bugfix (0.9.x)

### DIFF
--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -149,14 +149,14 @@ def renderView(request):
             for r in range(1, valuesToLose):
               del series[0]
             series.consolidate(valuesPerPoint)
-            timestamps = range(series.start, series.end, secondsPerPoint)
+            timestamps = range(int(series.start), int(series.end) + 1, int(secondsPerPoint))
           else:
-            timestamps = range(series.start, series.end, series.step)
+            timestamps = range(int(series.start), int(series.end) + 1, int(series.step))
           datapoints = zip(series, timestamps)
           series_data.append(dict(target=series.name, datapoints=datapoints))
       else:
         for series in data:
-          timestamps = range(series.start, series.end, series.step)
+          timestamps = range(int(series.start), int(series.end) + 1, int(series.step))
           datapoints = zip(series, timestamps)
           series_data.append( dict(target=series.name, datapoints=datapoints) )
 


### PR DESCRIPTION
Basically the key to this is that the range() function returns a list of numbers up to but not including series.end. This meant that if the final timestamp in a series aligned exactly with the end of a series a datapoint was dropped because it's timestamp was not generated. A symptom of this was the the constantLine function only generated one (the first) out of two points when using the JSON format (used by Grafana, etc) so no line was displayed.

I've also made a change to ensure all parameters to range() are ints (as done elsewhere throughout the code) as it seems that sometimes the values can be floats which causes an unhandled exception.

This should resolve https://github.com/graphite-project/graphite-web/issues/539
