### PR TITLE
Hot data cache

### DIFF
--- a/webapp/graphite/intervals.py
+++ b/webapp/graphite/intervals.py
@@ -118,6 +118,8 @@ class Interval:
     end = max(self.end, other.end)
     return Interval(start, end)
 
+  def includes(self, other, precision = 60):
+    return self.start <= other.start and self.end >= other.end - precision
 
 def union_overlapping(intervals):
   """Union any overlapping intervals in the given set."""

--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -79,10 +79,11 @@
 ## Data directories
 # NOTE: If any directory is unreadable in STANDARD_DIRS it will break metric browsing
 #CERES_DIR = '/opt/graphite/storage/ceres'
+#HOT_WHISPER_DIR = '/opt/graphite/storage/how_whisper'
 #WHISPER_DIR = '/opt/graphite/storage/whisper'
 #RRD_DIR = '/opt/graphite/storage/rrd'
 # Data directories using the "Standard" finder (i.e. not Ceres)
-#STANDARD_DIRS = [WHISPER_DIR, RRD_DIR] # Default: set from the above variables
+#STANDARD_DIRS = [HOT_WHISPER_DIR, WHISPER_DIR, RRD_DIR] # Default: set from the above variables
 #LOG_DIR = '/opt/graphite/storage/log/webapp'
 #INDEX_FILE = '/opt/graphite/storage/index'  # Search index file
 

--- a/webapp/graphite/node.py
+++ b/webapp/graphite/node.py
@@ -9,6 +9,9 @@ class Node(object):
     self.local = True
     self.is_leaf = False
 
+  def __str__(self):
+    return '%s(path=%s)' % (self.__class__.__name__, self.path)
+
   def __repr__(self):
     return '<%s[%x]: %s>' % (self.__class__.__name__, id(self), self.path)
 
@@ -28,6 +31,9 @@ class LeafNode(Node):
 
   def fetch(self, startTime, endTime):
     return self.reader.fetch(startTime, endTime)
+
+  def __str__(self):
+    return 'LeafNode(path=%s, reader=%s)' % (id(self), self.path, self.reader)
 
   def __repr__(self):
     return '<LeafNode[%x]: %s (%s)>' % (id(self), self.path, self.reader)

--- a/webapp/graphite/readers.py
+++ b/webapp/graphite/readers.py
@@ -42,6 +42,19 @@ class MultiReader(object):
     return IntervalSet( sorted(interval_sets) )
 
   def fetch(self, startTime, endTime):
+    # get 1st available node which covers the full range
+    interval = Interval(startTime, endTime)
+    best_node = None
+    for n in self.nodes:
+      for i in n.intervals:
+        if i.includes(interval):
+          best_node = n
+          break
+
+    # if there is an interval with full coverage - we use it to reduce reads
+    if best_node:
+      return best_node.fetch(startTime, endTime)
+
     # Start the fetch on each node
     results = [ n.fetch(startTime, endTime) for n in self.nodes ]
 
@@ -81,7 +94,7 @@ class MultiReader(object):
       # Look for the finer precision value first if available
       i1 = (t - start1) / step1
 
-      if len(values1) > i1:
+      if 0 <= i1 < len(values1):
         v1 = values1[i1]
       else:
         v1 = None
@@ -89,7 +102,7 @@ class MultiReader(object):
       if v1 is None:
         i2 = (t - start2) / step2
 
-        if len(values2) > i2:
+        if 0 <= i2 < len(values2):
           v2 = values2[i2]
         else:
           v2 = None

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -94,7 +94,7 @@ def fetchData(requestContext, pathExpr):
   startTime = int( epoch( requestContext['startTime'] ) )
   endTime   = int( epoch( requestContext['endTime'] ) )
 
-  def _fetchData(pathExpr,startTime, endTime, requestContext, seriesList):
+  def _fetchData(pathExpr, startTime, endTime, requestContext, seriesList):
     matching_nodes = STORE.find(pathExpr, startTime, endTime, local=requestContext['localOnly'])
     fetches = [(node, node.fetch(startTime, endTime)) for node in matching_nodes if node.is_leaf]
 

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -44,6 +44,7 @@ INDEX_FILE = ''
 LOG_DIR = ''
 CERES_DIR = ''
 WHISPER_DIR = ''
