### PR TITLE
Add template() function to parameterize seriesList arguments

### DIFF
--- a/docs/render_api.rst
+++ b/docs/render_api.rst
@@ -203,6 +203,43 @@ Examples:
   &from=monday
   (show data since the previous monday)
 
+template
+--------
+
+The ``target`` metrics can use a special ``template`` function which
+allows the metric paths to contain variables. Values for these variables
+can be provided via the ``template`` query parameter.
+
+Examples
+^^^^^^^^
+
+Example:
+
+.. code-block:: none
+
+  &target=template(hosts.$hostname.cpu)&template[hostname]=worker1
+
+Default values for the template variables can also be provided:
+
+.. code-block:: none
+
+  &target=template(hosts.$hostname.cpu, hostname="worker1")
+
+Positional arguments can be used instead of named ones:
+
+.. code-block:: none
+
+  &target=template(hosts.$1.cpu, "worker1")
+  &target=template(hosts.$1.cpu, "worker1")&template[1]=worker*
+
+In addition to path substitution, variables can be used for numeric and string literals:
+
+.. code-block:: none
+
+  &target=template(constantLine($number))&template[number]=123
+  &target=template(sinFunction($name))&template[name]=nameOfMySineWaveMetric
+
+
 Data Display Formats
 ====================
 

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -14,7 +14,13 @@ def evaluateTarget(requestContext, target):
 
 
 def evaluateTokens(requestContext, tokens):
-  if tokens.expression:
+  if tokens.template:
+    expression = tokens.expression
+    for kwarg in tokens.kwargs:
+      expression = expression.replace(kwarg.argname, kwarg.args[0])
+    return evaulateTokens(requestContext, expression)
+
+  elif tokens.expression:
     return evaluateTokens(requestContext, tokens.expression)
 
   elif tokens.pathExpression:

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -31,14 +31,17 @@ def evaluateTokens(requestContext, tokens, replacements=None):
     expression = tokens.pathExpression
     if replacements:
       for name in replacements:
-        expression = expression.replace('$'+name, str(replacements[name]))
+        if expression == '$'+name and type(replacements[name]) != type(''):
+          return replacements[name]
+        else:
+          expression = expression.replace('$'+name, str(replacements[name]))
     return fetchData(requestContext, expression)
 
   elif tokens.call:
     if tokens.call.funcname == 'template':
       # if template propagates down here, it means the grammar didn't match the invocation
       # as tokens.template. this generally happens if you try to pass non-numeric/string args
-      raise ValueError("invaild template() syntax, only numeric and string values are allowed")
+      raise ValueError("invaild template() syntax, only string/numeric arguments are allowed")
 
     func = SeriesFunctions[tokens.call.funcname]
     args = [evaluateTokens(requestContext, arg, replacements) for arg in tokens.call.args]

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -31,7 +31,7 @@ def evaluateTokens(requestContext, tokens, replacements=None):
     expression = tokens.pathExpression
     if replacements:
       for name in replacements:
-        if expression == '$'+name and isinstance(replacements[name], basestring):
+        if expression == '$'+name and not isinstance(replacements[name], str):
           return replacements[name]
         else:
           expression = expression.replace('$'+name, str(replacements[name]))

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -1,3 +1,4 @@
+import re
 from graphite.render.grammar import grammar
 from graphite.render.datalib import fetchData, TimeSeries
 
@@ -31,8 +32,14 @@ def evaluateTokens(requestContext, tokens, replacements=None):
     expression = tokens.pathExpression
     if replacements:
       for name in replacements:
-        if expression == '$'+name and not isinstance(replacements[name], str):
-          return replacements[name]
+        if expression == '$'+name:
+          val = replacements[name]
+          if not isinstance(val, str) and not isinstance(val, basestring):
+            return val
+          elif re.match('^-?[\d.]+$', val):
+            return float(val)
+          else:
+            return val
         else:
           expression = expression.replace('$'+name, str(replacements[name]))
     return fetchData(requestContext, expression)

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -31,10 +31,15 @@ def evaluateTokens(requestContext, tokens, replacements=None):
     expression = tokens.pathExpression
     if replacements:
       for name in replacements:
