### PR TITLE
Update attime.py to use pytz

### DIFF
--- a/webapp/graphite/render/attime.py
+++ b/webapp/graphite/render/attime.py
@@ -12,16 +12,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
+import pytz
 from datetime import datetime,timedelta
 from time import daylight
 from django.utils import timezone
+from django.conf import settings
 
 months = ['jan','feb','mar','apr','may','jun','jul','aug','sep','oct','nov','dec']
 weekdays = ['sun','mon','tue','wed','thu','fri','sat']
 
 def parseATTime(s, tzinfo=None):
   if tzinfo is None:
-    tzinfo = timezone.get_current_timezone()
+    tzinfo = pytz.timezone(settings.TIME_ZONE)
   s = s.strip().lower().replace('_','').replace(',','').replace(' ','')
   if s.isdigit():
     if len(s) == 8 and int(s[:4]) > 1900 and int(s[4:6]) < 13 and int(s[6:]) < 32:


### PR DESCRIPTION
Change instantiation of tzinfo object to match that in views.py because get_current_timezone() returns the LocalTimezone implementation of tzinfo which does not support 'localize' and results in an AttributeError