### PR TITLE
backport sortByName() to 0.9.X

### DIFF
--- a/webapp/content/js/composer_widgets.js
+++ b/webapp/content/js/composer_widgets.js
@@ -1126,6 +1126,7 @@ function createFunctionsMenu() {
         {text: 'Transform Nulls', handler: applyFuncToEachWithInput('transformNull', 'Please enter the value to transform null values to')},
         {text: 'Substring', handler: applyFuncToEachWithInput('substr', 'Enter a starting position')},
         {text: 'Group', handler: applyFuncToAll('group')},
+        {text: 'sortByName', handler: applyFuncToEach('sortByName')},
         {text: 'Area Between', handler: applyFuncToEach('areaBetween')},
 //        {text: 'GroupByNode', handler: applyFuncToEachWithInput('group')}, // requires 2 parameters
 //        {text: 'Add Threshold Line', handler: applyFuncToEachWithInput('threshold', 'Enter a threshold value')},

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1557,6 +1557,18 @@ def limit(requestContext, seriesList, n):
   """
   return seriesList[0:n]
 
+def sortByName(requestContext, seriesList):
+  """
+  Takes one metric or a wildcard seriesList.
+
+  Sorts the list of metrics by the metric name.
+  """
+  def compare(x,y):
+    return cmp(x.name, y.name)
+
+  seriesList.sort(compare)
+  return seriesList
+
 def sortByMaxima(requestContext, seriesList):
   """
   Takes one metric or a wildcard seriesList.
@@ -2770,6 +2782,7 @@ SeriesFunctions = {
   'maximumBelow' : maximumBelow,
   'nPercentile' : nPercentile,
   'limit' : limit,
+  'sortByName' : sortByName,
   'sortByMaxima' : sortByMaxima,
   'sortByMinima' : sortByMinima,
   'useSeriesAbove': useSeriesAbove,


### PR DESCRIPTION
Backporting PR #522 to the 0.9.x branch. This seems to have been in at one point; because the original patch for master (a different PR) was upported from 0.9.x. While testing 10.0-alpha with Grafana; the sortByName() Function did just that..function. When reverting back to the latest 0.9.x source; the function caused all of my grafana panels to go blank. Panel was calling for a function that's not in 0.9.x.

see (https://github.com/grafana/grafana/issues/690) for more details.

