### PR TITLE
Use OrderedDict in groupByNode

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -20,7 +20,6 @@ import time
 from datetime import datetime, timedelta
 from itertools import izip, imap
 from os import environ
-from collections import OrderedDict
 
 from graphite.logger import log
 from graphite.render.attime import parseTimeOffset, parseATTime
@@ -2822,15 +2821,20 @@ def groupByNode(requestContext, seriesList, nodeNum, callback):
     sumSeries(ganglia.by-function.server1.*.cpu.load5),sumSeries(ganglia.by-function.server2.*.cpu.load5),...
 
   """
-  metaSeries = OrderedDict()
+  metaSeries = {}
+  keys = []
   for series in seriesList:
     key = series.name.split(".")[nodeNum]
-    metaSeries.setdefault(key, []).append(series)
+    if key not in metaSeries:
+      metaSeries[key] = [series]
+      keys.append(key)
+    else:
+      metaSeries[key].append(series)
   for key in metaSeries.keys():
     metaSeries[key] = SeriesFunctions[callback](requestContext,
         metaSeries[key])[0]
     metaSeries[key].name = key
-  return metaSeries.values()
+  return [ metaSeries[key] for key in keys ]
 
 def exclude(requestContext, seriesList, pattern):
   """

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -20,6 +20,7 @@ import time
 from datetime import datetime, timedelta
 from itertools import izip, imap
 from os import environ
+from collections import OrderedDict
 
 from graphite.logger import log
 from graphite.render.attime import parseTimeOffset, parseATTime
@@ -2821,20 +2822,15 @@ def groupByNode(requestContext, seriesList, nodeNum, callback):
     sumSeries(ganglia.by-function.server1.*.cpu.load5),sumSeries(ganglia.by-function.server2.*.cpu.load5),...
 
   """
-  metaSeries = {}
-  keys = []
+  metaSeries = OrderedDict()
   for series in seriesList:
     key = series.name.split(".")[nodeNum]
-    if key not in metaSeries.keys():
-      metaSeries[key] = [series]
-      keys.append(key)
-    else:
-      metaSeries[key].append(series)
+    metaSeries.setdefault(key, []).append(series)
   for key in metaSeries.keys():
     metaSeries[key] = SeriesFunctions[callback](requestContext,
         metaSeries[key])[0]
     metaSeries[key].name = key
-  return [ metaSeries[key] for key in keys ]
+  return metaSeries.values()
 
 def exclude(requestContext, seriesList, pattern):
   """

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -218,7 +218,7 @@ def sumSeriesWithWildcards(requestContext, seriesList, *position): #XXX
 
   for series in seriesList:
     newname = '.'.join(map(lambda x: x[1], filter(lambda i: i[0] not in positions, enumerate(series.name.split('.')))))
-    if newname in newSeries.keys():
+    if newname in newSeries:
       newSeries[newname] = sumSeries(requestContext, (series, newSeries[newname]))[0]
     else:
       newSeries[newname] = series
@@ -281,7 +281,7 @@ def multiplySeriesWithWildcards(requestContext, seriesList, *position): #XXX
 
   for series in seriesList:
     newname = '.'.join(map(lambda x: x[1], filter(lambda i: i[0] not in positions, enumerate(series.name.split('.')))))
-    if newname in newSeries.keys():
+    if newname in newSeries:
       newSeries[newname] = multiplySeries(requestContext, (newSeries[newname], series))[0]
     else:
       newSeries[newname] = series


### PR DESCRIPTION
Checking `key` for membership in `metaSeries.keys()` is inefficient and
unnecessary since we can use the `setdefault` method to replace that
logic.

Additionally, the `keys` list appears to only be necessary for the
purposes of maintaining ordering; this can be managed instead by using
an OrderedDict instead of a dict and a list.