### PR TITLE
URL shortener was added to 0.9.13 release notes

### DIFF
--- a/docs/releases/0_9_13.rst
+++ b/docs/releases/0_9_13.rst
@@ -38,6 +38,7 @@ Graphite-web
 * Sort "User Graphs" by creator's username (ciranor)
 * New ``changed()`` function (kamaradclimber, obfuscurity)
 * Use ``query_bulk`` for improved cache query performance (huy, deniszh)
+* A URL shortener has been added to the composer toolbar (seveas, cbowman0, deniszh)
 * Allow metric finder to return jsonp objects (kali-hernandez-sociomantic)
 * Document use of alpha color values in ``colorList`` and ``bgcolor`` (ojilles)
 * Improved documentation for ``areaBetween()`` (ojilles, gwaldo)


### PR DESCRIPTION
Backport PR #939 to 0.9.x branch 
