### PR TITLE
small documentation and example snippet for non-root wsgi installs

### DIFF
--- a/docs/config-webapp.rst
+++ b/docs/config-webapp.rst
@@ -1,8 +1,8 @@
 Configuring The Webapp
 ======================
 
-Running the webapp with mod_wsgi as non-root application (Apache)
------------------------------------------------------------------
+Running the webapp with mod_wsgi as URL-prefixed application (Apache)
+---------------------------------------------------------------------
 
 
 When using the new ``URL_PREFIX`` parameter in ``local_settings.py`` the 

--- a/examples/example-graphite-vhost.conf
+++ b/examples/example-graphite-vhost.conf
@@ -42,18 +42,17 @@ WSGISocketPrefix run/wsgi
         # django-admin.py collectstatic --noinput --settings=graphite.settings
         Alias /static/ /opt/graphite/static/
 
-		####################
-		# NON-ROOT install #
-		####################
-		# If using URL_PREFIX in local_settings for non-root install
- 		# your WSGIScriptAlias line should look like the following (e.g. URL_PREFX="/graphite"
+        ########################
+        # URL-prefixed install #
+        ########################
+        # If using URL_PREFIX in local_settings for URL-prefixed install (that is not located at "/"))
+        # your WSGIScriptAlias line should look like the following (e.g. URL_PREFX="/graphite"
 
-		# WSGIScriptAlias /graphite /srv/graphite-web/conf/graphite.wsgi/graphite
-		# Alias /graphite/static /opt/graphite/webapp/content
-		#  <Location "/graphite/static/">
+        # WSGIScriptAlias /graphite /srv/graphite-web/conf/graphite.wsgi/graphite
+        # Alias /graphite/static /opt/graphite/webapp/content
+        #  <Location "/graphite/static/">
         #        SetHandler None
         # </Location>
-
 
 
         # XXX In order for the django admin site media to work you


### PR DESCRIPTION
I've found that non-root install as wsgi-script with the new URL_PREFIX aren't very smooth yet.

I've added some snippets to examples and documentation to show what is needed for installation under some path in Apache. Hope this is useful for others. I took my quite some time to find out, why i always got 404 from django.
