### PR TITLE
Bump webapp version to 0.9.13

### DIFF
--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -26,7 +26,7 @@ except ImportError:
   rrdtool = False
 
 GRAPHITE_WEB_APP_SETTINGS_LOADED = False
-WEBAPP_VERSION = '0.9.12'
+WEBAPP_VERSION = '0.9.13'
 DEBUG = False
 JAVASCRIPT_DEBUG = False
 


### PR DESCRIPTION
This is *not* a formal release or tagging, just noticed this version set in settings.py so let's go ahead and bump it.