### PR TITLE
Relative time timezone fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 MANIFEST
 .vagrant/
+.venv/
 _trial_temp
 build
 dist

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,7 @@ simplejson==2.1.6
 django-tagging==0.3.6
 gunicorn
 pytz
+mock
 pyparsing==1.5.7
 cairocffi
 git+git://github.com/graphite-project/whisper.git#egg=whisper

--- a/webapp/graphite/render/attime.py
+++ b/webapp/graphite/render/attime.py
@@ -38,11 +38,11 @@ def parseATTime(s, tzinfo=None):
     offset = '-' + offset
   else:
     ref,offset = s,''
-  return (parseTimeReference(ref) + parseTimeOffset(offset)).astimezone(tzinfo)
+  return tzinfo.localize((parseTimeReference(ref) + parseTimeOffset(offset)), daylight)
 
 
 def parseTimeReference(ref):
-  if not ref or ref == 'now': return timezone.now()
+  if not ref or ref == 'now': return datetime.now()
 
   #Time-of-day reference
   i = ref.find(':')
@@ -65,7 +65,7 @@ def parseTimeReference(ref):
     hour,min = 16,0
     ref = ref[7:]
 
-  refDate = timezone.now().replace(hour=hour,minute=min,second=0)
+  refDate = datetime.now().replace(hour=hour,minute=min,second=0)
 
   #Day reference
   if ref in ('yesterday','today','tomorrow'): #yesterday, today, tomorrow

--- a/webapp/tests/test_attime.py
+++ b/webapp/tests/test_attime.py
@@ -1,4 +1,3 @@
-from mock import patch
 try:
     import unittest2 as unittest
 except ImportError:

--- a/webapp/tests/test_attime.py
+++ b/webapp/tests/test_attime.py
@@ -1,27 +1,88 @@
 from mock import patch
-import datetime
 try:
     import unittest2 as unittest
 except ImportError:
     import unittest
-from django.test import TestCase
-from django.utils import timezone
 from graphite.render.attime import parseTimeReference, parseATTime, parseTimeOffset, getUnitString
 
