### PR TITLE
Fix querystring cross site nastiness

### DIFF
--- a/webapp/graphite/templates/dashboard.html
+++ b/webapp/graphite/templates/dashboard.html
@@ -36,7 +36,7 @@
     {% endif %}
 
     {% if querystring %}
-    var queryString = JSON.parse('{{ querystring }}');
+    var queryString = JSON.parse('{{ querystring|escapejs }}');
     {% endif %}
 
     var permissions = JSON.parse('{{ permissions }}');


### PR DESCRIPTION
There is still cross-site scripting nastiness hiding in querystring parameter. The following url shows the nastiness and the attached patch fixes it
http://localhost:8080/dashboard/?asd%22%3C/script%3E%3Cmarquee%3E%3Ch1%20style%3d%27font-size:98pt%27%3Esuch%20hardened%3Cbr%3E%3Cimg%20src%3d%27http://i.imgur.com/38RBJe1.png%27%20/%3E
