### PR TITLE
Handle missing divisor series in divideSeries gracefully.

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -522,7 +522,14 @@ def divideSeries(requestContext, dividendSeriesList, divisorSeries):
 
 
   """
-  if len(divisorSeries) != 1:
+  if len(divisorSeries) == 0:
+    for series in dividendSeriesList:
+      series.name = "divideSeries(%s,MISSING)" % (series.name,)
+      series.pathExpression = series.name
+      for i in range(len(series)):
+        series[i] = None
+    return dividendSeriesList
+  if len(divisorSeries) > 1:
     raise ValueError("divideSeries second argument must reference exactly 1 series")
 
   divisorSeries = divisorSeries[0]


### PR DESCRIPTION
If all the data points for a series go out of scope then the series effectively disappears, with datalib.fetchData returning an empty series list.  This caused divideSeries to throw an exception.  In practice, graphs would suddenly stop rendering if they contained at least one divideSeries expression with data that got too old.

This is a minimal fix - None values are generated on the fly when required by divideSeries.  Since the divisorSeries is empty, we can't get the path expression for labeling.  A better fix (I think) would be to have datalib.findData return the series, but with all None data points.  I'm not sure how much work that would involve or how much would break, where the current behavior is expected.