### PR TITLE
Fix: Issue: CarbonLink ignore CARBONLINK_HOSTS = []

### DIFF
--- a/webapp/graphite/carbonlink.py
+++ b/webapp/graphite/carbonlink.py
@@ -114,6 +114,10 @@ class CarbonLinkPool:
     if metric.startswith(settings.CARBON_METRIC_PREFIX):
       return self.send_request_to_all(request)
 
+    if not self.hosts:
+      log.cache("CarbonLink is not connected to any host. Returning empty nodes list")
+      return result
+
     host = self.select_host(metric)
     conn = self.get_connection(host)
     log.cache("CarbonLink sending request for %s to %s" % (metric, str(host)))


### PR DESCRIPTION
when configured with CARBONLINK_HOSTS = []
 - select_host fails with webapp/graphite/render/hashing.py, line 88, in get_nodes ZeroDivisionError: integer division or modulo by zero
 - trying to get_connection on empty host list is waste of time (and fails similarly as select_host)