### PR TITLE
Coverage integration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -94,3 +94,16 @@ deps =
 commands =
 	flake8 {toxinidir}/webapp/graphite
 	flake8 {toxinidir}/webapp/tests
+
+[testenv:coverage]
+basepython = python2.7
+deps =
+	{[testenv]deps}
+	Django<1.7
+	coverage
+	django-coverage
+	pyparsing
+setenv =
+	{[testenv]setenv}
+	TEST_RUNNER=django_coverage.coverage_runner.CoverageRunner
+

--- a/webapp/tests/settings.py
+++ b/webapp/tests/settings.py
@@ -14,6 +14,9 @@ from django import VERSION
 
 if VERSION < (1, 6):
     TEST_RUNNER = 'discover_runner.DiscoverRunner'
+elif 'TEST_RUNNER' in os.environ:
+    TEST_RUNNER = os.environ['TEST_RUNNER']
+
 
 CACHES = {
     'default': {


### PR DESCRIPTION
Coverage integration using ``django-coverage``.

Still fails on Django 1.4 and 1.5 for whatever reason.

Also, it doesn't seem to measure the coverage correctly yet, for example the ``functions`` don't seem to be included.