### PR TITLE
Fixing release notes for upcoming 0.9.13 release

### DIFF
--- a/docs/releases/0_9_13.rst
+++ b/docs/releases/0_9_13.rst
@@ -141,6 +141,7 @@ Carbon
 * Fixing instrumentation (avishai-ish-shalom, jssr)
 * Fix exception handling (steve-dave)
 * Fix CACHE_WRITE_STRATEGY (jssr)
+* Fix aggregated metrics (pgul, ctavan)
 
 Whisper
 ^^^^^^^


### PR DESCRIPTION
I hope I didn't miss anyone.
Notes:
- "Fix per-host replication" in carbon was reverted, so, removed from notes.
- Giving kudos for @favoretti for initial hack which lead to "Bulk-fetch metrics from remote hosts".

In progress: we need  to decide what to do with PR https://github.com/graphite-project/carbon/pull/240 (yep, it's from carbon because of wrong issue but really belongs to graphite-web) and #1026 IMO.
And :ship: it ASAP. :smile_cat:    
