### PR TITLE
add support for globstars in standard finder

### DIFF
--- a/webapp/content/js/completer.js
+++ b/webapp/content/js/completer.js
@@ -41,7 +41,9 @@ MetricCompleter = Ext.extend(Ext.form.ComboBox, {
   },
 
   prepareQuery: function (queryEvent) {
-    queryEvent.query += '*';
+    if (queryEvent.query.substr(-1) != '*') {
+      queryEvent.query += '*';
+    }
   },
 
   onSpecialKey: function (field, e) {


### PR DESCRIPTION
This should address the request originally made in #168.

The code change to support this was simple enough, that I figured I could send a pull request to start some discussion on it.

There may be a more efficient way to implement globstar, but at least this doesn't seem pathological, and has very little impacting on existing code and performance.