### PR TITLE
scrambled results when merging cached carbon data with whisper data

### DIFF
--- a/webapp/graphite/readers.py
+++ b/webapp/graphite/readers.py
@@ -179,7 +179,8 @@ class WhisperReader(object):
 
       try:
         i = int(interval - start) / step
-        values[i] = value
+        if (i>=0 and i<len(values)):
+          values[i] = value
       except:
         pass
 


### PR DESCRIPTION
When merging cached data from carbon with the data pulled from the whisper file, the values were getting scrambled (i.e., values reported at the wrong timestamp).  In my case I was seeing this with:

- a whisper file that stores data every 300 seconds
- a request for the past 6 hours of data
- a job that just rewrote 24 hours of data (so 24 hours were in carbon's cache)
- a very slow rate of flushing carbon's cache into the whisper files

So while the whisper file was returning this:

```
Tue Mar 10 13:30:00 2015        41.000000
Tue Mar 10 13:35:00 2015        41.000000
Tue Mar 10 13:40:00 2015        41.000000
Tue Mar 10 13:45:00 2015        41.000000
Tue Mar 10 13:50:00 2015        41.000000
Tue Mar 10 13:55:00 2015        41.000000
Tue Mar 10 14:00:00 2015        41.000000
Tue Mar 10 14:05:00 2015        41.000000
Tue Mar 10 14:10:00 2015        41.000000
Tue Mar 10 14:15:00 2015        41.000000
Tue Mar 10 14:20:00 2015        41.000000
Tue Mar 10 14:25:00 2015        41.000000
Tue Mar 10 14:30:00 2015        45.000000
Tue Mar 10 14:35:00 2015        45.000000
Tue Mar 10 14:40:00 2015        45.000000
Tue Mar 10 14:45:00 2015        45.000000
Tue Mar 10 14:50:00 2015        45.000000
Tue Mar 10 14:55:00 2015        None
Tue Mar 10 15:00:00 2015        None
Tue Mar 10 15:05:00 2015        None
```
The graphite query was returning:

```
temperature.fahrenheit.mean,2015-03-10 13:30:00,35.1
temperature.fahrenheit.mean,2015-03-10 13:35:00,35.1
temperature.fahrenheit.mean,2015-03-10 13:40:00,41.0
temperature.fahrenheit.mean,2015-03-10 13:45:00,35.1
temperature.fahrenheit.mean,2015-03-10 13:50:00,41.0
temperature.fahrenheit.mean,2015-03-10 13:55:00,41.0
temperature.fahrenheit.mean,2015-03-10 14:00:00,41.0
temperature.fahrenheit.mean,2015-03-10 14:05:00,35.1
temperature.fahrenheit.mean,2015-03-10 14:10:00,35.1
temperature.fahrenheit.mean,2015-03-10 14:15:00,41.0
temperature.fahrenheit.mean,2015-03-10 14:20:00,41.0
temperature.fahrenheit.mean,2015-03-10 14:25:00,41.0
temperature.fahrenheit.mean,2015-03-10 14:30:00,35.1
temperature.fahrenheit.mean,2015-03-10 14:35:00,35.1
temperature.fahrenheit.mean,2015-03-10 14:40:00,45.0
temperature.fahrenheit.mean,2015-03-10 14:45:00,35.1
temperature.fahrenheit.mean,2015-03-10 14:50:00,45.0
temperature.fahrenheit.mean,2015-03-10 14:55:00,35.1
temperature.fahrenheit.mean,2015-03-10 15:00:00,45.0
temperature.fahrenheit.mean,2015-03-10 15:05:00,35.1
```

Once the cached data was flushed into the whisper file by carbon then the graphite query began to work properly again..

I'll preface this by stating I'm not a python programmer.  What I found is that when merging the cached data into the whisper data, the cached data (which is a longer series) attempts to write outside the bounds of the values array that holds the whisper file data.  I assumed the try block was there to catch those conditions, but the scrambled data problem was resolved as soon as I specifically checked that the cached data's calculated index was within the bounds of the array before attempting to write it.  I left the try in place, and perhaps there is a better fix than this (or a more idiomatic python approach than my fix).
