### PR TITLE
Make 'pip install -r requirements.txt' work again

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ Twisted==11.1.0
 python-memcached==1.47
 txAMQP==0.4
 simplejson==2.1.6
-django-tagging==0.3.1
+django-tagging==0.3.5
 gunicorn
 pytz
 pyparsing==1.5.7

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands =
 	django-admin.py test
 deps =
 	cairocffi
-	django-tagging
+	django-tagging>=0.3.5,<0.4
 	pytz
 	mock
 	git+git://github.com/graphite-project/whisper.git#egg=whisper


### PR DESCRIPTION
Django 1.8 doesn't work with django-tagging < 0.3.5.

Fixes: #1249

Merging a totally unrelated PR "broke the build" and this fixes it.