-        expression = expression.replace('$'+name, replacements[name])
+        expression = expression.replace('$'+name, str(replacements[name]))
     return fetchData(requestContext, expression)
 
   elif tokens.call:
+    if tokens.call.funcname == 'template':
+      # if template propagates down here, it means the grammar didn't match the invocation
+      # as tokens.template. this generally happens if you try to pass non-numeric/string args
+      raise ValueError("invaild template() syntax, only numeric and string values are allowed")
+
     func = SeriesFunctions[tokens.call.funcname]
     args = [evaluateTokens(requestContext, arg, replacements) for arg in tokens.call.args]
     kwargs = dict([(kwarg.argname, evaluateTokens(requestContext, kwarg.args[0], replacements))

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -31,7 +31,7 @@ def evaluateTokens(requestContext, tokens, replacements=None):
     expression = tokens.pathExpression
     if replacements:
       for name in replacements:
-        if expression == '$'+name and type(replacements[name]) != type(''):
+        if expression == '$'+name and isinstance(replacements[name], basestring):
           return replacements[name]
         else:
           expression = expression.replace('$'+name, str(replacements[name]))

--- a/webapp/graphite/render/grammar.py
+++ b/webapp/graphite/render/grammar.py
@@ -70,9 +70,14 @@ kwarg = Group(argname + equal + arg)('kwargs*')
 args = delimitedList(~kwarg + arg)  # lookahead to prevent failing on equals
 kwargs = delimitedList(kwarg)
 
+template = Group(
+  Literal('template') + leftParen +
+  expression + comma + kwargs +
+  rightParen
+)('template')
+
 call = Group(
-  funcname + leftParen +
-  Optional(
+  funcname + leftParen + Optional(
     args + Optional(
       comma + kwargs
     )
@@ -101,10 +106,10 @@ pathElement = Combine(
 pathExpression = delimitedList(pathElement, delim='.', combine=True)('pathExpression')
 
 if __version__.startswith('1.'):
-    expression << Group(call | pathExpression)('expression')
+    expression << Group(template | call | pathExpression)('expression')
     grammar << expression
 else:
-    expression <<= Group(call | pathExpression)('expression')
+    expression <<= Group(template | call | pathExpression)('expression')
     grammar <<= expression
 
 

--- a/webapp/graphite/render/grammar.py
+++ b/webapp/graphite/render/grammar.py
@@ -70,12 +70,6 @@ kwarg = Group(argname + equal + arg)('kwargs*')
 args = delimitedList(~kwarg + arg)  # lookahead to prevent failing on equals
 kwargs = delimitedList(kwarg)
 
-template = Group(
-  Literal('template') + leftParen +
-  expression + comma + kwargs +
-  rightParen
-)('template')
-
 call = Group(
   funcname + leftParen + Optional(
     args + Optional(
@@ -104,6 +98,13 @@ pathElement = Combine(
   ZeroOrMore(matchEnum | partialPathElem)
 )
 pathExpression = delimitedList(pathElement, delim='.', combine=True)('pathExpression')
+
+template = Group(
+  Literal('template') + leftParen +
+  (call | pathExpression) +
+  comma + kwargs +
+  rightParen
+)('template')
 
 if __version__.startswith('1.'):
     expression << Group(template | call | pathExpression)('expression')

--- a/webapp/graphite/render/grammar.py
+++ b/webapp/graphite/render/grammar.py
@@ -71,7 +71,8 @@ args = delimitedList(~kwarg + arg)  # lookahead to prevent failing on equals
 kwargs = delimitedList(kwarg)
 
 call = Group(
-  funcname + leftParen + Optional(
+  funcname + leftParen +
+  Optional(
     args + Optional(
       comma + kwargs
     )
@@ -101,7 +102,8 @@ pathExpression = delimitedList(pathElement, delim='.', combine=True)('pathExpres
 
 template = Group(
   Literal('template') + leftParen +
-  (call | pathExpression) + Optional(
+  (call | pathExpression) +
+  Optional(
     comma + args + Optional(
       comma + kwargs
     )

--- a/webapp/graphite/render/grammar.py
+++ b/webapp/graphite/render/grammar.py
@@ -100,12 +100,19 @@ pathElement = Combine(
 )
 pathExpression = delimitedList(pathElement, delim='.', combine=True)('pathExpression')
 
+litarg = Group(
+  number | aString
+)('args*')
+litkwarg = Group(argname + equal + litarg)('kwargs*')
+litargs = delimitedList(~litkwarg + litarg)  # lookahead to prevent failing on equals
+litkwargs = delimitedList(litkwarg)
+
 template = Group(
   Literal('template') + leftParen +
   (call | pathExpression) +
   Optional(
-    comma + args + Optional(
-      comma + kwargs
+    comma + litargs + Optional(
+      comma + litkwargs
     )
   ) +
   rightParen

--- a/webapp/graphite/render/grammar.py
+++ b/webapp/graphite/render/grammar.py
@@ -110,11 +110,7 @@ litkwargs = delimitedList(litkwarg)
 template = Group(
   Literal('template') + leftParen +
   (call | pathExpression) +
-  Optional(
-    comma + litargs + Optional(
-      comma + litkwargs
-    )
-  ) +
+  Optional(comma + (litargs | litkwargs)) +
   rightParen
 )('template')
 

--- a/webapp/graphite/render/grammar.py
+++ b/webapp/graphite/render/grammar.py
@@ -101,8 +101,11 @@ pathExpression = delimitedList(pathElement, delim='.', combine=True)('pathExpres
 
 template = Group(
   Literal('template') + leftParen +
-  (call | pathExpression) +
-  comma + kwargs +
+  (call | pathExpression) + Optional(
+    comma + args + Optional(
+      comma + kwargs
+    )
+  ) +
   rightParen
 )('template')
 

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -255,7 +255,7 @@ def parseOptions(request):
 
   template = dict()
   for key, val in queryParams.items():
-    if key.find("template[", 0) == 0:
+    if key.startswith("template["):
       template[key[9:-1]] = val
   requestOptions['template'] = template
 

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -54,6 +54,7 @@ def renderView(request):
     'startTime' : requestOptions['startTime'],
     'endTime' : requestOptions['endTime'],
     'localOnly' : requestOptions['localOnly'],
+    'template' : requestOptions['template'],
     'data' : []
   }
   data = requestContext['data']
@@ -251,6 +252,12 @@ def parseOptions(request):
   # Collect the targets
   for target in mytargets:
     requestOptions['targets'].append(target)
+
+  template = dict()
+  for key, val in queryParams.items():
+    if key.find("template[", 0) == 0:
+      template[key[9:-1]] = val
+  requestOptions['template'] = template
 
   if 'pickle' in queryParams:
     requestOptions['format'] = 'pickle'

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -3,6 +3,7 @@ import json
 import os
 import time
 import logging
+import shutil
 
 from graphite.render.hashing import hashRequest, hashData
 import whisper
@@ -22,10 +23,35 @@ if hasattr(logging, "NullHandler"):
 
 class RenderTest(TestCase):
     db = os.path.join(settings.WHISPER_DIR, 'test.wsp')
+    hostcpu = os.path.join(settings.WHISPER_DIR, 'hosts/hostname/cpu.wsp')
 
     def wipe_whisper(self):
         try:
             os.remove(self.db)
+        except OSError:
+            pass
+
+    def create_whisper_hosts(self):
+        worker1 = self.hostcpu.replace('hostname', 'worker1')
+        worker2 = self.hostcpu.replace('hostname', 'worker2')
+        try:
+            os.makedirs(worker1.replace('cpu.wsp', ''))
+            os.makedirs(worker2.replace('cpu.wsp', ''))
+        except OSError:
+            pass
+
+        whisper.create(worker1, [(1, 60)])
+        whisper.create(worker2, [(1, 60)])
+
+        ts = int(time.time())
+        whisper.update(worker1, 1, ts)
+        whisper.update(worker2, 2, ts)
+
+    def wipe_whisper_hosts(self):
+        try:
+            os.remove(self.hostcpu.replace('hostname', 'worker1'))
+            os.remove(self.hostcpu.replace('hostname', 'worker2'))
+            shutil.rmtree(self.hostcpu.replace('hostname/cpu.wsp', ''))
         except OSError:
             pass
 
@@ -178,3 +204,31 @@ class RenderTest(TestCase):
         })
         data = json.loads(response.content)[0]
         self.assertEqual(data['target'], 'nameOfSeries')
+
+    def test_template_pathExpression_variables(self):
+        self.create_whisper_hosts()
+        self.addCleanup(self.wipe_whisper_hosts)
+
+        url = reverse('graphite.render.views.renderView')
+        response = self.client.get(url, {
+                 'target': 'template(sumSeries(hosts.$1.cpu),"worker1")',
+                 'format': 'json',
+        })
+        data = json.loads(response.content)[0]
+        self.assertEqual(data['target'], 'sumSeries(hosts.worker1.cpu)')
+
+        response = self.client.get(url, {
+                 'target': 'template(sumSeries(hosts.$1.cpu),"worker1")',
+                 'format': 'json',
+                 'template[1]': 'worker*'
+        })
+        data = json.loads(response.content)[0]
+        self.assertEqual(data['target'], 'sumSeries(hosts.worker*.cpu)')
+
+        response = self.client.get(url, {
+                 'target': 'template(sumSeries(hosts.$hostname.cpu))',
+                 'format': 'json',
+                 'template[hostname]': 'worker*'
+        })
+        data = json.loads(response.content)[0]
+        self.assertEqual(data['target'], 'sumSeries(hosts.worker*.cpu)')

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -133,7 +133,7 @@ class RenderTest(TestCase):
         expected = [[12, 1393398060], [12, 1393401660]]
         self.assertEqual(data, expected)
 
-    def test_template_variables(self):
+    def test_template_numeric_variables(self):
         url = reverse('graphite.render.views.renderView')
         response = self.client.get(url, {
                  'target': 'template(constantLine($1),12)',
@@ -157,3 +157,24 @@ class RenderTest(TestCase):
         # all the from/until/tz combinations lead to the same window
         expected = [[12, 1393398060], [12, 1393401660]]
         self.assertEqual(data, expected)
+
+    def test_template_string_variables(self):
+        url = reverse('graphite.render.views.renderView')
+        response = self.client.get(url, {
+                 'target': 'template(time($1),"nameOfSeries")',
+                 'format': 'json',
+                 'from': '07:01_20140226',
+                 'until': '08:01_20140226',
+        })
+        data = json.loads(response.content)[0]
+        self.assertEqual(data['target'], 'nameOfSeries')
+
+        url = reverse('graphite.render.views.renderView')
+        response = self.client.get(url, {
+                 'target': 'template(time($name),name="nameOfSeries")',
+                 'format': 'json',
+                 'from': '07:01_20140226',
+                 'until': '08:01_20140226',
+        })
+        data = json.loads(response.content)[0]
+        self.assertEqual(data['target'], 'nameOfSeries')

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -184,6 +184,19 @@ class RenderTest(TestCase):
         expected = [[12, 1393398060], [12, 1393401660]]
         self.assertEqual(data, expected)
 
+        url = reverse('graphite.render.views.renderView')
+        response = self.client.get(url, {
+                 'target': 'template(constantLine($num))',
+                 'format': 'json',
+                 'from': '07:01_20140226',
+                 'until': '08:01_20140226',
+                 'template[num]': '12',
+        })
+        data = json.loads(response.content)[0]['datapoints']
+        # all the from/until/tz combinations lead to the same window
+        expected = [[12, 1393398060], [12, 1393401660]]
+        self.assertEqual(data, expected)
+
     def test_template_string_variables(self):
         url = reverse('graphite.render.views.renderView')
         response = self.client.get(url, {
@@ -201,6 +214,17 @@ class RenderTest(TestCase):
                  'format': 'json',
                  'from': '07:01_20140226',
                  'until': '08:01_20140226',
+        })
+        data = json.loads(response.content)[0]
+        self.assertEqual(data['target'], 'nameOfSeries')
+
+        url = reverse('graphite.render.views.renderView')
+        response = self.client.get(url, {
+                 'target': 'template(time($name))',
+                 'format': 'json',
+                 'from': '07:01_20140226',
+                 'until': '08:01_20140226',
+                 'template[name]': 'nameOfSeries',
         })
         data = json.loads(response.content)[0]
         self.assertEqual(data['target'], 'nameOfSeries')

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -132,3 +132,28 @@ class RenderTest(TestCase):
         # all the from/until/tz combinations lead to the same window
         expected = [[12, 1393398060], [12, 1393401660]]
         self.assertEqual(data, expected)
+
+    def test_template_variables(self):
+        url = reverse('graphite.render.views.renderView')
+        response = self.client.get(url, {
+                 'target': 'template(constantLine($1),12)',
+                 'format': 'json',
+                 'from': '07:01_20140226',
+                 'until': '08:01_20140226',
+        })
+        data = json.loads(response.content)[0]['datapoints']
+        # all the from/until/tz combinations lead to the same window
+        expected = [[12, 1393398060], [12, 1393401660]]
+        self.assertEqual(data, expected)
+
+        url = reverse('graphite.render.views.renderView')
+        response = self.client.get(url, {
+                 'target': 'template(constantLine($num),num=12)',
+                 'format': 'json',
+                 'from': '07:01_20140226',
+                 'until': '08:01_20140226',
+        })
+        data = json.loads(response.content)[0]['datapoints']
+        # all the from/until/tz combinations lead to the same window
+        expected = [[12, 1393398060], [12, 1393401660]]
+        self.assertEqual(data, expected)


### PR DESCRIPTION
Adds a `template()` function which acts kind of like a search/replace + eval. Any references to `$var` inside the template are replaced with a corresponding value.

The `template()` function takes both positional and kwargs. Positional args are numbered (i.e. `$1`, `$2`) and values can be passed in either as args or via the requests' query parameters. You can also provide both, to use the positional argument as a default but allow it to be overridden by the request:

```
/render?target=template(sumSeries(hosts.$1.cpu-*.idle.value),"fe1")
/render?target=template(sumSeries(hosts.$1.cpu-*.idle.value))&template[1]=fe1
/render?target=template(sumSeries(hosts.$1.cpu-*.idle.value),"fe1")&template[1]=fe*
```

Kwargs are named, and can also be passed in via the query parameters:

```
/render?target=template(sumSeries(hosts.$hostname.cpu-*.idle.value),hostname="fe1")
/render?target=template(sumSeries(hosts.$hostname.cpu-*.idle.value))&template[hostname]=fe*
/render?target=template(sumSeries(hosts.$hostname.cpu-*.idle.value),hostname="fe1")&template[hostname]=fe*
```

All the examples above are functional on this pull request. I need to flesh out the docs (and maybe add some tests), but am looking for some feedback on this direction (does it make sense, would it be useful to others) before I continue.

cc @jssjr 