### PR TITLE
[critical] fix bug on carbonlink cache

### DIFF
--- a/webapp/graphite/readers.py
+++ b/webapp/graphite/readers.py
@@ -164,9 +164,13 @@ class WhisperReader(object):
     time_info, values = data
     (start,end,step) = time_info
 
+    meta_info = whisper.info(self.fs_path)
+    lowest_step = min([i['secondsPerPoint'] for i in meta_info['archives']])
     # Merge in data from carbon's cache
+    cached_datapoints = []
     try:
-      cached_datapoints = CarbonLink.query(self.real_metric_path)
+        if step == lowest_step:
+            cached_datapoints = CarbonLink.query(self.real_metric_path)
     except:
       log.exception("Failed CarbonLink query '%s'" % self.real_metric_path)
       cached_datapoints = []


### PR DESCRIPTION
Hi!
there is fix for a bug on carbon-link cache: its not downscale value for lower retention interval.
Example:
lowest precision in archive 10s, for 1d - 60s, agg method -- average. Value sent to graphite: 0.1 (10 req/s for example)
10s: 0, 0, 1, 0, 0, 1, 0.1
60s: 0.5, 0.1 // 0.1 * 60 is 60 req/s, instead of 10.
This fix disable carbonlink query for requests with step higher than lowers pointPerSecond in archive.
