### PR TITLE
add support for posting 'when'

### DIFF
--- a/webapp/graphite/events/views.py
+++ b/webapp/graphite/events/views.py
@@ -48,7 +48,8 @@ def post_event(request):
         values["what"] = event["what"]
         values["tags"] = event.get("tags", None)
         values["when"] = datetime.datetime.fromtimestamp(
-            event.get("when", time.time()))
+            event.get("when", time.time())) if not event.get("when") 
+            else datetime.datetime.fromtimestamp(float(event["when"]))
         if "data" in event:
             values["data"] = event["data"]
 


### PR DESCRIPTION
allow for back-filling of events during posting by manually setting 'when'.

e.g. curl -X POST http://localhost:8000/events/ -d '{"what": "deploy that thing", "tags": "deploy", "when": "1411142400.0"}'

p.s. apologies for the bad style, I wasn't sure how best to fit that there matching the existing style.
