### PR TITLE
fix ordering of sorting on saved graphs

### DIFF
--- a/webapp/graphite/browser/views.py
+++ b/webapp/graphite/browser/views.py
@@ -237,7 +237,7 @@ def userGraphLookup(request):
     no_graphs.update(leafNode)
     nodes.append(no_graphs)
 
-  nodes.sort()
+  nodes.sort(key=lambda node: node['allowChildren'], reverse = True)
 
   return json_response(nodes, request)
 

--- a/webapp/graphite/browser/views.py
+++ b/webapp/graphite/browser/views.py
@@ -178,7 +178,7 @@ def userGraphLookup(request):
   try:
 
     if not username:
-      profiles = Profile.objects.exclude(user__username='default')
+      profiles = Profile.objects.exclude(user__username='default').order_by('user__username')
 
       for profile in profiles:
         if profile.mygraph_set.count():


### PR DESCRIPTION
The model returns the graphs sorted with "order_by('name')". This change ensures branch nodes are give priority over leaf nodes. Python's stable sort preserves the ordering by graph name.