-MOCK_DATE = datetime.datetime(2015, 1, 1, 11, 00)
+from datetime import datetime, timedelta
+
+from django.utils import timezone
+from django.test import TestCase
+import pytz
+import mock
+
+class MockedDateTime(datetime):
+    def __new__(cls, *args, **kwargs):
+        return datetime.__new__(datetime, *args, **kwargs)
+    @classmethod
+    def now(cls):
+        return cls(2015, 3, 8, 12, 0, 0)
+
+@mock.patch('graphite.render.attime.datetime', MockedDateTime)
+class ATTimeTimezoneTests(TestCase):
+    default_tz = timezone.get_current_timezone()
+    specified_tz = pytz.timezone("America/Los_Angeles")
+    def test_should_return_absolute_time(self):
+        time_string = '12:0020150308'
+
+        expected_time = self.default_tz.localize(datetime.strptime(time_string,'%H:%M%Y%m%d'))
+        actual_time = parseATTime(time_string)
+        self.assertEqual(actual_time, expected_time)
+
+    def test_absolute_time_should_respect_tz(self):
+        time_string = '12:0020150308'
+        expected_time = self.specified_tz.localize(datetime.strptime(time_string, '%H:%M%Y%m%d'))
+        actual_time = parseATTime(time_string, self.specified_tz)
+        self.assertEqual(actual_time, expected_time)
+
+    def test_midnight(self):
+        expected_time = self.specified_tz.localize(datetime.strptime("0:00_20150308", '%H:%M_%Y%m%d'))
+        actual_time = parseATTime("midnight", self.specified_tz)
+        self.assertEqual(actual_time, expected_time)
+
+    def test_offset_with_tz(self):
+        expected_time = self.specified_tz.localize(datetime.strptime("5:00_20150308", '%H:%M_%Y%m%d'))
+        actual_time = parseATTime("midnight+5h", self.specified_tz)
+        self.assertEqual(actual_time, expected_time)
+
+    def test_relative_day_with_tz(self):
+        expected_time = self.specified_tz.localize(datetime.strptime("0:00_20150309", '%H:%M_%Y%m%d'))
+        actual_time = parseATTime("midnight_tomorrow", self.specified_tz)
+        self.assertEqual(actual_time, expected_time)
+
+    def test_relative_day_and_offset_with_tz(self):
+        expected_time = self.specified_tz.localize(datetime.strptime("3:00_20150309", '%H:%M_%Y%m%d'))
+        actual_time = parseATTime("midnight_tomorrow+3h", self.specified_tz)
+        self.assertEqual(actual_time, expected_time)
+
+    def test_should_return_current_time(self):
+        expected_time = self.default_tz.localize(datetime.strptime("12:00_20150308", '%H:%M_%Y%m%d'))
+        actual_time = parseATTime("now")
+        self.assertEqual(actual_time, expected_time)
+
+    def test_now_should_respect_tz(self):
+        expected_time = self.specified_tz.localize(datetime.strptime("12:00_20150308", '%H:%M_%Y%m%d'))
+        actual_time = parseATTime("now", self.specified_tz)
+        self.assertEqual(actual_time, expected_time)
+
+    def test_should_handle_dst_boundary(self):
+        expected_time = self.specified_tz.localize(datetime.strptime("03:00_20150308", '%H:%M_%Y%m%d'))
+        actual_time = parseATTime("midnight+2h", self.specified_tz)
+        self.assertEqual(actual_time, expected_time)
+
+MOCK_DATE = datetime(2015, 1, 1, 11, 00)
+
+class AnotherMockedDateTime(datetime):
+    def __new__(cls, *args, **kwargs):
+        return datetime.__new__(datetime, *args, **kwargs)
+    @classmethod
+    def now(cls):
+        return cls(2015, 1, 1, 11, 0, 0)
 
 
-class parseTimeTest(TestCase):
-
-    def setUp(self):
-        self.patcher = patch.object(timezone, 'now', return_value=MOCK_DATE)
-        self.mock_now = self.patcher.start()
-
-    def tearDown(self):
-        self.patcher.stop()
-
-
-class parseTimeReferenceTest(parseTimeTest):
+@mock.patch('graphite.render.attime.datetime', AnotherMockedDateTime)
+class parseTimeReferenceTest(TestCase):
 
     def test_parse_empty_return_now(self):
         time_ref = parseTimeReference('')
@@ -45,67 +106,67 @@ class parseTimeReferenceTest(parseTimeTest):
 
     def test_parse_hour_return_hour_of_today(self):
         time_ref = parseTimeReference("8:50")
-        expected = datetime.datetime(MOCK_DATE.year, MOCK_DATE.month, MOCK_DATE.day, 8, 50)
+        expected = datetime(MOCK_DATE.year, MOCK_DATE.month, MOCK_DATE.day, 8, 50)
         self.assertEquals(time_ref, expected)
 
     def test_parse_hour_am(self):
         time_ref = parseTimeReference("8:50am")
-        expected = datetime.datetime(MOCK_DATE.year, MOCK_DATE.month, MOCK_DATE.day, 8, 50)
+        expected = datetime(MOCK_DATE.year, MOCK_DATE.month, MOCK_DATE.day, 8, 50)
         self.assertEquals(time_ref, expected)
 
     def test_parse_hour_pm(self):
         time_ref = parseTimeReference("8:50pm")
-        expected = datetime.datetime(MOCK_DATE.year, MOCK_DATE.month, MOCK_DATE.day, 20, 50)
+        expected = datetime(MOCK_DATE.year, MOCK_DATE.month, MOCK_DATE.day, 20, 50)
         self.assertEquals(time_ref, expected)
 
     def test_parse_noon(self):
         time_ref = parseTimeReference("noon")
