### PR TITLE
Remove ref to nonexistent images, fixes #689

### DIFF
--- a/webapp/content/css/dashboard.css
+++ b/webapp/content/css/dashboard.css
@@ -88,14 +88,8 @@ img.graph-img {
 
 .x-layout-split-east .x-layout-mini {
   width: 10px !important;
-  background-image: url(../img/mini-right2.gif);
 }
-/*
-.x-layout-split-west .x-layout-mini {
-  width: 10px !important;
-  background-image: url(../img/mini-left2.gif);
-}
-*/
+
 .x-layout-cmini-north {
   height: 10px !important;
 }
@@ -109,15 +103,9 @@ img.graph-img {
   height: 10px !important;
   background-image: url(../img/mini-top2.gif);
 }
-/*
-.x-layout-cmini-east .x-layout-mini {
-  width: 10px !important;
-  background-image: url(../img/mini-left2.gif);
-}
-*/
+
 .x-layout-cmini-west .x-layout-mini {
   width: 10px !important;
-  background-image: url(../img/mini-right2.gif);
 }
 
 /* DnD classes */


### PR DESCRIPTION
This old css was pointing to a button element that never existed. By removing the old refs, we automatically pick up the default ExtJS nav element.
