### PR TITLE
adding an integralByInterval() function

### DIFF
--- a/webapp/content/js/composer_widgets.js
+++ b/webapp/content/js/composer_widgets.js
@@ -1089,6 +1089,7 @@ function createFunctionsMenu() {
         {text: 'Square Root', handler: applyFuncToEach('squareRoot')},
         {text: 'Time-adjusted Derivative', handler: applyFuncToEachWithInput('perSecond', "Please enter a maximum value if this metric is a wrapping counter (or just leave this blank)", {allowBlank: true})},
         {text: 'Integral', handler: applyFuncToEach('integral')},
+	{text: 'Integral by Interval', handler: applyFuncToEachWithInput('integralByInterval', 'Integral this metric with a reset every ___ (examples: 1d, 1h, 10min)', {quote: true})},
         {text: 'Percentile Values', handler: applyFuncToEachWithInput('percentileOfSeries', "Please enter the percentile to use")},
         {text: 'Non-negative Derivative', handler: applyFuncToEachWithInput('nonNegativeDerivative', "Please enter a maximum value if this metric is a wrapping counter (or just leave this blank)", {allowBlank: true})},
         {text: 'Log', handler: applyFuncToEachWithInput('log', 'Please enter a base')},

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -24,7 +24,7 @@ from os import environ
 from graphite.logger import log
 from graphite.render.attime import parseTimeOffset, parseATTime
 from graphite.events import models
-from graphite.util import epoch
+from graphite.util import epoch, timestamp, deltaseconds
 
 # XXX format_units() should go somewhere else
 if environ.get('READTHEDOCS'):
@@ -32,8 +32,6 @@ if environ.get('READTHEDOCS'):
 else:
   from graphite.render.glyph import format_units
   from graphite.render.datalib import TimeSeries
-
-from graphite.util import epoch, timestamp, deltaseconds
 
 NAN = float('NaN')
 INF = float('inf')

--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -152,6 +152,10 @@ def timestamp(datetime):
   "Convert a datetime object into epoch time"
   return time.mktime( datetime.timetuple() )
 
+def deltaseconds(timedelta):
+  "Convert a timedelta object into seconds (same as timedelta.total_seconds() in Python 2.7+)"
+  return (timedelta.microseconds + (timedelta.seconds + timedelta.days * 24 * 3600) * 10**6) / 10**6
+
 # This whole song & dance is due to pickle being insecure
 # The SafeUnpickler classes were largely derived from
 # http://nadiana.com/python-pickle-insecure

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -7,6 +7,7 @@ from fnmatch import fnmatch
 from django.test import TestCase
 from django.conf import settings
 from mock import patch, call, MagicMock
+from datetime import datetime
 
 from graphite.render.datalib import TimeSeries
 from graphite.render import functions
@@ -59,6 +60,18 @@ class FunctionsTest(TestCase):
             series, expected = conf
             result = functions._getPercentile(series, 30)
             self.assertEqual(expected, result, 'For series index <%s> the 30th percentile ordinal is not %d, but %d ' % (index, expected, result))
+
+    def test_integral(self):
+	seriesList = [TimeSeries('test', 0, 600, 60, [None, 1, 2, 3, 4, 5, None, 6, 7, 8])]
+	expected = [TimeSeries('integral(test)', 0, 600, 60, [None, 1, 3, 6, 10, 15, None, 21, 28, 36])]
+	result = functions.integral({}, seriesList)
+        self.assertEqual(expected, result, 'integral result incorrect')
+
+    def test_integralByInterval(self):
+        seriesList = [TimeSeries('test', 0, 600, 60, [None, 1, 2, 3, 4, 5, None, 6, 7, 8])]
+	expected = [TimeSeries("integral(test,'2min')", 0, 600, 60, [0, 1, 2, 5, 4, 9, 0, 6, 7, 15])]
+	result = functions.integralByInterval({'startTime' : datetime(1970,1,1)}, seriesList, '2min')
+	self.assertEqual(expected, result, 'integralByInterval result incorrect %s %s' %(result, result[0]))
 
     def test_n_percentile(self):
         seriesList = []

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -62,16 +62,16 @@ class FunctionsTest(TestCase):
             self.assertEqual(expected, result, 'For series index <%s> the 30th percentile ordinal is not %d, but %d ' % (index, expected, result))
 
     def test_integral(self):
-	seriesList = [TimeSeries('test', 0, 600, 60, [None, 1, 2, 3, 4, 5, None, 6, 7, 8])]
-	expected = [TimeSeries('integral(test)', 0, 600, 60, [None, 1, 3, 6, 10, 15, None, 21, 28, 36])]
-	result = functions.integral({}, seriesList)
+        seriesList = [TimeSeries('test', 0, 600, 60, [None, 1, 2, 3, 4, 5, None, 6, 7, 8])]
+        expected = [TimeSeries('integral(test)', 0, 600, 60, [None, 1, 3, 6, 10, 15, None, 21, 28, 36])]
+        result = functions.integral({}, seriesList)
         self.assertEqual(expected, result, 'integral result incorrect')
 
     def test_integralByInterval(self):
         seriesList = [TimeSeries('test', 0, 600, 60, [None, 1, 2, 3, 4, 5, None, 6, 7, 8])]
-	expected = [TimeSeries("integral(test,'2min')", 0, 600, 60, [0, 1, 2, 5, 4, 9, 0, 6, 7, 15])]
-	result = functions.integralByInterval({'startTime' : datetime(1970,1,1)}, seriesList, '2min')
-	self.assertEqual(expected, result, 'integralByInterval result incorrect %s %s' %(result, result[0]))
+        expected = [TimeSeries("integral(test,'2min')", 0, 600, 60, [0, 1, 2, 5, 4, 9, 0, 6, 7, 15])]
+        result = functions.integralByInterval({'startTime' : datetime(1970,1,1)}, seriesList, '2min')
+        self.assertEqual(expected, result, 'integralByInterval result incorrect %s %s' %(result, result[0]))
 
     def test_n_percentile(self):
         seriesList = []

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -1,7 +1,6 @@
 import copy
 import math
 import pytz
-from datetime import datetime
 from fnmatch import fnmatch
 
 from django.test import TestCase


### PR DESCRIPTION
This will do the same as integral() function, except resetting the total to 0 periodicaly.

For example:

     target=integralByInterval(company.sales.perMinute,"1d")&from=midnight-10days

This would start at zero on the left side of the graph, adding the sales each minute, and show the evolution of sales per day during the last 10 days.