+HOT_WHISPER_DIR = ''
 RRD_DIR = ''
 STANDARD_DIRS = []
 
@@ -165,6 +166,8 @@ if not LOG_DIR:
   LOG_DIR = join(STORAGE_DIR, 'log', 'webapp')
 if not WHISPER_DIR:
   WHISPER_DIR = join(STORAGE_DIR, 'whisper/')
+if not HOT_WHISPER_DIR:
+    HOT_WHISPER_DIR = join(STORAGE_DIR, 'hot_whisper/')
 if not CERES_DIR:
   CERES_DIR = join(STORAGE_DIR, 'ceres/')
 if not RRD_DIR:
@@ -172,6 +175,9 @@ if not RRD_DIR:
 if not STANDARD_DIRS:
   try:
     import whisper  # noqa
+    if os.path.exists(HOT_WHISPER_DIR):
+      STANDARD_DIRS.append(HOT_WHISPER_DIR)
+
     if os.path.exists(WHISPER_DIR):
       STANDARD_DIRS.append(WHISPER_DIR)
   except ImportError:

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -12,7 +12,7 @@ from graphite.remote_storage import RemoteStore
 from graphite.node import LeafNode
 from graphite.intervals import Interval, IntervalSet
 from graphite.readers import MultiReader
-
+# from graphite.logger import log
 
 def get_finder(finder_path):
   module_name, class_name = finder_path.rsplit('.', 1)
@@ -130,6 +130,8 @@ class Store:
         best_candidate = min(leaf_nodes, key=distance_to_requested_interval)
         if distance_to_requested_interval(best_candidate) <= settings.FIND_TOLERANCE:
           minimal_node_set.append(best_candidate)
+
+      # log.metric_access("Found %s nodes for a query %s: %s", len(minimal_node_set), query, minimal_node_set)
 
       if len(minimal_node_set) == 1:
         yield minimal_node_set.pop()

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -12,6 +12,7 @@ from graphite.remote_storage import RemoteStore
 from graphite.node import LeafNode
 from graphite.intervals import Interval, IntervalSet
 from graphite.readers import MultiReader
+from graphite.logger import log
 
 
 def get_finder(finder_path):
@@ -81,7 +82,7 @@ class Store:
         continue
 
       # Calculate best minimal node set
-      minimal_node_set = set()
+      minimal_node_set = []
       covered_intervals = IntervalSet([])
 
       # If the query doesn't fall entirely within the FIND_TOLERANCE window
@@ -105,7 +106,7 @@ class Store:
       for node in leaf_nodes:
         if node.local and measure_of_added_coverage(node, False) > 0:
           nodes_remaining.remove(node)
-          minimal_node_set.add(node)
+          minimal_node_set.append(node)
           covered_intervals = covered_intervals.union(node.intervals)
 
       while nodes_remaining:
@@ -116,7 +117,7 @@ class Store:
           break
 
         nodes_remaining.remove(best_node)
-        minimal_node_set.add(best_node)
+        minimal_node_set.append(best_node)
         covered_intervals = covered_intervals.union(best_node.intervals)
 
       # Sometimes the requested interval falls within the caching window.
@@ -129,7 +130,7 @@ class Store:
 
         best_candidate = min(leaf_nodes, key=distance_to_requested_interval)
         if distance_to_requested_interval(best_candidate) <= settings.FIND_TOLERANCE:
-          minimal_node_set.add(best_candidate)
+          minimal_node_set.append(best_candidate)
 
       if len(minimal_node_set) == 1:
         yield minimal_node_set.pop()

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -40,20 +40,20 @@ class Store:
     if not local:
       remote_requests = [ r.find(query) for r in self.remote_stores if r.available ]
 
-    matching_nodes = set()
+    matching_nodes = []
 
     # Search locally
     for finder in self.finders:
       for node in finder.find_nodes(query):
         #log.info("find() :: local :: %s" % node)
-        matching_nodes.add(node)
+        matching_nodes.append(node)
 
     # Gather remote search results
     if not local:
       for request in remote_requests:
         for node in request.get_results():
           #log.info("find() :: remote :: %s from %s" % (node,request.store.host))
