### PR TITLE
Only refresh dashboard on positive integer [0.9.x]

### DIFF
--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -648,7 +648,9 @@ function initDashboard () {
       change: function (field, newValue) { updateAutoRefresh(newValue); },
       specialkey: function (field, e) {
                     if (e.getKey() == e.ENTER) {
-                      updateAutoRefresh( field.getValue() );
+                      if (field.getValue() >= 1) {
+                        updateAutoRefresh( field.getValue() );
+                      }
                     }
                   }
     }


### PR DESCRIPTION
Only refresh on positive integer, discovered by @linkslice. This is a backport of https://github.com/graphite-project/graphite-web/commit/ac4b82eadf098bffbc1e8bc53de7666eb2af1519 to `0.9.x`.

Refs #724
