### PR TITLE
django 1.8 warning fixes

### DIFF
--- a/webapp/graphite/browser/views.py
+++ b/webapp/graphite/browser/views.py
@@ -244,7 +244,7 @@ def userGraphLookup(request):
 
 def json_response(nodes, request=None):
   if request:
-    jsonp = request.REQUEST.get('jsonp', False)
+    jsonp = request.GET.get('jsonp', False)
   else:
     jsonp = False
   #json = str(nodes) #poor man's json encoder for simple types

--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -29,8 +29,8 @@ except ImportError:
 
 
 def index_json(request):
-  jsonp = request.REQUEST.get('jsonp', False)
-  cluster = request.REQUEST.get('cluster', False)
+  jsonp = request.GET.get('jsonp', False)
+  cluster = request.GET.get('cluster', False)
 
   def find_matches():
     matches = []
@@ -68,14 +68,14 @@ def index_json(request):
 
 def search_view(request):
   try:
-    query = str( request.REQUEST['query'] )
+    query = str( request.GET['query'] )
   except:
     return HttpResponseBadRequest(content="Missing required parameter 'query'",
                                   content_type="text/plain")
   search_request = {
     'query' : query,
-    'max_results' : int( request.REQUEST.get('max_results', 25) ),
-    'keep_query_pattern' : int(request.REQUEST.get('keep_query_pattern', 0)),
+    'max_results' : int( request.GET.get('max_results', 25) ),
+    'keep_query_pattern' : int(request.GET.get('keep_query_pattern', 0)),
   }
   #if not search_request['query'].endswith('*'):
   #  search_request['query'] += '*'
@@ -87,22 +87,22 @@ def search_view(request):
 def find_view(request):
   "View for finding metrics matching a given pattern"
   profile = getProfile(request)
-  format = request.REQUEST.get('format', 'treejson')
-  local_only = int( request.REQUEST.get('local', 0) )
-  wildcards = int( request.REQUEST.get('wildcards', 0) )
-  fromTime = int( request.REQUEST.get('from', -1) )
-  untilTime = int( request.REQUEST.get('until', -1) )
-  jsonp = request.REQUEST.get('jsonp', False)
+  format = request.GET.get('format', 'treejson')
+  local_only = int( request.GET.get('local', 0) )
+  wildcards = int( request.GET.get('wildcards', 0) )
+  fromTime = int( request.GET.get('from', -1) )
+  untilTime = int( request.GET.get('until', -1) )
+  jsonp = request.GET.get('jsonp', False)
 
   if fromTime == -1:
     fromTime = None
   if untilTime == -1:
     untilTime = None
 
-  automatic_variants = int( request.REQUEST.get('automatic_variants', 0) )
+  automatic_variants = int( request.GET.get('automatic_variants', 0) )
 
   try:
-    query = str( request.REQUEST['query'] )
+    query = str( request.GET['query'] )
   except:
     return HttpResponseBadRequest(content="Missing required parameter 'query'",
                                   content_type="text/plain")
@@ -168,12 +168,12 @@ def find_view(request):
 
 def expand_view(request):
   "View for expanding a pattern into matching metric paths"
-  local_only    = int( request.REQUEST.get('local', 0) )
-  group_by_expr = int( request.REQUEST.get('groupByExpr', 0) )
-  leaves_only   = int( request.REQUEST.get('leavesOnly', 0) )
+  local_only    = int( request.GET.get('local', 0) )
+  group_by_expr = int( request.GET.get('groupByExpr', 0) )
+  leaves_only   = int( request.GET.get('leavesOnly', 0) )
 
   results = {}
-  for query in request.REQUEST.getlist('query'):
+  for query in request.GET.getlist('query'):
     results[query] = set()
     for node in STORE.find(query, local=local_only):
       if node.is_leaf or not leaves_only:
@@ -197,8 +197,8 @@ def expand_view(request):
 
 
 def get_metadata_view(request):
