### PR TITLE
Include pysqlite by default

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ python-memcached==1.47
 txAMQP==0.4
 simplejson==2.1.6
 django-tagging==0.3.1
+pysqlite
 gunicorn
 pytz
 pyparsing==1.5.7


### PR DESCRIPTION
Graphite-web uses SQLite by default (including the DATABASES setting in local_settings.py) so it makes no sense imho not to install this driver by default.

Cherry-picked into `master` from `0.9.x`, refs #1115.