### PR TITLE
Fix graph lookup with non-ascii names

### DIFF
--- a/webapp/graphite/browser/views.py
+++ b/webapp/graphite/browser/views.py
@@ -91,7 +91,7 @@ def myGraphLookup(request):
   }
 
   try:
-    path = str( request.GET['path'] )
+    path = request.GET.get('path', u'')
 
     if path:
       if path.endswith('.'):
@@ -101,7 +101,7 @@ def myGraphLookup(request):
         userpath_prefix = path + '.'
 
     else:
-      userpath_prefix = ""
+      userpath_prefix = u""
 
     matches = [ graph for graph in profile.mygraph_set.all().order_by('name') if graph.name.startswith(userpath_prefix) ]
 
@@ -124,15 +124,15 @@ def myGraphLookup(request):
          if name in leaf_inserted: continue
          leaf_inserted.add(name)
 
-      node = {'text' : str(name) }
+      node = {'text': name}
 
       if isBranch:
-        node.update( { 'id' : str(userpath_prefix + name + '.') } )
+        node.update({'id': userpath_prefix + name + '.'})
         node.update(branchNode)
 
       else:
         m = md5()
-        m.update(name)
+        m.update(name.encode('utf-8'))
         node.update( { 'id' : str(userpath_prefix + m.hexdigest()), 'graphUrl' : str(graph.url) } )
         node.update(leafNode)
 

--- a/webapp/tests/test_browser.py
+++ b/webapp/tests/test_browser.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+import json
 import os
 
 from django.contrib.auth.models import User
@@ -47,3 +49,16 @@ class BrowserTest(TestCase):
         self.assertEqual(response.content.split(','),
                          ['collectd.test.load.load.midterm',
                           'collectd.test.load.load.shortterm'])
+
+    def test_unicode_graph_name(self):
+        url = reverse('browser_my_graph')
+        user = User.objects.create_user('test', 'test@example.com', 'pass')
+        self.client.login(username='test', password='pass')
+
+        response = self.client.get(url, {'path': ''})
+        self.assertEqual(response.status_code, 200)
+        user.profile.mygraph_set.create(name=u'fòo', url='bar')
+        response = self.client.get(url, {'path': ''})
+        self.assertEqual(response.status_code, 200)
+        [leaf] = json.loads(response.content)
+        self.assertEqual(leaf['text'], u'fòo')


### PR DESCRIPTION
Calling `str()` on unicode strings makes python 2 unhappy…