-        expected = datetime.datetime(MOCK_DATE.year, MOCK_DATE.month, MOCK_DATE.day, 12, 0)
+        expected = datetime(MOCK_DATE.year, MOCK_DATE.month, MOCK_DATE.day, 12, 0)
         self.assertEquals(time_ref, expected)
 
     def test_parse_midnight(self):
         time_ref = parseTimeReference("midnight")
-        expected = datetime.datetime(MOCK_DATE.year, MOCK_DATE.month, MOCK_DATE.day, 0, 0)
+        expected = datetime(MOCK_DATE.year, MOCK_DATE.month, MOCK_DATE.day, 0, 0)
         self.assertEquals(time_ref, expected)
 
     def test_parse_teatime(self):
         time_ref = parseTimeReference("teatime")
-        expected = datetime.datetime(MOCK_DATE.year, MOCK_DATE.month, MOCK_DATE.day, 16, 0)
+        expected = datetime(MOCK_DATE.year, MOCK_DATE.month, MOCK_DATE.day, 16, 0)
         self.assertEquals(time_ref, expected)
 
     def test_parse_yesterday(self):
         time_ref = parseTimeReference("yesterday")
-        expected = datetime.datetime(2014, 12, 31, 0, 0)
+        expected = datetime(2014, 12, 31, 0, 0)
         self.assertEquals(time_ref, expected)
 
     def test_parse_tomorrow(self):
         time_ref = parseTimeReference("tomorrow")
-        expected = datetime.datetime(2015, 1, 2, 0, 0)
+        expected = datetime(2015, 1, 2, 0, 0)
         self.assertEquals(time_ref, expected)
 
     def test_parse_MM_slash_DD_slash_YY(self):
         time_ref = parseTimeReference("02/25/15")
-        expected = datetime.datetime(2015, 2, 25, 0, 0)
+        expected = datetime(2015, 2, 25, 0, 0)
         self.assertEquals(time_ref, expected)
 
     def test_parse_MM_slash_DD_slash_YYYY(self):
         time_ref = parseTimeReference("02/25/2015")
-        expected = datetime.datetime(2015, 2, 25, 0, 0)
+        expected = datetime(2015, 2, 25, 0, 0)
         self.assertEquals(time_ref, expected)
 
     def test_parse_YYYYMMDD(self):
         time_ref = parseTimeReference("20140606")
-        expected = datetime.datetime(2014, 6, 6, 0, 0)
+        expected = datetime(2014, 6, 6, 0, 0)
         self.assertEquals(time_ref, expected)
 
     def test_parse_MonthName_DayOfMonth_onedigits(self):
         time_ref = parseTimeReference("january8")
-        expected = datetime.datetime(2015, 1, 8, 0, 0)
+        expected = datetime(2015, 1, 8, 0, 0)
         self.assertEquals(time_ref, expected)
 
     def test_parse_MonthName_DayOfMonth_twodigits(self):
         time_ref = parseTimeReference("january10")
-        expected = datetime.datetime(2015, 1, 10, 0, 0)
+        expected = datetime(2015, 1, 10, 0, 0)
         self.assertEquals(time_ref, expected)
 
     def test_parse_MonthName_DayOfMonth_threedigits_raise_ValueError(self):
@@ -118,7 +179,7 @@ class parseTimeReferenceTest(parseTimeTest):
 
     def test_parse_monday_return_monday_before_now(self):
         time_ref = parseTimeReference("monday")
-        expected = datetime.datetime(2014, 12, 29, 0, 0)
+        expected = datetime(2014, 12, 29, 0, 0)
         self.assertEquals(time_ref, expected)
 
 
@@ -126,7 +187,7 @@ class parseTimeOffsetTest(TestCase):
 
     def test_parse_None_returns_empty_timedelta(self):
         time_ref = parseTimeOffset(None)
-        expected = datetime.timedelta(0)
+        expected = timedelta(0)
         self.assertEquals(time_ref, expected)
 
     def test_parse_integer_raises_TypeError(self):
@@ -151,72 +212,72 @@ class parseTimeOffsetTest(TestCase):
 
     def test_parse_minus_only_returns_zero(self):
         time_ref = parseTimeOffset("-")
