### PR TITLE
Bypass loopback prevention for deliberate loopbacks (master)

### DIFF
--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -77,6 +77,10 @@ def is_local_interface(host):
   if ':' in host:
     host = host.split(':',1)[0]
 
+  # If "localhost" or a loopback IP has been specified it is a deliberate reference
+  if host == 'localhost' or host.startswith('127.'):
+    return False
+
   try:
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.connect( (host, 4242) )

--- a/webapp/tests/test_util.py
+++ b/webapp/tests/test_util.py
@@ -1,10 +1,16 @@
 from django.test import TestCase
 
+import socket
+
 from graphite import util
 
 
 class UtilTest(TestCase):
     def test_is_local_interface(self):
-        addresses = ['127.0.0.1', '127.0.0.1:8080', '8.8.8.8']
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(('8.8.8.8', 0))  # connecting to a UDP address doesn't send packets
+        local_ip_address = s.getsockname()[0]
+        s.close()
+        addresses = [local_ip_address, local_ip_address + ':8080', '127.0.0.1', '127.0.0.1:8080', '8.8.8.8']
         results = [ util.is_local_interface(a) for a in addresses ]
-        self.assertEqual( results, [True, True, False] )
+        self.assertEqual( results, [True, True, False, False, False] )


### PR DESCRIPTION
Sometimes you may want to query a separate local graphite-web instance and if you have configured one or more of your clusters hosts with a hostname of localhost or an IP of 127.x.x.x then this would be the case so with this patch they is treated as a remote host.

Master port of https://github.com/graphite-project/graphite-web/pull/1069