### PR TITLE
JSON.parse in applyState if the state is a string (as it is for the init.ial request load if not using fragment urls)

### DIFF
--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -2536,6 +2536,13 @@ function getState() {
 function applyState(state) {
   setDashboardName(state.name);
 
+  // sometimes the server calls json.dumps once too many times.
+  // fixing that seems hard.
+  // so let's Just Fix It
+  if (typeof(state) == "string") {
+    state = JSON.parse(state);
+  }
+
   //state.timeConfig = {type, quantity, units, untilQuantity, untilUnits, startDate, startTime, endDate, endTime}
   var timeConfig = state.timeConfig
   TimeRange.type = timeConfig.type;


### PR DESCRIPTION
This fixes a long-standing bug on our install where non-fragment-url-loaded requests were getting a JavaScript error.
