### PR TITLE
Add documentation about Dashboard CLI

### DIFF
--- a/docs/dashboard.rst
+++ b/docs/dashboard.rst
@@ -321,3 +321,50 @@ The format is as a set of key-value pairs separated by ampersands, like a query 
 ``drawNullAsZero=true&graphOnly=true``
   
 Any new graphs created after saving that as the default graph parameters would have unreported metrics graphed as zeroes and omit the grid lines.
+
+Using CLI to Export\Import Dashboards
+-------------------------------------
+The Dashboard CLI Tool allow to export\import dashboard from Graphite, to storing and it in local file system or in any VCS (Version Control System).
+The exported dashboards are stored in YAML format, that allow easy modify them.
+
+Install Dashboard CLI
+^^^^^^^^^^^^^^^^^^^^^
+You can install Graphite-Dashboard CLI tool with pip:
+```bash
+pip install graphite-dashboard
+``` 
+Or with clone repo:
+```bash
+git clone https://github.com/blacked/graphite-dashboard.git
+```
+
+Export\Import Dashboards using CLI Tool
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Export all dashboards from Graphite to local file system
+```bash
+$ graphite-dashboard copy '*' http://graphite.local ./dashboards
+```
+
+Import all dashboards from local file system to Graphite
+```bash
+$ graphite-dashboard copy '*' ./dashboards http://graphite.local
+```
+
+Copy specific dashboard from one Graphite server to another
+```bash
+$ graphite-dashboard copy TestDashboard http://graphite1.local http://graphite2.local
+```
+
+Synchronize Dashboards between multiple Graphite hosts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+When using multiple horizontal scaled graphite hosts with loadbalancer, it might be useful to synchronize dashboard between hosts.
+```bash
+$ graphite-dashboard sync '*' http://graphite1.local http://graphite2.local http://graphite3.local
+```
+
+Delete Dashboard using CLI
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+Delete dashboard 'TestDashboard' from multiple Graphite hosts:
+```bash
+$ graphite-dashboard delete 'TestDashboard' http://graphite1.local http://graphite2.local
+```


### PR DESCRIPTION
I wrote tool to export\import\copy\sync graphite dashboard (https://github.com/blacked/graphite-dashboard).
It allow to track dashboards in git, and because it keep dashboards as YAML files it also easy to modify them.
I suppose it will be useful to refer to it in Graphite  dashboards documentation.

