### PR TITLE
Bypass loopback prevention for deliberate loopbacks (0.9.x)

### DIFF
--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -98,6 +98,10 @@ def is_local_interface(host):
   if ':' in host:
     host = host.split(':',1)[0]
 
+  # If "localhost" or a loopback IP has been specified it is a deliberate reference
+  if host == 'localhost' or host.startswith('127.'):
+    return False
+
   try:
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.connect( (host, 4242) )


### PR DESCRIPTION
Sometimes you may want to query a separate local graphite-web instance and if you have configured one or more of your clusters hosts with a hostname of localhost or an IP of 127.x.x.x then this would be the case so with this patch they is treated as a remote host.

0.9.x port of https://github.com/graphite-project/graphite-web/pull/1070