### PR TITLE
Add --interface flag, to allow devel server to only listen on 127.0.0.1

### DIFF
--- a/bin/run-graphite-devel-server.py
+++ b/bin/run-graphite-devel-server.py
@@ -8,7 +8,7 @@ option_parser = OptionParser(usage='''
 %prog [options] GRAPHITE_ROOT
 ''')
 option_parser.add_option('--port', default=8080, action='store', type=int, help='Port to listen on')
-option_parser.add_option('--interface', default="0.0.0.0", action='store', help='Interface to listen on')
+option_parser.add_option('--interface', default='0.0.0.0', action='store', help='Interface to listen on')
 option_parser.add_option('--libs', default=None, help='Path to the directory containing the graphite python package')
 option_parser.add_option('--noreload', action='store_true', help='Disable monitoring for changes')
 

--- a/bin/run-graphite-devel-server.py
+++ b/bin/run-graphite-devel-server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/local/opt/python/bin/python2.7
 
 import sys, os
 import subprocess
@@ -8,6 +8,7 @@ option_parser = OptionParser(usage='''
 %prog [options] GRAPHITE_ROOT
 ''')
 option_parser.add_option('--port', default=8080, action='store', type=int, help='Port to listen on')
+option_parser.add_option('--interface', default="0.0.0.0", action='store', help='Interface to listen on')
 option_parser.add_option('--libs', default=None, help='Path to the directory containing the graphite python package')
 option_parser.add_option('--noreload', action='store_true', help='Disable monitoring for changes')
 
@@ -45,7 +46,7 @@ command = [
   'runserver',
   '--pythonpath', python_path,
   '--settings', 'graphite.settings',
-  '0.0.0.0:%d' % options.port
+  '%s:%d' % (options.interface, options.port)
 ]
 
 if options.noreload:

--- a/bin/run-graphite-devel-server.py
+++ b/bin/run-graphite-devel-server.py
@@ -1,4 +1,4 @@
-#!/usr/local/opt/python/bin/python2.7
+#!/usr/bin/env python
 
 import sys, os
 import subprocess


### PR DESCRIPTION
Defaults to 0.0.0.0, so existing behavior remains unchanged. But it's easier when running a dev instance on a laptop and not wanting to mess around with OS X firewall setting, to just specify --interface=127.0.0.1 instead.