### PR TITLE
Sort nodes with numbers: [n1, n12, n2] changed to [n1, n2, n12]

### DIFF
--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -85,10 +85,10 @@ def search_view(request):
   return json_response_for(request, dict(metrics=results))
 
 
-node_sort_RE = re.compile(r"([^0-9]+|[0-9]+)")
+node_sort_RE = re.compile(r"(\d+)")
 
 def node_sort_key(node):
-  matches = node_sort_RE.findall(node.name)
+  matches = node_sort_RE.split(node.name)
   for index, value in enumerate(matches):
     if value.isdigit():
       matches[index] = int(matches[index])


### PR DESCRIPTION
Reordering nodes with any count of numbers in name.

For example:

Nodes list before fix:
[p1, p12s1, p12s12, p12s2, p2] 

Nodes list after fix:
[p1, p2, p12s1, p12s2, p12s12]