### PR TITLE
Remove # prefix in RGB colors passed to colorList

### DIFF
--- a/docs/render_api.rst
+++ b/docs/render_api.rst
@@ -440,7 +440,7 @@ Examples:
 .. code-block:: none
 
   &bgcolor=blue
-  &bgcolor=#2222FF
+  &bgcolor=2222FF
 
 cacheTimeout
 ------------
@@ -460,7 +460,7 @@ Example:
 
 .. code-block:: none
 
-  &colorList=green,yellow,orange,red,purple,#DECAFF
+  &colorList=green,yellow,orange,red,purple,DECAFF
 
 .. _param-drawNullAsZero:
 
@@ -730,7 +730,7 @@ Example:
 
 .. code-block:: none
 
-  &majorGridLineColor=#FF22FF
+  &majorGridLineColor=FF22FF
 
 margin
 ------


### PR DESCRIPTION
It seems you don't need to # prefix to RGB colors in colorList, and suggesting it in the docs means you have to URL encode it, so seems reasonable to just remove it from the docs.
