### PR TITLE
Register "grep" as a render series function

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -3238,6 +3238,7 @@ SeriesFunctions = {
   'sortByMinima' : sortByMinima,
   'useSeriesAbove': useSeriesAbove,
   'exclude' : exclude,
+  'grep' : grep,
 
   # Data Filter functions
   'removeAbovePercentile' : removeAbovePercentile,


### PR DESCRIPTION
When using the function grep(series, pattern) the following error is reported:

 KeyError at /render/  u'grep'

The fix is to register the keyword "grep" with the existing grep function in the SeriesFunctions dictionary.
