### PR TITLE
HttpRequest.raw_post_data was deprecated in Django 1.4

### DIFF
--- a/webapp/graphite/events/views.py
+++ b/webapp/graphite/events/views.py
@@ -42,7 +42,7 @@ def detail(request, event_id):
 
 def post_event(request):
     if request.method == 'POST':
-        event = json.loads(request.raw_post_data)
+        event = json.loads(request.body)
         assert isinstance(event, dict)
 
         values = {}

--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -265,7 +265,7 @@ def set_metadata_view(request):
 
   elif request.method == 'POST':
     if request.META.get('CONTENT_TYPE') == 'application/json':
-      operations = json.loads( request.raw_post_data )
+      operations = json.loads( request.body )
     else:
       operations = json.loads( request.POST['operations'] )
 

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -367,7 +367,7 @@ def delegateRendering(graphType, graphOptions):
 def renderLocalView(request):
   try:
     start = time()
-    reqParams = StringIO(request.raw_post_data)
+    reqParams = StringIO(request.body)
     graphType = reqParams.readline().strip()
     optionsPickle = reqParams.read()
     reqParams.close()


### PR DESCRIPTION
Backport of PR #567 to 0.9.x
(simple cherry-pick)
