### PR TITLE
Update compat.py for django 1.7 compatibility

### DIFF
--- a/webapp/graphite/compat.py
+++ b/webapp/graphite/compat.py
@@ -7,6 +7,8 @@ class ContentTypeMixin(object):
     def __init__(self, *args, **kwargs):
         if VERSION < (1, 5) and 'content_type' in kwargs:
             kwargs['mimetype'] = kwargs.pop('content_type')
+        elif VERSION > (1, 7) and 'mimetype' in kwargs:
+            kwargs['content_type'] = kwargs.pop('mimetype')
         super(ContentTypeMixin, self).__init__(*args, **kwargs)
 
 


### PR DESCRIPTION
Fix for django 1.7 error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 111, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/graphite/webapp/graphite/render/views.py", line 207, in renderView
    response = HttpResponse(content=result, mimetype='application/json')
  File "/opt/graphite/webapp/graphite/compat.py", line 10, in __init__
    super(ContentTypeMixin, self).__init__(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/django/http/response.py", line 318, in __init__
    super(HttpResponse, self).__init__(*args, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'mimetype'
```

Based on findings from this thread where "mimetype" has once again been swapped out in favor of "control_type" in 1.7:  https://github.com/caffeinehit/django-oauth2-provider/issues/77