### PR TITLE
Do /metrics/find queries in parallel

### DIFF
--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -18,10 +18,13 @@ class RemoteStore(object):
     self.host = host
 
 
-  def find(self, query):
+  def find(self, query, result_queue=False):
     request = FindRequest(self, query)
     request.send()
-    return request
+    if result_queue:
+      result_queue.put(request)
+    else:
+      return request
 
 
   def fail(self):


### PR DESCRIPTION
Based on what was done to fetchData() in #1026.

`/metrics/find/` queries are used less often since #1010 went in, but the composer still uses them.
This makes browsing metrics through the composer much less painful :-)

The code has been very lightly tested (it is December 30th code after all), but it works on a 10 node cluster.

cc @bmhatfield 
