### PR TITLE
Backport PR #646 and #1169 to 0.9.x

### DIFF
--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -26,7 +26,10 @@ def evaluateTokens(requestContext, tokens):
   elif tokens.call:
     func = SeriesFunctions[tokens.call.func]
     args = [evaluateTokens(requestContext, arg) for arg in tokens.call.args]
-    return func(requestContext, *args)
+    try:
+      return func(requestContext, *args)
+    except NormalizeEmptyResultError:
+      return []
 
   elif tokens.number:
     if tokens.number.integer:
@@ -66,4 +69,4 @@ def extractPathExpressions(targets):
 
 
 #Avoid import circularities
-from graphite.render.functions import SeriesFunctions
+from graphite.render.functions import SeriesFunctions,NormalizeEmptyResultError

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -117,14 +117,24 @@ def lcm(a,b):
   return a * b
 
 def normalize(seriesLists):
-  seriesList = reduce(lambda L1,L2: L1+L2,seriesLists)
-  step = reduce(lcm,[s.step for s in seriesList])
-  for s in seriesList:
-    s.consolidate( step / s.step )
-  start = min([s.start for s in seriesList])
-  end = max([s.end for s in seriesList])
-  end -= (end - start) % step
-  return (seriesList,start,end,step)
+  if seriesLists:
+    seriesList = reduce(lambda L1,L2: L1+L2,seriesLists)
+    if seriesList:
+      step = reduce(lcm,[s.step for s in seriesList])
+      for s in seriesList:
+        s.consolidate( step / s.step )
+      start = min([s.start for s in seriesList])
+      end = max([s.end for s in seriesList])
+      end -= (end - start) % step
+      return (seriesList,start,end,step)
+  raise NormalizeEmptyResultError()
+
+class NormalizeEmptyResultError(Exception):
+  """
+  Error thrown by the function 'normalize'
+  when it has an empty result
+  """
+  pass
 
 def formatPathExpressions(seriesList):
    # remove duplicates

--- a/webapp/graphite/render/functions_test.py
+++ b/webapp/graphite/render/functions_test.py
@@ -15,6 +15,7 @@ settings.configure(
 
 from graphite.render.datalib import TimeSeries
 import graphite.render.functions as functions
+from graphite.render.functions import NormalizeEmptyResultError
 
 
 class FunctionsTest(unittest.TestCase):
@@ -90,6 +91,11 @@ class FunctionsTest(unittest.TestCase):
         TestNPercentile(90, [ [50], [91], [181], [271], [90], [180], [270], [270] ])
         TestNPercentile(95, [ [50], [96], [191], [286], [95], [190], [285], [285] ])
 
+    def test_normalize_empty(self):
+      try:
+        functions.normalize([])
+      except NormalizeEmptyResultError:
+        pass
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Make normalize() accept empty series.
Remove useless double call.