### PR TITLE
adding timeslice method

### DIFF
--- a/webapp/content/js/composer_widgets.js
+++ b/webapp/content/js/composer_widgets.js
@@ -1095,6 +1095,7 @@ function createFunctionsMenu() {
         {text: 'Invert', handler: applyFuncToEach('invert')},
         {text: 'Absolute Value', handler: applyFuncToEach('absolute')},
         {text: 'timeShift', handler: applyFuncToEachWithInput('timeShift', 'Shift this metric ___ back in time (examples: 10min, 7d, 2w)', {quote: true})},
+        {text: 'timeSlice', handler: applyFuncToEachWithInput('timeSlice', 'Start showing metric at (example: 14:57 20150115)', {quote: true})},
         {text: 'Summarize', handler: applyFuncToEachWithInput('summarize', 'Please enter a summary interval (examples: 10min, 1h, 7d)', {quote: true})},
         {text: 'Hit Count', handler: applyFuncToEachWithInput('hitcount', 'Please enter a summary interval (examples: 10min, 1h, 7d)', {quote: true})}
       ]

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2475,11 +2475,22 @@ def timeShift(requestContext, seriesList, timeShift, resetEnd=True):
   return results
 
 
-def timeSlice(requestContext, seriesList, startSliceAt, endSliceAt):
+def timeSlice(requestContext, seriesList, startSliceAt, endSliceAt="now"):
   """
   Takes one metric or a wildcard seriesList, followed by a quoted string with the
   time to start the line and another quoted string with the time to end the line.
   See ``from / until`` in the render\_api_ for examples of time formats.
+
+  Useful when, for example, you've collected all of your metrics by router port
+  but you want to show metrics by customer location and the customer's router port
+  has changed over time.
+
+  Example:
+
+  .. code-block:: none
+
+    &target=timeSlice(network.core.port1,"00:00 20140101","11:59 20140630")
+    &target=timeSlice(network.core.port1,"12:00 20140630","now")
 
   """
 

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -21,7 +21,7 @@ import random
 import time
 
 from graphite.logger import log
-from graphite.render.attime import parseTimeOffset
+from graphite.render.attime import parseTimeOffset, parseATTime
 
 from graphite.events import models
 

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2482,9 +2482,8 @@ def timeSlice(requestContext, seriesList, startSliceAt, endSliceAt="now"):
   The start and end times are inclusive. See ``from / until`` in the render\_api_
   for examples of time formats.
 
-  Useful when, for example, you've collected all of your metrics by router port
-  but you want to show metrics by customer location and the customer's router port
-  has changed over time.
+  Useful for filtering out a part of a series of data from a wider range of
+  data.
 
   Example:
 

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2406,7 +2406,10 @@ def timeStack(requestContext, seriesList, timeShiftUnit, timeShiftStart, timeShi
   if timeShiftUnit[0].isdigit():
     timeShiftUnit = '-' + timeShiftUnit
   delta = parseTimeOffset(timeShiftUnit)
-  series = seriesList[0] # if len(seriesList) > 1, they will all have the same pathExpression, which is all we care about.
+
+  # if len(seriesList) > 1, they will all have the same pathExpression, which is all we care about.
+  series = seriesList[0]
+
   results = []
   timeShiftStartint = int(timeShiftStart)
   timeShiftEndint = int(timeShiftEnd)
@@ -2461,7 +2464,8 @@ def timeShift(requestContext, seriesList, timeShift, resetEnd=True):
   myContext['endTime'] = requestContext['endTime'] + delta
   results = []
   if len(seriesList) > 0:
-    series = seriesList[0] # if len(seriesList) > 1, they will all have the same pathExpression, which is all we care about.
+    # if len(seriesList) > 1, they will all have the same pathExpression, which is all we care about.
+    series = seriesList[0]
 
     for shiftedSeries in evaluateTarget(myContext, series.pathExpression):
       shiftedSeries.name = 'timeShift(%s, %s)' % (shiftedSeries.name, timeShift)
@@ -2495,7 +2499,6 @@ def timeSlice(requestContext, seriesList, startSliceAt, endSliceAt="now"):
   """
 
   results = []
-  series = seriesList[0] # if len(seriesList) > 1, they will all have the same pathExpression, which is all we care about.
   start = time.mktime(parseATTime(startSliceAt).timetuple())
   end = time.mktime(parseATTime(endSliceAt).timetuple())
 

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2477,9 +2477,10 @@ def timeShift(requestContext, seriesList, timeShift, resetEnd=True):
 
 def timeSlice(requestContext, seriesList, startSliceAt, endSliceAt="now"):
   """
-  Takes one metric or a wildcard seriesList, followed by a quoted string with the
+  Takes one metric or a wildcard metric, followed by a quoted string with the
   time to start the line and another quoted string with the time to end the line.
-  See ``from / until`` in the render\_api_ for examples of time formats.
+  The start and end times are inclusive. See ``from / until`` in the render\_api_
+  for examples of time formats.
 
   Useful when, for example, you've collected all of your metrics by router port
   but you want to show metrics by customer location and the customer's router port
@@ -2499,8 +2500,8 @@ def timeSlice(requestContext, seriesList, startSliceAt, endSliceAt="now"):
   start = time.mktime(parseATTime(startSliceAt).timetuple())
   end = time.mktime(parseATTime(endSliceAt).timetuple())
 
-  for slicedSeries in evaluateTarget(requestContext, series.pathExpression):
-    slicedSeries.name = 'timeSlice(%s, %s, %s)' % (slicedSeries.name, start, end)
+  for slicedSeries in seriesList:
+    slicedSeries.name = 'timeSlice(%s, %s, %s)' % (slicedSeries.name, int(start), int(end))
 
     curr = time.mktime(requestContext["startTime"].timetuple())
     for i, v in enumerate(slicedSeries):


### PR DESCRIPTION
This change will allow selecting only a slice of time from a line to display on the graph. This is useful in the following situation:

A customer just wants to know how much bandwidth their site used last year. They don't care about the link to their site. At the beginning of the year the customer is using port ge-0/0/0. Halfway through the year the customer is upgraded to ae0, an aggregated port that contains ge-0/0/0. All traffic that goes through ae0 necessarily goes through ge-0/0/0. Were a graph to be made over the entire year for all traffic to the site then it would have to include both ge-0/0/0 and ae0 to cover the whole year except that from 'Jul 1' to 'Dec 31' would be double the actual value because it would include traffic from both ge-0/0/0 and ae0. This new function, combined with sumSeries, allows me to say 'show ge-0/0/0 from Jan 1 to Jun 30 and ae0 from Jul 1 to Dec 31' and get one line that is an accurate representation of traffic for the customer for the entire year.