### PR TITLE
Whitenoise is not working with python 2.6

### DIFF
--- a/webapp/graphite/wsgi.py
+++ b/webapp/graphite/wsgi.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 try:
     from importlib import import_module
@@ -13,20 +14,22 @@ from graphite.logger import log
 
 application = get_wsgi_application()
 
-try:
-    from whitenoise.django import DjangoWhiteNoise
-except ImportError:
-    pass
-else:
-    application = DjangoWhiteNoise(application)
-    prefix = "/".join((settings.URL_PREFIX.strip('/'), 'static'))
-    for directory in settings.STATICFILES_DIRS:
-        application.add_files(directory, prefix=prefix)
-    for app_path in settings.INSTALLED_APPS:
-        module = import_module(app_path)
-        directory = os.path.join(os.path.dirname(module.__file__), 'static')
-        if os.path.isdir(directory):
+# whitenoise working only in python >= 2.7
+if sys.version_info[0] >= 2 and sys.version_info[1] >= 7:
+    try:
+        from whitenoise.django import DjangoWhiteNoise
+    except ImportError:
+        pass
+    else:
+        application = DjangoWhiteNoise(application)
+        prefix = "/".join((settings.URL_PREFIX.strip('/'), 'static'))
+        for directory in settings.STATICFILES_DIRS:
             application.add_files(directory, prefix=prefix)
+        for app_path in settings.INSTALLED_APPS:
+            module = import_module(app_path)
+            directory = os.path.join(os.path.dirname(module.__file__), 'static')
+            if os.path.isdir(directory):
+                application.add_files(directory, prefix=prefix)
 
 # Initializing the search index can be very expensive. The import below
 # ensures the index is preloaded before any requests are handed to the


### PR DESCRIPTION
and throwing errors when it's installed. Fixing issue https://github.com/graphite-project/graphite-web/issues/1252