### PR TITLE
Fixing caching issue similar to #467 but for rendered graphs.

### DIFF
--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -209,7 +209,7 @@ def renderView(request):
     response = buildResponse(image, useSVG and 'image/svg+xml' or 'image/png')
 
   if useCache:
-    cache.set(requestKey, response, cacheTimeout)
+    cache.add(requestKey, response, cacheTimeout)
 
   log.rendering('Total rendering time %.6f seconds' % (time() - start))
   return response


### PR DESCRIPTION
See https://github.com/graphite-project/graphite-web/pull/945#issuecomment-54818928
Backport to 0.9.x