-          matching_nodes.add(node)
+          matching_nodes.append(node)
 
     # Group matching nodes by their path
     nodes_by_path = {}

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -12,7 +12,6 @@ from graphite.remote_storage import RemoteStore
 from graphite.node import LeafNode
 from graphite.intervals import Interval, IntervalSet
 from graphite.readers import MultiReader
-from graphite.logger import log
 
 
 def get_finder(finder_path):

--- a/webapp/tests/settings.py
+++ b/webapp/tests/settings.py
@@ -42,10 +42,13 @@ os.mkdir(LOG_DIR)
 WHISPER_DIR = join(TEMP_GRAPHITE_DIR, 'whisper/')
 os.mkdir(WHISPER_DIR)
 
+HOT_WHISPER_DIR = join(TEMP_GRAPHITE_DIR, 'hot_whisper/')
+os.mkdir(HOT_WHISPER_DIR)
+
 # Manually add WHISPER_DIR to STANDARD_DIRS
 # STANDARD_DIRS is generated programtically in settings.py, the modification of
 # WHISPER_DIR above does not change the value in STANDARD_DIRS.
-STANDARD_DIRS = [WHISPER_DIR]
+STANDARD_DIRS = [HOT_WHISPER_DIR, WHISPER_DIR]
 
 INDEX_FILE = os.path.join(TEMP_GRAPHITE_DIR, 'index')
 

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -17,155 +17,158 @@ LOGGER = logging.getLogger()
 
 # logging.NullHandler is a python 2.7ism
 if hasattr(logging, "NullHandler"):
-    LOGGER.addHandler(logging.NullHandler())
+  LOGGER.addHandler(logging.NullHandler())
 
 
 class RenderTest(TestCase):
-    db_std = os.path.join(settings.WHISPER_DIR, 'test.wsp')
-    db_hot = os.path.join(settings.HOT_WHISPER_DIR, 'test.wsp')
+  db_std = os.path.join(settings.WHISPER_DIR, 'test.wsp')
+  db_hot = os.path.join(settings.HOT_WHISPER_DIR, 'test.wsp')
 
-    def wipe_whisper(self):
-        try:
-            os.remove(self.db_std)
-        except OSError:
-            pass
+  def wipe_whisper(self):
+    try:
+      os.remove(self.db_std)
+    except OSError:
+      pass
 
-        try:
-            os.remove(self.db_hot)
-        except OSError:
-            pass
+    try:
+      os.remove(self.db_hot)
+    except OSError:
+      pass
 
-    def test_render_view(self):
-        url = reverse('graphite.render.views.renderView')
+  def test_render_view(self):
+    url = reverse('graphite.render.views.renderView')
 
-        ts = int(time.time())
-        std_points = 60
-        hot_points = 10
-        request_fields = {'target': 'test', 'format': 'json', 'local': 1, 'until': ts, 'from': ts - 6}
+    ts = int(time.time())
+    std_points = 60
+    hot_points = 10
+    request_fields = {'target': 'test', 'format': 'json', 'local': 1, 'until': ts, 'from': ts - 6}
 
-        response = self.client.get(url, request_fields)
-        self.assertEqual(json.loads(response.content), [])
-        self.assertTrue(response.has_header('Expires'))
-        self.assertTrue(response.has_header('Last-Modified'))
-        self.assertTrue(response.has_header('Cache-Control'))
+    response = self.client.get(url, request_fields)
+    self.assertEqual(json.loads(response.content), [])
+    self.assertTrue(response.has_header('Expires'))
+    self.assertTrue(response.has_header('Last-Modified'))
+    self.assertTrue(response.has_header('Cache-Control'))
 
-        response = self.client.get(url, {'target': 'test'})
-        self.assertEqual(response['Content-Type'], 'image/png')
-        self.assertTrue(response.has_header('Expires'))
-        self.assertTrue(response.has_header('Last-Modified'))
-        self.assertTrue(response.has_header('Cache-Control'))
+    response = self.client.get(url, {'target': 'test'})
+    self.assertEqual(response['Content-Type'], 'image/png')
+    self.assertTrue(response.has_header('Expires'))
+    self.assertTrue(response.has_header('Last-Modified'))
+    self.assertTrue(response.has_header('Cache-Control'))
 
