### PR TITLE
Add match parameter to transformNull

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2537,9 +2537,9 @@ def transformNull(requestContext, seriesList, default=0, match=None):
   This would produce -1 when the index page was visited but the error count was not
   recorded.
   """
-  if len(match) > 1:
-    raise ValueError("transformNull match argument if specified must reference exactly 1 series")
   if match:
+    if len(match) > 1:
+      raise ValueError("transformNull match argument if specified must reference exactly 1 series")
     match = match[0]
     series_max = max(map(len, seriesList) + [0])
     if series_max > len(match):

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2520,7 +2520,7 @@ def transformNull(requestContext, seriesList, default=0, match=None):
   drawNullAsZero flag in graphical mode but also works in text only
   mode.
 
-  If match is specified, only transforms Null when the 
+  If match is specified, only transforms Null when the
   corresponding value in match is not Null.
 
   Example:
@@ -2554,8 +2554,8 @@ def transformNull(requestContext, seriesList, default=0, match=None):
 
   for series in seriesList:
     series.name = "transformNull(%s,%g%s)" % (
-      series.name, 
-      default, 
+      series.name,
+      default,
       ",%s" % match.name if match else ""
     )
     series.pathExpression = series.name

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2513,12 +2513,16 @@ def threshold(requestContext, value, label=None, color=None):
 
   return [series]
 
-def transformNull(requestContext, seriesList, default=0):
+def transformNull(requestContext, seriesList, default=0, match=None):
   """
   Takes a metric or wild card seriesList and an optional value
   to transform Nulls to. Default is 0. This method compliments
   drawNullAsZero flag in graphical mode but also works in text only
   mode.
+
+  If match is specified, only transforms Null when the 
+  corresponding value in match is not Null.
+
   Example:
 
   .. code-block:: none
@@ -2527,15 +2531,31 @@ def transformNull(requestContext, seriesList, default=0):
 
   This would take any page that didn't have values and supply negative 1 as a default.
   Any other numeric value may be used as well.
+
+    &target=transformNull(webapp.pages.index.errors,-1,webapp.pages.index.views)
+
+  This would produce -1 when the index page was visited but the error count was not
+  recorded.
   """
-  def transform(v):
-    if v is None: return default
-    else: return v
+  if match:
+    match = match[0]
+    match.extend([None] * (max(map(len, seriesList)) - len(match)))
+    def transform(i, v):
+      if v is None and match[i] is not None: return default
+      else: return v
+  else:
+    def transform(i, v):
+      if v is None: return default
+      else: return v
 
   for series in seriesList:
-    series.name = "transformNull(%s,%g)" % (series.name, default)
+    series.name = "transformNull(%s,%g%s)" % (
+      series.name, 
+      default, 
+      ",%s" % match.name if match else ""
+    )
     series.pathExpression = series.name
-    values = [transform(v) for v in series]
+    values = [transform(i, v) for i, v in enumerate(series)]
     series.extend(values)
     del series[:len(values)]
   return seriesList

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2537,9 +2537,13 @@ def transformNull(requestContext, seriesList, default=0, match=None):
   This would produce -1 when the index page was visited but the error count was not
   recorded.
   """
+  if len(match) > 1:
+    raise ValueError("transformNull match argument if specified must reference exactly 1 series")
   if match:
     match = match[0]
-    match.extend([None] * (max(map(len, seriesList)) - len(match)))
+    series_max = max(map(len, seriesList) + [0])
+    if series_max > len(match):
+        match.extend([None] * (series_max - len(match)))
     def transform(i, v):
       if v is None and match[i] is not None: return default
       else: return v

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -191,6 +191,51 @@ class FunctionsTest(TestCase):
                         "Transformed value should be {0}, not {1}".format(transform, result_val),
                     )
 
+    def test_transform_null_match(self):
+        base = [
+            TimeSeries(
+                "collectd.test-db1.load.value",
+                0,
+                1,
+                1,
+                [x if x % 3 == 0 else None for x in range(20)]
+            )
+        ]
+        match = [
+            TimeSeries(
+                "collectd.test-db2.load.value",
+                0,
+                1,
+                1,
+                [x if x % 2 == 0 else None for x in range(20)]
+            )
+        ]
+        transform = -5
+        seriesList = []
+        expectedList = [
+            TimeSeries(
+                "transformNull("
+                    "collectd.test-db1.load.value,"
+                    "-5,"
+                    "collectd.test-db2.load.value"
+                ")",
+                0,
+                1,
+                1,
+                [
+                    x if x % 3 == 0 else 
+                        -5 if x % 2 == 0 else 
+                            None 
+                                for x in range(20)
+                ]
+            )
+        ]
+        gotList = functions.transformNull({}, base, transform, match)
+        self.assertEqual(len(gotList), 1)
+        for got, expected in zip(gotList, expectedList):
+            self.assertEqual(got.name, expected.name)
+            self.assertListEqual(got, expected)
+
     def test_alias(self):
         seriesList = self._generate_series_list()
         substitution = "Ni!"

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -215,18 +215,18 @@ class FunctionsTest(TestCase):
         expectedList = [
             TimeSeries(
                 "transformNull("
-                    "collectd.test-db1.load.value,"
-                    "-5,"
-                    "collectd.test-db2.load.value"
+                "collectd.test-db1.load.value,"
+                "-5,"
+                "collectd.test-db2.load.value"
                 ")",
                 0,
                 1,
                 1,
                 [
-                    x if x % 3 == 0 else 
-                        -5 if x % 2 == 0 else 
-                            None 
-                                for x in range(20)
+                    x if x % 3 == 0 else
+                    -5 if x % 2 == 0 else
+                    None
+                    for x in range(20)
                 ]
             )
         ]


### PR DESCRIPTION
None is only transformed when the match (another series) has a valid value at the same position.

We have multiple stats that are reported simultaneously and we expect to compare.  Some stats are from dynamic counters, where the counter doesn't exist until the first event is counted.  The service runs periodically with a varying duration, so there are also periods where all stats are None.  In this case we want to transform Nones to 0 only when a report was generated.