-  key = request.REQUEST['key']
-  metrics = request.REQUEST.getlist('metric')
+  key = request.GET['key']
+  metrics = request.GET.getlist('metric')
   results = {}
   for metric in metrics:
     try:

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -222,7 +222,7 @@ def renderView(request):
 
 
 def parseOptions(request):
-  queryParams = request.REQUEST
+  queryParams = request.GET
 
   # Start with some defaults
   graphOptions = {'width' : 330, 'height' : 250}
@@ -390,7 +390,7 @@ def renderMyGraphView(request,username,graphName):
   except ObjectDoesNotExist:
     return errorPage("User %s doesn't have a MyGraph named '%s'" % (username,graphName))
 
-  request_params = dict(request.REQUEST.items())
+  request_params = dict(request.GET.items())
   if request_params:
     url_parts = urlsplit(graph.url)
     query_string = url_parts[3]


### PR DESCRIPTION
Think nice to have clear output when you doing development
```
/home/roman/work/graphite-web/webapp/graphite/metrics/views.py:90: RemovedInDjango19Warning: `request.REQUEST` is deprecated, use `request.GET` or `request.POST` instead.
  format = request.REQUEST.get('format', 'treejson')

/home/roman/work/graphite-web/webapp/graphite/metrics/views.py:91: RemovedInDjango19Warning: `request.REQUEST` is deprecated, use `request.GET` or `request.POST` instead.
  local_only = int( request.REQUEST.get('local', 0) )

/home/roman/work/graphite-web/webapp/graphite/metrics/views.py:92: RemovedInDjango19Warning: `request.REQUEST` is deprecated, use `request.GET` or `request.POST` instead.
  wildcards = int( request.REQUEST.get('wildcards', 0) )

/home/roman/work/graphite-web/webapp/graphite/metrics/views.py:93: RemovedInDjango19Warning: `request.REQUEST` is deprecated, use `request.GET` or `request.POST` instead.
  fromTime = int( request.REQUEST.get('from', -1) )

/home/roman/work/graphite-web/webapp/graphite/metrics/views.py:94: RemovedInDjango19Warning: `request.REQUEST` is deprecated, use `request.GET` or `request.POST` instead.
  untilTime = int( request.REQUEST.get('until', -1) )

/home/roman/work/graphite-web/webapp/graphite/metrics/views.py:95: RemovedInDjango19Warning: `request.REQUEST` is deprecated, use `request.GET` or `request.POST` instead.
  jsonp = request.REQUEST.get('jsonp', False)

/home/roman/work/graphite-web/webapp/graphite/metrics/views.py:102: RemovedInDjango19Warning: `request.REQUEST` is deprecated, use `request.GET` or `request.POST` instead.
  automatic_variants = int( request.REQUEST.get('automatic_variants', 0) )

/home/roman/work/graphite-web/webapp/graphite/metrics/views.py:105: RemovedInDjango19Warning: `request.REQUEST` is deprecated, use `request.GET` or `request.POST` instead.
  query = str( request.REQUEST['query'] )

[11/Jun/2015 20:12:10]"GET /metrics/find/?_dc=1434053530776&query=*&format=treejson&path=&node=GraphiteTree HTTP/1.1" 200 166
[11/Jun/2015 20:12:11]"GET /metrics/find/?_dc=1434053531840&query=local.*&format=treejson&path=local&node=local HTTP/1.1" 200 90
/home/roman/work/graphite-web/webapp/graphite/browser/views.py:247: RemovedInDjango19Warning: `request.REQUEST` is deprecated, use `request.GET` or `request.POST` instead.
  jsonp = request.REQUEST.get('jsonp', False)

[11/Jun/2015 20:12:13]"GET /browser/usergraph/?_dc=1434053533021&query=*&format=treejson&path=&node=UserGraphsTree HTTP/1.1" 200 95
```