### PR TITLE
Rework of 'query-bulk' implementation for 0.9.x

### DIFF
--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -194,6 +194,10 @@
 # You *should* use 127.0.0.1 here in most cases
 #CARBONLINK_HOSTS = ["127.0.0.1:7002:a", "127.0.0.1:7102:b", "127.0.0.1:7202:c"]
 #CARBONLINK_TIMEOUT = 1.0
+# Using 'query-bulk' queries for carbon
+# It's more effective, but python-carbon 0.9.13 (or latest from 0.9.x branch) is required
+# See https://github.com/graphite-project/carbon/pull/132 for details
+#CARBONLINK_QUERY_BULK = False
 
 #####################################
 # Additional Django Settings #

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -76,6 +76,7 @@ LOG_RENDERING_PERFORMANCE = False
 #Miscellaneous settings
 CARBONLINK_HOSTS = ["127.0.0.1:7002"]
 CARBONLINK_TIMEOUT = 1.0
+CARBONLINK_QUERY_BULK = False
 SMTP_SERVER = "localhost"
 DOCUMENTATION_URL = "http://graphite.readthedocs.org/"
 ALLOW_ANONYMOUS_CLI = True


### PR DESCRIPTION
Please see issue #378, I just reworked for latest 0.9.x branch and made configurable. Corresponding change for carbon was merged by @mleinart while ago - https://github.com/graphite-project/carbon/pull/132
Replacing #824.

Kindly asking @mleinart , @sidnei, @drawks and @jssjr for reviews.

Example how it works:
I just deployed 0.9.12 graphite using https://github.com/obfuscurity/synthesize/, upgrade it to 0.9.x and put my change. Then I put 14 metrics under test -
![screen shot 2014-08-17 at 21 38 46](https://cloud.githubusercontent.com/assets/1227222/3945526/27a16b60-2646-11e4-99f4-24b7ba15d3c6.png)
When I'm running `curl 'https://localhost:8443/render/?target=test.test*.value&rawData'` in default installation I got in cache.log:

```
Sun Aug 17 13:58:45 2014 :: CarbonLink cache-query request for test.test1.value returned 1 datapoints
Sun Aug 17 13:58:45 2014 :: CarbonLink cache-query request for test.test10.value returned 1 datapoints
Sun Aug 17 13:58:45 2014 :: CarbonLink cache-query request for test.test11.value returned 1 datapoints
Sun Aug 17 13:58:45 2014 :: CarbonLink cache-query request for test.test12.value returned 1 datapoints
Sun Aug 17 13:58:45 2014 :: CarbonLink cache-query request for test.test13.value returned 1 datapoints
Sun Aug 17 13:58:45 2014 :: CarbonLink cache-query request for test.test14.value returned 1 datapoints
Sun Aug 17 13:58:45 2014 :: CarbonLink cache-query request for test.test2.value returned 1 datapoints
Sun Aug 17 13:58:45 2014 :: CarbonLink cache-query request for test.test3.value returned 1 datapoints
Sun Aug 17 13:58:45 2014 :: CarbonLink cache-query request for test.test4.value returned 1 datapoints
Sun Aug 17 13:58:45 2014 :: CarbonLink cache-query request for test.test5.value returned 1 datapoints
Sun Aug 17 13:58:45 2014 :: CarbonLink cache-query request for test.test6.value returned 1 datapoints
Sun Aug 17 13:58:45 2014 :: CarbonLink cache-query request for test.test7.value returned 1 datapoints
Sun Aug 17 13:58:45 2014 :: CarbonLink cache-query request for test.test8.value returned 1 datapoints
Sun Aug 17 13:58:45 2014 :: CarbonLink cache-query request for test.test9.value returned 1 datapoints
```

After switching CARBON_QUERY_BULK = True and restarting graphite-web same request give me:

```
Sun Aug 17 14:26:26 2014 :: CarbonLink creating a new socket for ('127.0.0.1', None)
Sun Aug 17 14:26:26 2014 :: CarbonLink cache-query-bulk request returned 14 datapoints
```
