### PR TITLE
Get rid of `import *`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,6 @@ obsoletes = graphite <= 0.9.9
 # E222 multiple spaces after operator
 # E225 missing whitespace around operator
 # E301 expected 1 blank line, found 0
-# F403 'import *' used; unable to detect undefined names
 # E228 missing whitespace around modulo operator
 # E127 continuation line over-indented for visual indent
 # E123 closing bracket does not match indentation of opening bracket's line
@@ -56,4 +55,4 @@ obsoletes = graphite <= 0.9.9
 # E271 multiple spaces after keyword
 # E272 multiple spaces before keyword
 
-ignore=E128,E111,E501,E231,E201,E202,E203,E251,E124,E265,E121,E261,E226,E302,E262,E701,E241,E221,E703,E502,F841,E401,E222,E126,E303,E122,E222,E225,E301,F403,E228,E127,E123,E713,E125,E227,E271,E272
+ignore=E128,E111,E501,E231,E201,E202,E203,E251,E124,E265,E121,E261,E226,E302,E262,E701,E241,E221,E703,E502,F841,E401,E222,E126,E303,E122,E222,E225,E301,E228,E127,E123,E713,E125,E227,E271,E272

--- a/webapp/graphite/render/grammar.py
+++ b/webapp/graphite/render/grammar.py
@@ -1,4 +1,8 @@
-from pyparsing import *
+from pyparsing import (
+    ParserElement, Forward, Combine, Optional, Word, Literal, CaselessKeyword,
+    CaselessLiteral, Group, FollowedBy, LineEnd, OneOrMore, ZeroOrMore,
+    nums, alphas, alphanums, printables, delimitedList, quotedString,
+)
 
 ParserElement.enablePackrat()
 grammar = Forward()

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -137,13 +137,13 @@ FLUSHRRDCACHED = ''
 
 ## Load our local_settings
 try:
-  from graphite.local_settings import *
+  from graphite.local_settings import *  # noqa
 except ImportError:
   print >> sys.stderr, "Could not import graphite.local_settings, using defaults!"
 
 ## Load Django settings if they werent picked up in local_settings
 if not GRAPHITE_WEB_APP_SETTINGS_LOADED:
-  from graphite.app_settings import *
+  from graphite.app_settings import *  # noqa
 
 STATICFILES_DIRS = (
     join(WEBAPP_DIR, 'content'),


### PR DESCRIPTION
This allows to properly detect missing/unused imports.
