### PR TITLE
Remove pytz dependency check (0.9.x)

### DIFF
--- a/check-dependencies.py
+++ b/check-dependencies.py
@@ -87,14 +87,6 @@ except ImportError:
     fatal += 1
 
 
-# Test for a pytz module
-try:
-  import pytz
-except ImportError:
-  print "[FATAL] Unable to import the 'pytz' module, do you have pytz installed for python %s?" % py_version
-  fatal += 1
-
-
 # Test for zope.interface
 try:
   from zope.interface import Interface


### PR DESCRIPTION
Fixes #1081. Unnecessary since we [vendor pytz](https://github.com/graphite-project/graphite-web/tree/0.9.x/webapp/graphite/thirdparty) in 0.9.x.