### PR TITLE
Serve staticfiles in the webapp if whitenoise is installed

### DIFF
--- a/check-dependencies.py
+++ b/check-dependencies.py
@@ -171,6 +171,14 @@ except ImportError:
   optional += 1
 
 
+# Test for whitenoise
+try:
+    import whitenoise
+except ImportError:
+    sys.stderr.write("[OPTIONAL] Unable to import the 'whitenoise' module. This is useful for serving static files.\n")
+    optional += 1
+
+
 if optional:
   sys.stderr.write("%d optional dependencies not met. Please consider the optional items before proceeding.\n" % optional)
 else:

--- a/docs/config-local-settings.rst
+++ b/docs/config-local-settings.rst
@@ -112,6 +112,9 @@ STATIC_ROOT
           alias /opt/graphite/static/;
       }
 
+  Alternatively, static files can be served directly by the Graphite webapp if
+  you install the ``whitenoise`` Python package.
+
 DASHBOARD_CONF
   `Default: CONF_DIR/dashboard.conf`
   The location of the Graphite-web Dashboard configuration

--- a/examples/example-graphite-vhost.conf
+++ b/examples/example-graphite-vhost.conf
@@ -39,10 +39,10 @@ WSGISocketPrefix run/wsgi
 
 
         # XXX To serve static files, either:
-	# * Install the whitenoise Python package (pip install whitenoise)
-	# * Collect static files in a directory by running:
+        # * Install the whitenoise Python package (pip install whitenoise)
+        # * Collect static files in a directory by running:
         #     django-admin.py collectstatic --noinput --settings=graphite.settings
-	#   And set an alias to serve static files with Apache:
+        #   And set an alias to serve static files with Apache:
         Alias /static/ /opt/graphite/static/
 
         ########################

--- a/examples/example-graphite-vhost.conf
+++ b/examples/example-graphite-vhost.conf
@@ -38,8 +38,11 @@ WSGISocketPrefix run/wsgi
         WSGIScriptAlias / /opt/graphite/conf/graphite.wsgi
 
 
-        # XXX You need to generate this directory by running:
-        # django-admin.py collectstatic --noinput --settings=graphite.settings
+        # XXX To serve static files, either:
+	# * Install the whitenoise Python package (pip install whitenoise)
+	# * Collect static files in a directory by running:
+        #     django-admin.py collectstatic --noinput --settings=graphite.settings
+	#   And set an alias to serve static files with Apache:
         Alias /static/ /opt/graphite/static/
 
         ########################

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,3 +47,4 @@ pyparsing==1.5.7
 cairocffi
 git+git://github.com/graphite-project/whisper.git#egg=whisper
 git+git://github.com/graphite-project/ceres.git#egg=ceres
+whitenoise

--- a/webapp/graphite/urls.py
+++ b/webapp/graphite/urls.py
@@ -16,7 +16,6 @@ import django
 from django.conf import settings
 from django.conf.urls import patterns, include, url
 from django.contrib import admin
-from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 try:
     from django.template.base import add_to_builtins
@@ -58,6 +57,5 @@ urlpatterns = patterns(
     '',
     (r'^{0}'.format(url_prefix), include(graphite_urls)),
 )
-urlpatterns += staticfiles_urlpatterns()
 
 handler500 = 'graphite.views.server_error'

--- a/webapp/graphite/wsgi.py
+++ b/webapp/graphite/wsgi.py
@@ -1,6 +1,9 @@
 import os
 
-from importlib import import_module
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'graphite.settings')  # noqa
 

--- a/webapp/graphite/wsgi.py
+++ b/webapp/graphite/wsgi.py
@@ -1,21 +1,29 @@
 import os
 
+from importlib import import_module
+
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'graphite.settings')  # noqa
 
-import django
-
+from django.conf import settings
+from django.core.wsgi import get_wsgi_application
 from graphite.logger import log
 
-if django.VERSION < (1, 4):
-    from django.core.handlers.wsgi import WSGIHandler
-    application = WSGIHandler()
-else:
-    # From 1.4 wsgi support was improved and since 1.7 old style WSGI script
-    # causes AppRegistryNotReady exception
-    # https://docs.djangoproject.com/en/dev/releases/1.7/#wsgi-scripts
-    from django.core.wsgi import get_wsgi_application
-    application = get_wsgi_application()
+application = get_wsgi_application()
 
+try:
+    from whitenoise.django import DjangoWhiteNoise
+except ImportError:
+    pass
+else:
+    application = DjangoWhiteNoise(application)
+    prefix = "/".join((settings.URL_PREFIX.strip('/'), 'static'))
+    for directory in settings.STATICFILES_DIRS:
+        application.add_files(directory, prefix=prefix)
+    for app_path in settings.INSTALLED_APPS:
+        module = import_module(app_path)
+        directory = os.path.join(os.path.dirname(module.__file__), 'static')
+        if os.path.isdir(directory):
+            application.add_files(directory, prefix=prefix)
 
 # Initializing the search index can be very expensive. The import below
 # ensures the index is preloaded before any requests are handed to the

--- a/webapp/tests/test_util.py
+++ b/webapp/tests/test_util.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
 from graphite import util
+from graphite.wsgi import application  # NOQA makes sure we have a working WSGI app
 
 
 class UtilTest(TestCase):


### PR DESCRIPTION
This avoids the collectstatic step & apache configuration. It's probably slightly less optimal than serving files with apache/nginx but much easier to start with.

Whitenoise is compatible with Django 1.4 and above.