### PR TITLE
Change initial nav bar config to be collapsed

### DIFF
--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -34,6 +34,7 @@ var navBarNorthConfig = {
   layoutConfig: { align: 'stretch' },
   collapsible: true,
   collapseMode: 'mini',
+  collapsed: true,
   split: true,
   title: "untitled",
   height: 350,


### PR DESCRIPTION
Our usual use case for dashboards is to view them rather than edit them so it would be better if the navigation bar was collapsed by default when the dashboard is first opened. This is particularly useful for wall monitors that sometimes reboot and need manual intervention to collapse the navigation bar at the moment.
