### PR TITLE
grafana colours

### DIFF
--- a/conf/graphTemplates.conf.example
+++ b/conf/graphTemplates.conf.example
@@ -63,3 +63,14 @@ foreground = black
 majorLine = grey
 minorLine = rose
 lineColors = 00ff00aa,ff000077,00337799
+
+[grafana]
+background = white
+foreground = black
+minorLine = grey
+majorLine = rose
+lineColors = #7eb26d,#eab839,#6ed0e0,#ef843c,#e24d42,#1f78c1,#ba43a9,#705da0,#508642,#cca300,#447ebc
+fontName = Sans
+fontSize = 10
+fontBold = False
+fontItalic = False


### PR DESCRIPTION
![grafanacolours](https://cloud.githubusercontent.com/assets/8308898/4063584/39cd8132-2e09-11e4-8c39-340b0925178d.png)
Allows same metric label colours as used in Grafana. Useful when changing graph rendering in Grafana from flot to PNG
