### PR TITLE
Number of results from cache query was incorrectly logged (0.9.x)

### DIFF
--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -138,7 +138,7 @@ class CarbonLinkPool:
   def query(self, metric):
     request = dict(type='cache-query', metric=metric)
     results = self.send_request(request)
-    log.cache("CarbonLink cache-query request for %s returned %d datapoints" % (metric, len(results)))
+    log.cache("CarbonLink cache-query request for %s returned %d datapoints" % (metric, len(results['datapoints'])))
     return results['datapoints']
 
   def get_metadata(self, metric, key):


### PR DESCRIPTION
This was always logging "1" instead of the actual number of results.
