### PR TITLE
Backport initial version of 0.9.13 release notes to 0.9.x

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -5,4 +5,16 @@ Release Notes
    :maxdepth: 1
    :glob:
 
-   releases/*
+   releases/0_10_0
+   releases/0_9_13
+   releases/0_9_12
+   releases/0_9_11
+   releases/0_9_10
+   releases/0_9_9
+   releases/0_9_8
+   releases/0_9_7
+   releases/0_9_6
+   releases/0_9_5
+   releases/0_9_4
+   releases/0_9_3
+   releases/0_9_2

--- a/docs/releases/0_9_13.rst
+++ b/docs/releases/0_9_13.rst
@@ -1,0 +1,125 @@
+.. _0-9-13:
+
+0.9.13
+======
+*8/26/2014*
+
+
+Graphite 0.9.13 is now available for usage. Source bundles are available from GitHub:
+
+* https://github.com/graphite-project/graphite-web/archive/0.9.13.tar.gz
+* https://github.com/graphite-project/carbon/archive/0.9.13.tar.gz
+* https://github.com/graphite-project/whisper/archive/0.9.13.tar.gz
+
+Graphite can also be installed from `Pypi <http://pypi.python.org/>`_ via
+`pip <http://www.pip-installer.org/en/latest/index.html>`_. Pypi bundles are here:
+
+* http://pypi.python.org/pypi/graphite-web/
+* http://pypi.python.org/pypi/carbon/
+* http://pypi.python.org/pypi/whisper/
+
+Upgrading
+---------
+Graphite 0.9.13 now requires a Django version of at least 1.4. Ensure this dependency is satisfied
+before updating *graphite-web*
+
+As always, comparing the example config files with existing ones is recommended to ensure
+awareness of any new features.
+
+Security Notes
+--------------
+
+New Features
+------------
+
+Graphite-web
+^^^^^^^^^^^^
+* New ``minimumBelow()`` function (ojilles)
+* Add ``margin()`` function to Composer menu (obfuscurity)
+* Sort "User Graphs" by creator's username (ciranor)
+* New ``changed()`` function (kamaradclimber, obfuscurity)
+* Use ``query_bulk`` for improved cache query performance (huy, deniszh)
+* Allow metric finder to return jsonp objects (kali-hernandez-sociomantic)
+* Document use of alpha color values in ``colorList`` and ``bgcolor`` (ojilles)
+* Improved documentation for ``areaBetween()`` (ojilles, gwaldo)
+* Improved documentation for ``cactiStyle()`` (ojilles)
+* Document installation via Synthesize (gwaldo)
+* Mention the Synthensize installation method for Windows users (gwaldo)
+* Massive cleanup across all of our documentation pages (gwaldo)
+* Support for custom remote authentication backends (steve-dave)
+* Improvements to the cache hash function (rmca, esc)
+* Improved logging on CarbonLink failed queries (jamesjuran)
+* Add navigation elements to reorder metrics in Composer (justino)
+* Use Django's native TZ method (jcsp)
+* New test suite and TravisCI integration (brutasse, esc)
+* Rename the metrics node from "Graphite" to "Metrics" (obfuscurity)
+* New ``perSecond()`` function (cbowman0, pcn)
+* Add Composer button to load existing graph url (justino)
+* Add ``maxDataPoints`` to limit number of returned datapoints for json requests (philiphoy, gingerlime)
+* Refactor json responses for clarity (whilp)
+
+Carbon
+^^^^^^
+* Record the blacklist and whitelist metrics (jssjr, deniszh)
+* Ability to run in the foreground without debug (jib, deniszh)
+* Introduce ``QUEUE_LOW_WATERMARK_PCT`` and ``TIME_TO_DEFER_SENDING`` to improve batching (pcn, steve-dave)
+* Configurable files for aggregation and rewrite rules (drawks)
+* New bulk cache query type (huy)
+* Bulk cache query instrumentation (mleinart)
+
+Whisper
+^^^^^^^
+* New whisper-fill utility imported from Carbonate project (jssjr, grobian, deniszh)
+
+Bug fixes
+---------
+
+Graphite-web
+^^^^^^^^^^^^
+* Missing ``pathExpression`` in ``constantLine()`` function (markolson)
+* Fix for ``CLUSTER_SERVERS`` when ``ip_nonlocal_bind`` is enabled (PrFalken)
+* Missing ExtJS gif in Dashboard when viewed in tree configuration (obfuscurity)
+* Fix docs builds for the [render function list](http://graphite.readthedocs.org/en/0.9.x/functions.html) (obfuscurity, gwaldo)
+* ``aliasByMetric()`` was including trailing arguments (obfuscurity)
+* Fix ``initialState`` for Dashboard (cbownman0, jamesjuran)
+* Broken ``series.name`` in ``percentileOfSeries`` (simm42)
+* Refresh "My Graphs" *after* graph is saved or deleted (obfuscurity)
+* Remove superfluous grid line with log scale (ralphm)
+* Fix ``holtWintersAberration()`` when bands have ``None`` values (aaronfc)
+* Number of results from cache query was incorrectly logged (steve-dave)
+* Dashboard should only refresh on positive values (linkslice)
+* Fix ``logBase()`` when value between 0 and 1 (wellle)
+* Fix ``PICKLE_SAFE`` for remote rendering (deniszh)
+* Fix ``yMaxValue`` when ``areaMode=stacked`` (bitprophet)
+* Convert ``time.mktime`` to int to fix ``identity()`` function (dpkp)
+* Compatibility fix in Graphlot (steve-dave)
+* Off-by-one bug that broke JSON output for ``constantLine`` (steve-dave)
+* Minor documentation fix for ``sumSeriesWithWildcards()`` (steve-dave)
+* Fix TypeError with ``sum()`` function (macolu)
+* Remote storage should return ``None`` when ``seriesList`` is empty (steve-dave)
+* Fix project url in ``setup.py`` (esc)
+* Fix condition where missing ``until`` paramater caused TypeError (steve-dave)
+* Remove old jQuery workaround in Graphlot (steve-dave)
+* Fix ``now`` handling in render queries (jcsp)
+* Fix ``PICKEL_SAFE`` for CarbonLink queries (Dieterbe)
+* Decimals not printed for ``cactiStyle()`` (SuminAndrew, drawks)
+* Typo in exception name (also)
+* Fix assumption that RemoteNode inherits from Node (mleinart)
+
+Carbon
+^^^^^^
+* Restore recursive mkdir on LOG_DIR`` (jamesjuran)
+* Fix per-host replication (dkulikovsky, deniszh)
+* More accurate queue length reporting (pcn, bitprophet)
+* Set ownership on log subdirectories if ``USER`` is defined (jamesjuran)
+* Improved documentation for ``FORWARD_ALL`` (hdoshi)
+* Fix whisper directory umask (alexandreboisvert, steve-dave)
+* Unable to load ``AGGREGATION_RULES`` (drawks)
+* Compatibility with Twisted 13.2.0 (esc, drawks)
+* Incorrect log rotation documentation (mleinart)
+
+Whisper
+^^^^^^^
+* Add optional ``now`` parameter to fetch for graphite-web compatibility (jcsp, steve-dave)
+* Remove unused Tox configuration (steve-dave)
+* TravisCI no longer supports Python 2.5 (steve-dave)


### PR DESCRIPTION
Also, fix ordering of release versions in releases.rst.

refs #893 