-        self.addCleanup(self.wipe_whisper)
+    self.addCleanup(self.wipe_whisper)
 
-        std_data_set = [[float(i) / 10, ts - std_points + 1 + i] for i in range(std_points - 1)]
-        hot_data_set = [[float(i) / 100, ts - hot_points + 1 + i] for i in range(hot_points - 1)]
+    std_data_set = [[float(i) / 10, ts - std_points + 1 + i] for i in range(std_points - 1)]
+    hot_data_set = [[float(i) / 100, ts - hot_points + 1 + i] for i in range(hot_points - 1)]
 
-        whisper.create(self.db_std, [(1, std_points)])
+    whisper.create(self.db_std, [(1, std_points)])
 
-        for [value, timestamp] in std_data_set:
-            whisper.update(self.db_std, value, timestamp)
+    for [value, timestamp] in std_data_set:
+      try:
+        whisper.update(self.db_std, value, timestamp)
+      except whisper.TimestampNotCovered:
+        pass
 
-        response = self.client.get(url, request_fields)
-        data = json.loads(response.content)
-        data_points = data[0]['datapoints'][-4:] \
-            if data[0]['datapoints'][-1][0] is not None \
-            else data[0]['datapoints'][-5:-1]
+    response = self.client.get(url, request_fields)
+    data = json.loads(response.content)
+    data_points = data[0]['datapoints'][-4:] \
+      if data[0]['datapoints'][-1][0] is not None \
+      else data[0]['datapoints'][-5:-1]
 
-        self.assertEqual(data_points, std_data_set[-4:])
+    self.assertEqual(data_points, std_data_set[-4:])
 
-        whisper.create(self.db_hot, [(1, hot_points)])
+    whisper.create(self.db_hot, [(1, hot_points)])
 
-        for [value, timestamp] in hot_data_set:
-            whisper.update(self.db_hot, value, timestamp)
+    for [value, timestamp] in hot_data_set:
+      whisper.update(self.db_hot, value, timestamp)
 
-        response = self.client.get(url, request_fields)
-        data = json.loads(response.content)
-        data_points = data[0]['datapoints'][-4:] \
-            if data[0]['datapoints'][-1][0] is not None \
-            else data[0]['datapoints'][-5:-1]
+    response = self.client.get(url, request_fields)
+    data = json.loads(response.content)
+    data_points = data[0]['datapoints'][-4:] \
+      if data[0]['datapoints'][-1][0] is not None \
+      else data[0]['datapoints'][-5:-1]
 
-        self.assertEqual(data_points, hot_data_set[-4:])
+    self.assertEqual(data_points, hot_data_set[-4:])
 
-        request_fields['from'] = ts - hot_points - 1
-        response = self.client.get(url, request_fields)
-        data = json.loads(response.content)
-        data_points = data[0]['datapoints'][-4:] \
-            if data[0]['datapoints'][-1][0] is not None \
-            else data[0]['datapoints'][-5:-1]
+    request_fields['from'] = ts - hot_points - 1
+    response = self.client.get(url, request_fields)
+    data = json.loads(response.content)
+    data_points = data[0]['datapoints'][-4:] \
+      if data[0]['datapoints'][-1][0] is not None \
+      else data[0]['datapoints'][-5:-1]
 
-        self.assertEqual(data_points, std_data_set[-4:])
+    self.assertEqual(data_points, std_data_set[-4:])
 
-    def test_hash_request(self):
-        # Requests with the same parameters should hash to the same values,
-        # regardless of HTTP method.
-        target_qd = QueryDict('&target=randomWalk(%27random%20walk%27)'
-                       '&target=randomWalk(%27random%20walk2%27)'
-                       '&target=randomWalk(%27random%20walk3%27)')
-        empty_qd = QueryDict('')
-        post_request = HttpRequest()
-        post_request.POST = target_qd.copy()
-        post_request.GET = empty_qd.copy()
-        get_request = HttpRequest()
-        get_request.GET = target_qd.copy()
-        get_request.POST = empty_qd.copy()
+  def test_hash_request(self):
+    # Requests with the same parameters should hash to the same values,
+    # regardless of HTTP method.
+    target_qd = QueryDict('&target=randomWalk(%27random%20walk%27)'
+                          '&target=randomWalk(%27random%20walk2%27)'
+                          '&target=randomWalk(%27random%20walk3%27)')
+    empty_qd = QueryDict('')
+    post_request = HttpRequest()
+    post_request.POST = target_qd.copy()
+    post_request.GET = empty_qd.copy()
+    get_request = HttpRequest()
+    get_request.GET = target_qd.copy()
+    get_request.POST = empty_qd.copy()
 
