### PR TITLE
Delay function

### DIFF
--- a/webapp/content/js/composer_widgets.js
+++ b/webapp/content/js/composer_widgets.js
@@ -1088,6 +1088,7 @@ function createFunctionsMenu() {
         {text: 'Power', handler: applyFuncToEachWithInput('pow', 'Please enter a power factor')},
         {text: 'Square Root', handler: applyFuncToEach('squareRoot')},
         {text: 'Time-adjusted Derivative', handler: applyFuncToEachWithInput('perSecond', "Please enter a maximum value if this metric is a wrapping counter (or just leave this blank)", {allowBlank: true})},
+	{text: 'Delay', handler: applyFuncToEachWithInput('scale', 'Please enter the number of steps to delay')},
         {text: 'Integral', handler: applyFuncToEach('integral')},
         {text: 'Percentile Values', handler: applyFuncToEachWithInput('percentileOfSeries', "Please enter the percentile to use")},
         {text: 'Non-negative Derivative', handler: applyFuncToEachWithInput('nonNegativeDerivative', "Please enter a maximum value if this metric is a wrapping counter (or just leave this blank)", {allowBlank: true})},

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1052,13 +1052,13 @@ def delay(requestContext, seriesList, steps):
   results = []
   for series in seriesList:
     newValues = []
-    prev = collections.deque(maxlen=steps)
+    prev = []
     for val in series:
       if len(prev) < steps:
         newValues.append(None)
         prev.append(val)
         continue
-      newValues.append(prev.popleft())
+      newValues.append(prev.pop(0))
       prev.append(val)
     newName = "delay(%s,%d)" % (series.name, steps)
     newSeries = TimeSeries(newName, series.start, series.end, series.step, newValues)

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1034,6 +1034,38 @@ def perSecond(requestContext, seriesList, maxValue=None):
     results.append(newSeries)
   return results
 
+def delay(requestContext, seriesList, steps):
+  """
+  This shifts all samples later by an integer number of steps.  This can be
+  used for custom derivative calculations, among other things.  Note: this
+  will pad the early end of the data with None for every step shifted.
+
+  Example:
+
+  .. code-block:: none
+
+    &target=divideSeries(server.FreeSpace,delay(server.FreeSpace,1))
+
+  This computes the change in server free space as a percentage of the previous
+  free space.
+  """
+  results = []
+  for series in seriesList:
+    newValues = []
+    prev = collections.deque(maxlen=steps)
+    for val in series:
+      if len(prev) < steps:
+        newValues.append(None)
+        prev.append(val)
+        continue
+      newValues.append(prev.popleft())
+      prev.append(val)
+    newName = "delay(%s,%d)" % (series.name, steps)
+    newSeries = TimeSeries(newName, series.start, series.end, series.step, newValues)
+    newSeries.pathExpression = newName
+    results.append(newSeries)
+  return results
+
 def integral(requestContext, seriesList):
   """
   This will show the sum over time, sort of like a continuous addition function.
@@ -3185,6 +3217,7 @@ SeriesFunctions = {
   'offset' : offset,
   'offsetToZero' : offsetToZero,
   'derivative' : derivative,
+  'delay': delay,
   'squareRoot' : squareRoot,
   'pow' : pow,
   'perSecond' : perSecond,

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -353,3 +353,16 @@ class FunctionsTest(TestCase):
             expected = [TimeSeries("changed(%s)" % name,0,1,1,c[1])]
             result = functions.changed({}, series)
             self.assertEqual(result, expected)
+
+    def test_delay(self):
+        source = [
+            TimeSeries('collectd.test-db1.load.value',0,1,1,[range(18)] + [None, None]),
+        ]
+        delay = 2
+        expectedList = [
+            TimeSeries('collectd.test-db1.load.value',0,1,1,[None, None] + [range(18)]),
+        ]
+        gotList = functions.delay({}, source, delay)
+        self.assertEqual(len(gotList), len(expectedList))
+        for got, expected in zip(gotList, expectedList):
+            self.assertListEqual(got, expected)


### PR DESCRIPTION
This delays a series by a number of time steps.  The delay method is the same as in derivative (Nones appended to the beginning).

Our immediate use case is computing a derivative using divideSeries, to find the percent difference from the previous data point.