### PR TITLE
Fix #788: Check if series is an empty list before doing movingAverage

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -608,6 +608,8 @@ def movingMedian(requestContext, seriesList, windowSize):
     &target=movingMedian(Server.instance*.threads.idle,'5min')
 
   """
+  if not seriesList:
+    return []
   windowInterval = None
   if isinstance(windowSize, basestring):
     delta = parseTimeOffset(windowSize)


### PR DESCRIPTION
After updating, I found that all my graphs that used movingAverage on a series that no longer exist would break and would 500 on the server. It is due to finding the max on an empty list. Simple check removes this issue.