-        self.assertEqual(hashRequest(get_request), hashRequest(post_request))
+    self.assertEqual(hashRequest(get_request), hashRequest(post_request))
 
-        # Check that POST parameters are included in cache key calculations
-        post_request_with_params = HttpRequest()
-        post_request_with_params.GET = empty_qd.copy()
-        post_request_with_params.POST = target_qd.copy()
-        empty_post_request = HttpRequest()
-        empty_post_request.GET = empty_qd.copy()
-        empty_post_request.POST = empty_qd.copy()
+    # Check that POST parameters are included in cache key calculations
+    post_request_with_params = HttpRequest()
+    post_request_with_params.GET = empty_qd.copy()
+    post_request_with_params.POST = target_qd.copy()
+    empty_post_request = HttpRequest()
+    empty_post_request.GET = empty_qd.copy()
+    empty_post_request.POST = empty_qd.copy()
 
-        self.assertNotEqual(hashRequest(post_request_with_params),
-                            hashRequest(empty_post_request))
+    self.assertNotEqual(hashRequest(post_request_with_params),
+                        hashRequest(empty_post_request))
 
-        # Check that changing the order of the parameters has no impact on the
-        # cache key
-        request_params = HttpRequest()
-        request_qd = QueryDict('&foo=1&bar=2')
-        request_params.GET = request_qd.copy()
-        request_params.POST = empty_qd.copy()
+    # Check that changing the order of the parameters has no impact on the
+    # cache key
+    request_params = HttpRequest()
+    request_qd = QueryDict('&foo=1&bar=2')
+    request_params.GET = request_qd.copy()
+    request_params.POST = empty_qd.copy()
 
-        reverse_request_params = HttpRequest()
-        reverse_request_qd = QueryDict('&bar=2&foo=1')
-        reverse_request_params.GET = reverse_request_qd.copy()
-        reverse_request_params.POST = empty_qd.copy()
+    reverse_request_params = HttpRequest()
+    reverse_request_qd = QueryDict('&bar=2&foo=1')
+    reverse_request_params.GET = reverse_request_qd.copy()
+    reverse_request_params.POST = empty_qd.copy()
 
-        self.assertEqual(hashRequest(request_params),
-                        hashRequest(reverse_request_params))
+    self.assertEqual(hashRequest(request_params),
+                     hashRequest(reverse_request_params))
 
-    def test_hash_data(self):
-        targets = ['foo=1', 'bar=2']
-        start_time = datetime.fromtimestamp(0)
-        end_time = datetime.fromtimestamp(1000)
-        self.assertEqual(hashData(targets, start_time, end_time),
-                        hashData(reversed(targets), start_time, end_time))
+  def test_hash_data(self):
+    targets = ['foo=1', 'bar=2']
+    start_time = datetime.fromtimestamp(0)
+    end_time = datetime.fromtimestamp(1000)
+    self.assertEqual(hashData(targets, start_time, end_time),
+                     hashData(reversed(targets), start_time, end_time))
 
-    def test_correct_timezone(self):
-        url = reverse('graphite.render.views.renderView')
-        response = self.client.get(url, {
-                 'target': 'constantLine(12)',
-                 'format': 'json',
-                 'from': '07:01_20140226',
-                 'until': '08:01_20140226',
-                 # tz is UTC
-        })
-        data = json.loads(response.content)[0]['datapoints']
-        # all the from/until/tz combinations lead to the same window
-        expected = [[12, 1393398060], [12, 1393401660]]
-        self.assertEqual(data, expected)
+  def test_correct_timezone(self):
+    url = reverse('graphite.render.views.renderView')
+    response = self.client.get(url, {
+      'target': 'constantLine(12)',
+      'format': 'json',
+      'from': '07:01_20140226',
+      'until': '08:01_20140226',
+      # tz is UTC
+    })
+    data = json.loads(response.content)[0]['datapoints']
+    # all the from/until/tz combinations lead to the same window
+    expected = [[12, 1393398060], [12, 1393401660]]
+    self.assertEqual(data, expected)
 
