### PR TITLE
allow for cairocffi imports

### DIFF
--- a/check-dependencies.py
+++ b/check-dependencies.py
@@ -22,13 +22,16 @@ except:
   fatal += 1
 
 
-# Test for pycairo
+# Test for pycairo or cairocffi
 try:
   import cairo
-except:
-  print "[FATAL] Unable to import the 'cairo' module, do you have pycairo installed for python %s?" % py_version
-  cairo = None
-  fatal += 1
+except ImportError:
+  try:
+    import cairocffi as cairo
+  except ImportError:
+    print "[FATAL] Unable to import the 'cairo' module, do you have pycairo installed for python %s?" % py_version
+    cairo = None
+    fatal += 1
 
 
 # Test that pycairo has the PNG backend

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -12,7 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-import os, cairo, math, itertools, re
+import os, math, itertools, re
+
+try:
+    import cairo
+except ImportError:
+    import cairocffi as cairo
+
 import StringIO
 from datetime import datetime, timedelta
 from urllib import unquote_plus


### PR DESCRIPTION
Backport from master to allow cairocffi as a drop-in replacement for pycairo.

Fix for #825
