### PR TITLE
Fix doc indentation and title underline warnings (0.9.x)

### DIFF
--- a/docs/releases/0_9_11.rst
+++ b/docs/releases/0_9_11.rst
@@ -1,4 +1,5 @@
 .. _0-9-11:
+
 0.9.11
 ======
 *8/20/2013*
@@ -112,7 +113,7 @@ Carbon
 * min/max aggregation methods are now supported (ishiro)
 
 Whisper
-^^^^^^
+^^^^^^^
 * Better commandline sanity checking and messaging (sejeff)
 * Handle SIGPIPE correctly in commandline utils (sejeff)
 * Option to intelligently aggregate values on whisper-resize (jens-rantil)

--- a/docs/releases/0_9_9.rst
+++ b/docs/releases/0_9_9.rst
@@ -40,8 +40,7 @@ Revamped Dashboard UI
 Other Stuff
 -----------
 * Tons of readthedocs.org improvements, also the example config files now have some great comment documentation
-* Whisper now supports rollup aggregation methods other than averaging. The default is
-still to average but there a new aggregation-schemas.conf (see Bug #853955)
+* Whisper now supports rollup aggregation methods other than averaging. The default is still to average but there a new aggregation-schemas.conf (see Bug #853955)
 * To learn about the new metric metadata API that can be used to configure custom rollup aggregation methods read my answer to https://answers.launchpad.net/graphite/+question/173304 (you can skip the question part if you just care about the new API)
 
 As for the current development focus, I can now finally work on the long-awaited merge of the 1.1


### PR DESCRIPTION
This should fix warnings I've seen in the RTD build:

```
/var/build/user_builds/graphite/checkouts/0.9.13-pre1/docs/releases/0_9_11.rst:2: WARNING: Explicit markup ends without a blank line; unexpected unindent.
/var/build/user_builds/graphite/checkouts/0.9.13-pre1/docs/releases/0_9_11.rst:115: WARNING: Title underline too short.
/var/build/user_builds/graphite/checkouts/0.9.x/docs/releases/0_9_9.rst:44: WARNING: Bullet list ends without a blank line; unexpected unindent.
```