-        response = self.client.get(url, {
-                 'target': 'constantLine(12)',
-                 'format': 'json',
-                 'from': '08:01_20140226',
-                 'until': '09:01_20140226',
-                 'tz': 'Europe/Berlin',
-        })
-        data = json.loads(response.content)[0]['datapoints']
-        # all the from/until/tz combinations lead to the same window
-        expected = [[12, 1393398060], [12, 1393401660]]
-        self.assertEqual(data, expected)
+    response = self.client.get(url, {
+      'target': 'constantLine(12)',
+      'format': 'json',
+      'from': '08:01_20140226',
+      'until': '09:01_20140226',
+      'tz': 'Europe/Berlin',
+      })
+    data = json.loads(response.content)[0]['datapoints']
+    # all the from/until/tz combinations lead to the same window
+    expected = [[12, 1393398060], [12, 1393401660]]
+    self.assertEqual(data, expected)

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -92,7 +92,7 @@ class RenderTest(TestCase):
         data_points = data[0]['datapoints'][-4:] \
             if data[0]['datapoints'][-1][0] is not None \
             else data[0]['datapoints'][-5:-1]
-        
+
         self.assertEqual(data_points, std_data_set[-4:])
 
     def test_hash_request(self):

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -57,8 +57,8 @@ class RenderTest(TestCase):
 
         self.addCleanup(self.wipe_whisper)
 
-        std_data_set = [[float(i) / 10, ts - std_points + 1 + i] for i in range(std_points)]
-        hot_data_set = [[float(i) / 100, ts - hot_points + 1 + i] for i in range(hot_points)]
+        std_data_set = [[float(i) / 10, ts - std_points + 1 + i] for i in range(std_points - 1)]
+        hot_data_set = [[float(i) / 100, ts - hot_points + 1 + i] for i in range(hot_points - 1)]
 
         whisper.create(self.db_std, [(1, std_points)])
 
@@ -67,7 +67,10 @@ class RenderTest(TestCase):
 
         response = self.client.get(url, request_fields)
         data = json.loads(response.content)
-        data_points = data[0]['datapoints'][-4:]
+        data_points = data[0]['datapoints'][-4:] \
+            if data[0]['datapoints'][-1][0] is not None \
+            else data[0]['datapoints'][-5:-1]
+
         self.assertEqual(data_points, std_data_set[-4:])
 
         whisper.create(self.db_hot, [(1, hot_points)])
@@ -77,13 +80,19 @@ class RenderTest(TestCase):
 
         response = self.client.get(url, request_fields)
         data = json.loads(response.content)
-        data_points = data[0]['datapoints'][-4:]
+        data_points = data[0]['datapoints'][-4:] \
+            if data[0]['datapoints'][-1][0] is not None \
+            else data[0]['datapoints'][-5:-1]
+
         self.assertEqual(data_points, hot_data_set[-4:])
 
         request_fields['from'] = ts - hot_points - 1
         response = self.client.get(url, request_fields)
         data = json.loads(response.content)
-        data_points = data[0]['datapoints'][-4:]
+        data_points = data[0]['datapoints'][-4:] \
+            if data[0]['datapoints'][-1][0] is not None \
+            else data[0]['datapoints'][-5:-1]
+        
         self.assertEqual(data_points, std_data_set[-4:])
 
     def test_hash_request(self):


### PR DESCRIPTION
This is a 2nd part of the Hot data cache feature. Idea of the feature is add an alternative location for metrics to serve dashboards with short time window -2 - -3 hours. Ideally this location should be located on an in-memory file system.

Here is how it works: There are 2 dirs are in the STANDARD_DIRS variable. Later system process these directories in order. If it can find a metric with enough data in the 1st directory - it will only read a file from there but will skip reading from the 2nd location. If the hot-data file does not provide enough information - the regular file will be used instead.