### PR TITLE
Namespace the request-cache with the local node address

### DIFF
--- a/webapp/graphite/render/hashing.py
+++ b/webapp/graphite/render/hashing.py
@@ -33,11 +33,11 @@ def hashRequest(request):
   return compactHash(normalizedParams)
 
 
-def hashData(targets, startTime, endTime):
+def hashData(targets, startTime, endTime, node):
   targetsString = ','.join(sorted(targets))
   startTimeString = startTime.strftime("%Y%m%d_%H%M")
   endTimeString = endTime.strftime("%Y%m%d_%H%M")
-  myHash = targetsString + '@' + startTimeString + ':' + endTimeString
+  myHash = targetsString + '@' + startTimeString + ':' + endTimeString + '/' + node
   return compactHash(myHash)
 
 

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -40,6 +40,7 @@ from graphite.render.attime import parseATTime
 from graphite.render.functions import PieFunctions
 from graphite.render.hashing import hashRequest, hashData
 from graphite.render.glyph import GraphTypes
+from graphite.storage import STORE
 
 from django.http import HttpResponse, HttpResponseServerError, HttpResponseRedirect
 from django.template import Context, loader
@@ -99,7 +100,7 @@ def renderView(request):
       targets = requestOptions['targets']
       startTime = requestOptions['startTime']
       endTime = requestOptions['endTime']
-      dataKey = hashData(targets, startTime, endTime)
+      dataKey = hashData(targets, startTime, endTime, STORE.local_host)
       cachedData = cache.get(dataKey)
       if cachedData:
         log.cache("Data-Cache hit [%s]" % dataKey)

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -34,6 +34,11 @@ class Store:
     self.directories = directories
     self.remote_hosts = remote_hosts
     self.remote_stores = [ RemoteStore(host) for host in remote_hosts if not is_local_interface(host) ]
+    self.local_host = [host for host in remote_hosts if is_local_interface(host)]
+    if len(self.local_host) == 1:
+      self.local_host = self.local_host[0]
+    else:
+      self.local_host = 'local'
 
     if not (directories or remote_hosts):
       raise ValueError("directories and remote_hosts cannot both be empty")

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -34,11 +34,7 @@ class Store:
     self.directories = directories
     self.remote_hosts = remote_hosts
     self.remote_stores = [ RemoteStore(host) for host in remote_hosts if not is_local_interface(host) ]
-    self.local_host = [host for host in remote_hosts if is_local_interface(host)]
-    if len(self.local_host) == 1:
-      self.local_host = self.local_host[0]
-    else:
-      self.local_host = 'local'
+    self.local_host = next((host for host in remote_hosts if is_local_interface(host)), 'local')
 
     if not (directories or remote_hosts):
       raise ValueError("directories and remote_hosts cannot both be empty")

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -98,8 +98,9 @@ class RenderTest(TestCase):
         targets = ['foo=1', 'bar=2']
         start_time = datetime.fromtimestamp(0)
         end_time = datetime.fromtimestamp(1000)
-        self.assertEqual(hashData(targets, start_time, end_time),
-                        hashData(reversed(targets), start_time, end_time))
+        local_node = 'local'
+        self.assertEqual(hashData(targets, start_time, end_time, local_node),
+                        hashData(reversed(targets), start_time, end_time, local_node))
 
 
     def test_consolidated_stacked_yMax(self):


### PR DESCRIPTION
This is a quick hack to enable shared memcache support in a carbon cluster using replication factor >= 2. Appending the local node information to the hash key stored in memcache will prevent false positives from occurring while rendering (and caching) pickles for the upstream graphite-web responsbile for rendering the user specified format.

I don't love the implementation, but it seems to be working well in my limited tests. (Currently on an :airplane:, and I don't have a proper local cluster setup to test with.)

/cc https://github.com/graphite-project/graphite-web/issues/1022
/cc https://github.com/graphite-project/graphite-web/issues/1102
/cc https://github.com/graphite-project/graphite-web/issues/1037
