### PR TITLE
Preserve the sign of legendValue values when using a unit system

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1401,7 +1401,7 @@ def legendValue(requestContext, seriesList, *valueTypes):
         value = valueFunc(series)
         formatted = None
         if value is not None:
-          formatted = "%.2f%s" % format_units(abs(value), system=system)
+          formatted = "%.2f%s" % format_units(value, system=system)
         series.name = "%-20s%-5s%-10s" % (series.name, valueType, formatted)
   return seriesList
 

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -412,3 +412,8 @@ class FunctionsTest(TestCase):
             'data': [],
         }, seriesList, '00:03 19700101', '00:08 19700101')
         self.assertEqual(results, expectedResult)
+
+    def test_legendValue_with_system_preserves_sign(self):
+        seriesList = [TimeSeries("foo", 0, 1, 1, [-10000, -20000, -30000, -40000])]
+        result = functions.legendValue({}, seriesList, "avg", "si")
+        self.assertEqual(result[0].name, "foo                 avg  -25.00K   ")


### PR DESCRIPTION
This seems to have been broken since the `system` argument to `legendValue()` was added in 1a826949732c394b03c7e2e94e65af82762b9103. `format_units()` already calls `abs()` as needed so we don't need to do so before passing the value into it.

/cc @jssjr