### PR TITLE
Use encode URL characters in target string

### DIFF
--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -913,9 +913,9 @@ function graphAreaToggle(target, options) {
   */
   var graphTargetString;
   if (target.substr(0,7) == "target=") {
-    graphTargetString = target;
+    graphTargetString = "target=" + encodeURIComponent(target.substr(7, target.length-7));
   } else {
-    graphTargetString = "target=" + target;
+    graphTargetString = "target=" + encodeURIComponent(target);
   }
   var graphTargetList = Ext.urlDecode(graphTargetString)['target'];
   if (typeof graphTargetList == 'string') {
@@ -970,7 +970,7 @@ function importGraphUrl(targetUrl, options) {
   if (graphTargetList.length == 0) {
     return;
   }
- 
+
   var graphTargetString = Ext.urlEncode({target: graphTargetList});
   var existingIndex = graphStore.findExact('target', graphTargetString);
 


### PR DESCRIPTION
Hey,

first thanks for this great project!

If been using e.g. '=' signs in my graphite metric name. This causes the __/dashboard__ view to not correctly create a graph view when clicking in the found metric. The generated graph view only contains the characters until the first '=' sign. This happens when the correct target string is given to the `Ext.urlDecode ` function which then internally only returns a part of that string.

E.g. i can see when debugging that the `graphTargetString ` string is `target=host.ip=127-0-0-1.version=v0-0-1.Service.Cpu`, but after calling `var graphTargetList = Ext.urlDecode(graphTargetString)['target'];`  `graphTargetList ` is `host.ip`.

With this PR the target string is first URL encoded using `encodeURIComponent ` before give to `Ext.urlDecode`.

 