-        expected = datetime.timedelta(0)
+        expected = timedelta(0)
         self.assertEquals(time_ref, expected)
 
     def test_parse_plus_only_returns_zero(self):
         time_ref = parseTimeOffset("+")
-        expected = datetime.timedelta(0)
+        expected = timedelta(0)
         self.assertEquals(time_ref, expected)
 
     def test_parse_ten_days(self):
         time_ref = parseTimeOffset("10days")
-        expected = datetime.timedelta(10)
+        expected = timedelta(10)
         self.assertEquals(time_ref, expected)
 
     def test_parse_zero_days(self):
         time_ref = parseTimeOffset("0days")
-        expected = datetime.timedelta(0)
+        expected = timedelta(0)
         self.assertEquals(time_ref, expected)
 
     def test_parse_minus_ten_days(self):
         time_ref = parseTimeOffset("-10days")
-        expected = datetime.timedelta(-10)
+        expected = timedelta(-10)
         self.assertEquals(time_ref, expected)
 
     def test_parse_five_seconds(self):
         time_ref = parseTimeOffset("5seconds")
-        expected = datetime.timedelta(seconds=5)
+        expected = timedelta(seconds=5)
         self.assertEquals(time_ref, expected)
 
     def test_parse_five_minutes(self):
         time_ref = parseTimeOffset("5minutes")
-        expected = datetime.timedelta(minutes=5)
+        expected = timedelta(minutes=5)
         self.assertEquals(time_ref, expected)
 
     def test_parse_five_hours(self):
         time_ref = parseTimeOffset("5hours")
-        expected = datetime.timedelta(hours=5)
+        expected = timedelta(hours=5)
         self.assertEquals(time_ref, expected)
 
     def test_parse_five_weeks(self):
         time_ref = parseTimeOffset("5weeks")
-        expected = datetime.timedelta(weeks=5)
+        expected = timedelta(weeks=5)
         self.assertEquals(time_ref, expected)
 
     def test_parse_one_month_returns_thirty_days(self):
         time_ref = parseTimeOffset("1month")
-        expected = datetime.timedelta(30)
+        expected = timedelta(30)
         self.assertEquals(time_ref, expected)
 
     def test_parse_two_months_returns_sixty_days(self):
         time_ref = parseTimeOffset("2months")
-        expected = datetime.timedelta(60)
+        expected = timedelta(60)
         self.assertEquals(time_ref, expected)
 
     def test_parse_twelve_months_returns_360_days(self):
         time_ref = parseTimeOffset("12months")
-        expected = datetime.timedelta(360)
+        expected = timedelta(360)
         self.assertEquals(time_ref, expected)
 
     def test_parse_one_year_returns_365_days(self):
         time_ref = parseTimeOffset("1year")
-        expected = datetime.timedelta(365)
+        expected = timedelta(365)
         self.assertEquals(time_ref, expected)
 
     def test_parse_two_years_returns_730_days(self):
         time_ref = parseTimeOffset("2years")
-        expected = datetime.timedelta(730)
+        expected = timedelta(730)
         self.assertEquals(time_ref, expected)
 
 
@@ -273,10 +334,10 @@ class getUnitStringTest(TestCase):
             result = getUnitString(1)
 
 
-class parseATTimeTest(parseTimeTest):
+class parseATTimeTest(TestCase):
 
     @unittest.expectedFailure
     def test_parse_noon_plus_yesterday(self):
         time_ref = parseATTime("noon+yesterday")
-        expected = datetime.datetime(MOCK_DATE.year, MOCK_DATE.month, MOCK_DATE.day - 1, 12, 00)
+        expected = datetime(MOCK_DATE.year, MOCK_DATE.month, MOCK_DATE.day - 1, 12, 00)
         self.assertEquals(time_ref, expected)


### PR DESCRIPTION
Changing `attime.py`'s treatment of relative times with specified timezones to have consistent behaviour with absolute times/restore behaviour from 0.9.12, as discussed in #1151 