### PR TITLE
Add function 'groupByNodes' to group on several indexes

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2821,20 +2821,7 @@ def groupByNode(requestContext, seriesList, nodeNum, callback):
     sumSeries(ganglia.by-function.server1.*.cpu.load5),sumSeries(ganglia.by-function.server2.*.cpu.load5),...
 
   """
-  metaSeries = {}
-  keys = []
-  for series in seriesList:
-    key = series.name.split(".")[nodeNum]
-    if key not in metaSeries.keys():
-      metaSeries[key] = [series]
-      keys.append(key)
-    else:
-      metaSeries[key].append(series)
-  for key in metaSeries.keys():
-    metaSeries[key] = SeriesFunctions[callback](requestContext,
-        metaSeries[key])[0]
-    metaSeries[key].name = key
-  return [ metaSeries[key] for key in keys ]
+  return groupByNodes(requestContext, seriesList, callback, nodeNum)
 
 def groupByNodes(requestContext, seriesList, callback, *nodes):
   """

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2836,6 +2836,39 @@ def groupByNode(requestContext, seriesList, nodeNum, callback):
     metaSeries[key].name = key
   return [ metaSeries[key] for key in keys ]
 
+def groupByNodes(requestContext, seriesList, callback, *nodes):
+  """
+  Takes a serieslist and maps a callback to subgroups within as defined by a common node
+
+  .. code-block:: none
+
+    &target=groupByNodes(ganglia.server*.*.cpu.load*,"sumSeries",1,4)
+
+  Would return multiple series which are each the result of applying the "sumSeries" function
+  to groups joined on the nodes' list (0 indexed) resulting in a list of targets like
+
+  .. code-block :: none
+
+    sumSeries(ganglia.server1.*.cpu.load5),sumSeries(ganglia.server1.*.cpu.load10),sumSeries(ganglia.server1.*.cpu.load15),sumSeries(ganglia.server2.*.cpu.load5),sumSeries(ganglia.server2.*.cpu.load10),sumSeries(ganglia.server2.*.cpu.load15),...
+
+  """
+  metaSeries = {}
+  keys = []
+  if isinstance(nodes, int):
+    nodes=[nodes]
+  for series in seriesList:
+    key = '.'.join(series.name.split(".")[n] for n in nodes)
+    if key not in metaSeries.keys():
+      metaSeries[key] = [series]
+      keys.append(key)
+    else:
+      metaSeries[key].append(series)
+  for key in metaSeries.keys():
+    metaSeries[key] = SeriesFunctions[callback](requestContext,
+        metaSeries[key])[0]
+    metaSeries[key].name = key
+  return [ metaSeries[key] for key in keys ]
+
 def exclude(requestContext, seriesList, pattern):
   """
   Takes a metric or a wildcard seriesList, followed by a regular expression
@@ -3401,6 +3434,7 @@ SeriesFunctions = {
   'map': mapSeries,
   'reduce': reduceSeries,
   'groupByNode' : groupByNode,
+  'groupByNodes' : groupByNodes,
   'constantLine' : constantLine,
   'stacked' : stacked,
   'areaBetween' : areaBetween,

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -250,6 +250,60 @@ class FunctionsTest(TestCase):
         with self.assertRaises(IndexError):
             verify_node_name(10000)
 
+    def test_groupByNode(self):
+        seriesList, inputList = self._generate_mr_series()
+
+        def verify_groupByNode(expectedResult, nodeNum):
+            results = functions.groupByNode({}, copy.deepcopy(seriesList), nodeNum, "keepLastValue")
+
+            for i, series in enumerate(results):
+                self.assertEqual(series.name, expectedResult[i].name)
+            self.assertEqual(results, expectedResult)
+
+        expectedResult   = [
+            TimeSeries('group',0,1,1,[None]),
+        ]
+        verify_groupByNode(expectedResult, 0)
+
+        expectedResult   = [
+            TimeSeries('server1',0,1,1,[None]),
+            TimeSeries('server2',0,1,1,[None]),
+        ]
+        verify_groupByNode(expectedResult, 1)
+
+    def test_groupByNodes(self):
+        seriesList, inputList = self._generate_mr_series()
+
+        def verify_groupByNodes(expectedResult, *nodes):
+            if isinstance(nodes, int):
+                node_number = [nodes]
+
+            results = functions.groupByNodes({}, copy.deepcopy(seriesList), "keepLastValue", *nodes)
+
+            for i, series in enumerate(results):
+                self.assertEqual(series.name, expectedResult[i].name)
+            self.assertEqual(results, expectedResult)
+
+        expectedResult = [
+            TimeSeries('server1',0,1,1,[None]),
+            TimeSeries('server2',0,1,1,[None]),
+        ]
+        verify_groupByNodes(expectedResult, 1)
+
+        expectedResult = [
+            TimeSeries('server1.metric1',0,1,1,[None]),
+            TimeSeries('server1.metric2',0,1,1,[None]),
+            TimeSeries('server2.metric1',0,1,1,[None]),
+            TimeSeries('server2.metric2',0,1,1,[None]),
+        ]
+        verify_groupByNodes(expectedResult, 1, 2)
+
+        expectedResult = [
+            TimeSeries('server1.group',0,1,1,[None]),
+            TimeSeries('server2.group',0,1,1,[None]),
+        ]
+        verify_groupByNodes(expectedResult, 1, 0)
+
     def test_alpha(self):
         seriesList = self._generate_series_list()
         alpha = 0.5


### PR DESCRIPTION
Add a new function 'groupByNodes' that support multiple indexes like the function 'aliasByNode'.

This avoids to add a new graph target for each new metric/node created.

Ex:
&target=groupByNodes(ganglia.**server`*`**.`*`.cpu.**load`*`**,"sumSeries",1,4)

Will "generate" the following formula : 
- sumSeries(ganglia.server1.*.cpu.load5)
- sumSeries(ganglia.server1.*.cpu.load10)
- sumSeries(ganglia.server1.*.cpu.load15)
- sumSeries(ganglia.server2.*.cpu.load5)
- sumSeries(ganglia.server2.*.cpu.load10)
- sumSeries(ganglia.server2.*.cpu.load15)
- ...

Will produce the following legends : 
- server1.load5
- server1.load10
- server1.load15
- ...
- server2.load5
- server2.load10
- server2.load15
- ...