### PR TITLE
Make HTTP clients only cache graphs as long as we keep them in memcached

### DIFF
--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -34,9 +34,15 @@ class RenderTest(TestCase):
 
         response = self.client.get(url, {'target': 'test', 'format': 'json'})
         self.assertEqual(json.loads(response.content), [])
+        self.assertTrue(response.has_header('Expires'))
+        self.assertTrue(response.has_header('Last-Modified'))
+        self.assertTrue(response.has_header('Cache-Control'))
 
         response = self.client.get(url, {'target': 'test'})
         self.assertEqual(response['Content-Type'], 'image/png')
+        self.assertTrue(response.has_header('Expires'))
+        self.assertTrue(response.has_header('Last-Modified'))
+        self.assertTrue(response.has_header('Cache-Control'))
 
         self.addCleanup(self.wipe_whisper)
         whisper.create(self.db, [(1, 60)])


### PR DESCRIPTION
We were previously setting `Cache-Control: no-cache` and `Pragma: no-cache` without setting any `Expires` or `Last-Modified` headers. This was causing some clients (e.g., WebKit on iOS) to cache images indefinitely.

We now set `Expires`, `Last-Modified`, and `Cache-Control: max-age` to tell clients to cache images for as long as we cache them in memcached. If we aren't using memcached, we tell clients not to cache the images at all.
