### PR TITLE
Update config-local-settings.rst

### DIFF
--- a/docs/config-local-settings.rst
+++ b/docs/config-local-settings.rst
@@ -98,7 +98,9 @@ STATIC_ROOT
   This directory doesn't even exists once you've installed graphite. It needs
   to be populated with the following command::
 
-      django-admin.py collectstatic --noinput --settings=graphite.settings
+      PYTHONPATH=$PATH:/opt/graphite:webapp django-admin.py collectstatic --noinput --settings=graphite.settings
+
+  Replace /opt/graphite points with actuall path to GRAPHITE_ROOT
 
   This collects static files for graphite-web and external apps (namely, the
   Django admin app) and puts them in a directory that needs to be available


### PR DESCRIPTION
Without specifying correct PYTHONPATH static files generation fails with module: graphite.settings cannot be found.