### PR TITLE
Fix identity function

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2461,8 +2461,8 @@ def identity(requestContext, name):
   """
   step = 60
   delta = timedelta(seconds=step)
-  start = time.mktime(requestContext["startTime"].timetuple())
-  end = time.mktime(requestContext["endTime"].timetuple())
+  start = int(time.mktime(requestContext["startTime"].timetuple()))
+  end = int(time.mktime(requestContext["endTime"].timetuple()))
   values = range(start, end, step)
   series = TimeSeries(name, start, end, step, values)
   series.pathExpression = 'identity("%s")' % name


### PR DESCRIPTION
convert time.mktime floats to int for start and end time values

currently attempts to use the identify() function crash with:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/django/core/handlers/base.py", line 111, in get_response
    response = callback(request, *callback_args, **callback_kwargs)
  File "/opt/graphite/webapp/graphite/render/views.py", line 110, in renderView
    seriesList = evaluateTarget(requestContext, target)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 10, in evaluateTarget
    result = evaluateTokens(requestContext, tokens)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 21, in evaluateTokens
    return evaluateTokens(requestContext, tokens.expression)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 29, in evaluateTokens
    return func(requestContext, *args)
  File "/opt/graphite/webapp/graphite/render/functions.py", line 2176, in identity
    values = range(start, end, step)
TypeError: range() integer end argument expected, got float.
```

(technically this stacktrace is from 0.9.x branch.  but offending code is unchanged in master)
