### PR TITLE
Fixed jmxtrans URL

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -302,7 +302,7 @@ Other
 .. _Host sFlow: http://host-sflow.sourceforge.net
 .. _Hubot: https://github.com/github/hubot
 .. _hubot-scripts: https://github.com/github/hubot-scripts
-.. _jmxtrans: http://code.google.com/p/jmxtrans
+.. _jmxtrans: https://github.com/jmxtrans/jmxtrans
 .. _Ledbetter: https://github.com/github/ledbetter
 .. _Leonardo: https://github.com/PrFalken/leonardo
 .. _Logster: https://github.com/etsy/logster


### PR DESCRIPTION
Original link (http://code.google.com/p/jmxtrans) says nothing but:

"This project has moved to Github: https://github.com/lookfirst/jmxtrans"

Going to this link says:

"The repository has moved to our new organization at: https://github.com/jmxtrans/jmxtrans"

That is the actual repo. Updated the tools.rst with the proper current location of the repo.