### PR TITLE
use add instead of set for rendered cache

### DIFF
--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -208,7 +208,7 @@ def renderView(request):
     response = buildResponse(image, 'image/svg+xml' if useSVG else 'image/png')
 
   if useCache:
-    cache.set(requestKey, response, cacheTimeout)
+    cache.add(requestKey, response, cacheTimeout)
 
   log.rendering('Total rendering time %.6f seconds' % (time() - start))
   return response


### PR DESCRIPTION
As per b9b635043acf2f5dd5be712f5e06b9911d16842f prefer 'add' over 'set'. This 
is a fix for the cached renderings (images) which wasn't addressed in the 
original bug fix.

Fix for master

cc @obfuscurity
