### PR TITLE
Build the default database path from STORAGE_DIR

### DIFF
--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -121,6 +121,8 @@ DASHBOARD_REQUIRE_PERMISSIONS = False
 # NOTE: Requires DASHBOARD_REQUIRE_AUTHENTICATION to be set
 DASHBOARD_REQUIRE_EDIT_GROUP = None
 
+DATABASES = None
+
 # If using rrdcached, set to the address or socket of the daemon
 FLUSHRRDCACHED = ''
 
@@ -178,16 +180,17 @@ if not STANDARD_DIRS:
   except ImportError:
     pass
 
-DATABASES = {
-  'default': {
-    'NAME': join(STORAGE_DIR, 'graphite.db'),
-    'ENGINE': 'django.db.backends.sqlite3',
-    'USER': '',
-    'PASSWORD': '',
-    'HOST': '',
-    'PORT': '',
-  },
-}
+if DATABASES is None:
+    DATABASES = {
+      'default': {
+        'NAME': join(STORAGE_DIR, 'graphite.db'),
+        'ENGINE': 'django.db.backends.sqlite3',
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': '',
+        'PORT': '',
+      },
+    }
 
 # Handle URL prefix in static files handling
 if URL_PREFIX and not STATIC_URL.startswith(URL_PREFIX):


### PR DESCRIPTION
Currently, the default database path is hardcoded to /opt.  In a
development installation, graphite-web may be installed anywhere
and will fail to start following the development installation
instructions.  Using STORAGE_DIR aligns this value with the
comments earlier in the file.
- Changed definition of DATABASES
- Moved DATABASES definition to after STORAGE_DIR definition.
