### PR TITLE
Run the tests on Django 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - TOXENV=py27-django14
   - TOXENV=py27-django15
   - TOXENV=py27-django16
+  - TOXENV=py27-django17
   - TOXENV=py27-django16-pyparsing1
   - TOXENV=docs
   - TOXENV=lint

--- a/tox.ini
+++ b/tox.ini
@@ -62,6 +62,13 @@ deps =
 	Django<1.7
 	pyparsing
 
+[testenv:py27-django17]
+basepython = python2.7
+deps =
+	{[testenv]deps}
+	Django<1.8
+	pyparsing
+
 [testenv:py27-django16-pyparsing1]
 basepython = python2.7
 deps =

--- a/webapp/graphite/app_settings.py
+++ b/webapp/graphite/app_settings.py
@@ -15,9 +15,6 @@ limitations under the License."""
 # DO NOT MODIFY THIS FILE DIRECTLY - use local_settings.py instead
 from os.path import dirname, join, abspath
 
-ADMINS = ()
-MANAGERS = ADMINS
-
 TEMPLATE_DIRS = (
   join(dirname( abspath(__file__) ), 'templates'),
 )
@@ -36,8 +33,6 @@ CACHES = {
 # http://blogs.law.harvard.edu/tech/stories/storyReader$15
 LANGUAGE_CODE = 'en-us'
 
-SITE_ID = 1
-
 # Absolute path to the directory that holds media.
 
 MEDIA_ROOT = ''
@@ -45,12 +40,6 @@ MEDIA_ROOT = ''
 # URL that handles the media served from MEDIA_ROOT.
 # Example: "http://media.lawrence.com"
 MEDIA_URL = ''
-
-# List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-  'django.template.loaders.filesystem.Loader',
-  'django.template.loaders.app_directories.Loader',
-)
 
 MIDDLEWARE_CLASSES = (
   'graphite.middleware.LogExceptionsMiddleware',

--- a/webapp/graphite/urls.py
+++ b/webapp/graphite/urls.py
@@ -17,7 +17,11 @@ from django.conf import settings
 from django.conf.urls import patterns, include, url
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-from django.template.loader import add_to_builtins
+
+try:
+    from django.template.base import add_to_builtins
+except ImportError:  # Django < 1.7
+    from django.template.loader import add_to_builtins
 
 if django.VERSION < (1, 5):  # load the "future" {% url %} tag
     add_to_builtins('django.templatetags.future')


### PR DESCRIPTION
Django 1.7 is python 2.7 and above, so this only adds a single build target.

I removed some settings that had the same value as django's default, having them set raised a (false positive) warning with Django 1.7 for no reason. I filed a [Django ticket](https://code.djangoproject.com/ticket/23469) for that issue.
