### PR TITLE
Add python 2.6 in our tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
-python: 2.7
+python:
+  - "2.6"
+  - "2.7"
 
 env:
   - TOXENV=py26-django14


### PR DESCRIPTION
We currently have tokens for `py26-*` but we haven't enabled `2.6` in our python list so we're only testing against `2.7`.

![screen_shot_2014-08-11_at_3_40_40_pm](https://cloud.githubusercontent.com/assets/494338/3881649/8ef54cfc-218f-11e4-8037-fd54e3a77a62.png)
