### PR TITLE
Set the step of timeFunction() to 10 seconds.

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2950,7 +2950,7 @@ def timeFunction(requestContext, name):
 
   """
 
-  step = 60
+  step = 10
   delta = timedelta(seconds=step)
   when = requestContext["startTime"]
   values = []


### PR DESCRIPTION
As far as I could tell, there was no reason that this was set at 60 seconds instead of 10 seconds.  10 seconds is the default resolution for most stats stored in Carbon, so it makes sense to match that.

If someone needs to go back to 60 second intervals, `summarize(time(), "60s", "min")` would do the trick.
