### PR TITLE
Bad multiline comment in functions.py

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -145,10 +145,7 @@ def normalize(seriesLists):
   raise NormalizeEmptyResultError()
 
 class NormalizeEmptyResultError(Exception):
-  """
-  Error thrown by the function 'normalize'
-  when it has an empty result
-  """
+  # throw error for normalize() when empty
   pass
 
 


### PR DESCRIPTION
Remove this, otherwise it ends up getting built for the RTD docs.

![screen shot 2015-01-11 at 10 31 50 am](https://cloud.githubusercontent.com/assets/494338/5695709/16f4ba7e-997d-11e4-86c6-9eba443fd897.png)
