### PR TITLE
Adapt reduceSeries to match the documentation

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2820,7 +2820,7 @@ def reduceSeries(requestContext, seriesLists, reduceFunction, reduceNode, *reduc
         i = reduceMatchers.index(node)
         metaSeries[reduceSeriesName][i] = series
   for key in keys:
-    metaSeries[key] = SeriesFunctions[reduceFunction](requestContext,metaSeries[key])[0]
+    metaSeries[key] = SeriesFunctions[reduceFunction](requestContext,*[[l] for l in metaSeries[key]])[0]
     metaSeries[key].name = key
   return [ metaSeries[key] for key in keys ]
 

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -323,6 +323,23 @@ class FunctionsTest(TestCase):
                          [call({},[inputList[0][0]],[inputList[0][1]]),
                           call({},[inputList[1][0]],[inputList[1][1]])])
 
+    def test_reduceSeries_asPercent(self):
+        seriesList = [
+            TimeSeries('group.server1.bytes_used',0,1,1,[1]),
+            TimeSeries('group.server1.total_bytes',0,1,1,[2]),
+            TimeSeries('group.server2.bytes_used',0,1,1,[3]),
+            TimeSeries('group.server2.total_bytes',0,1,1,[4]),
+        ]
+        for series in seriesList:
+            series.pathExpression = "tempPath"
+        expectedResult   = [
+            TimeSeries('group.server1.reduce.asPercent',0,1,1,[50]), #100*1/2
+            TimeSeries('group.server2.reduce.asPercent',0,1,1,[75])  #100*3/4
+        ]
+        mappedResult = [seriesList[0]],[seriesList[1]], [seriesList[2]],[seriesList[3]]
+        results = functions.reduceSeries({}, copy.deepcopy(mappedResult), "asPercent", 2, "bytes_used", "total_bytes")
+        self.assertEqual(results,expectedResult)
+
     def test_pow(self):
         seriesList = self._generate_series_list()
         factor = 2

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -319,7 +319,9 @@ class FunctionsTest(TestCase):
         with patch.dict(functions.SeriesFunctions,{ 'mock': mock }):
             results = functions.reduceSeries({}, copy.deepcopy(inputList), "mock", 2, "metric1","metric2" )
             self.assertEqual(results,expectedResult)
-        self.assertEqual(mock.mock_calls, [call({},inputList[0]), call({},inputList[1])])
+        self.assertEqual(mock.mock_calls,
+                         [call({},[inputList[0][0]],[inputList[0][1]]),
+                          call({},[inputList[1][0]],[inputList[1][1]])])
 
     def test_pow(self):
         seriesList = self._generate_series_list()


### PR DESCRIPTION
Dispatch match results as individual series lists of length one to the arguments of the called reduction function.

This would resolve #1066 and is related to #1015.