### PR TITLE
Add APIs to control carbon-cache flushing

### DIFF
--- a/webapp/graphite/metrics/urls.py
+++ b/webapp/graphite/metrics/urls.py
@@ -25,5 +25,7 @@ urlpatterns = patterns('graphite.metrics.views',
   ('^context/?$', 'context_view'),
   ('^get-metadata/?$', 'get_metadata_view'),
   ('^set-metadata/?$', 'set_metadata_view'),
+  ('^flush-cache/?$', 'flush_cache'),
+  ('^persist-cache$', 'persist_cache'),
   ('', 'find_view'),
 )

--- a/webapp/graphite/metrics/urls.py
+++ b/webapp/graphite/metrics/urls.py
@@ -27,5 +27,6 @@ urlpatterns = patterns('graphite.metrics.views',
   ('^set-metadata/?$', 'set_metadata_view'),
   ('^flush-cache/?$', 'flush_cache'),
   ('^persist-cache$', 'persist_cache'),
+  ('^set-param$', 'set_param'),
   ('', 'find_view'),
 )

--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -236,6 +236,39 @@ def expand_view(request):
   return response
 
 
+def persist_cache(request):
+  results = {}
+  if request.method == 'POST':
+    try:
+      results = CarbonLink.persist_cache()
+    except:
+      log.exception()
+      results = dict(error="Unexpected error occurred in CarbonLink.persist_cache()")
+  else:
+    results = dict(error="Invalid request method")
+
+  return json_response_for(request, results)
+
+def flush_cache(request):
+  metric = request.REQUEST['metric']
+  results = {}
+  if request.method == 'POST':
+    try:
+      results[metric] = CarbonLink.flush_cache(metric)
+    except:
+      log.exception()
+      results[metric] = dict(error="Unexpected error occurred in CarbonLink.flush_cache(%s)" % (metric))
+  elif request.method == 'DELETE':
+    try:
+      results[metric] = CarbonLink.stop_flush_cache()
+    except:
+      log.exception()
+      results[metric] = dict(error="Unexpected error occurred in CarbonLink.stop_flush_cache()")
+  else:
+    results = dict(error="Invalid request method")
+
+  return json_response_for(request, results)
+
 def get_metadata_view(request):
   key = request.REQUEST['key']
   metrics = request.REQUEST.getlist('metric')

--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -236,6 +236,23 @@ def expand_view(request):
   return response
 
 
+def set_param(request):
+  results = {}
+  if request.method == 'POST':
+    try:
+      datas = json.loads( request.body )
+      if "key" in datas and "value" in datas:
+        results = CarbonLink.set_param(datas["key"], datas["value"])
+      else:
+        results = dict(error="Invalid request datas")
+    except:
+      log.exception()
+      results = dict(error="Unexpected error occurred in CarbonLink.set_param()")
+  else:
+    results = dict(error="Invalid request method")
+
+  return json_response_for(request, results)
+
 def persist_cache(request):
   results = {}
   if request.method == 'POST':

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -211,6 +211,12 @@ class CarbonLinkPool:
     log.cache("CarbonLink set-metadata request received for %s:%s" % (metric, key))
     return results
 
+  def set_param(self, key, value):
+    request = dict(type='set-param', key=key, value=value)
+    results = self.send_request_to_hosts(request)
+    log.info("CarbonLink set-param request received for %s=%s : %s" % (key, value, results))
+    return results
+
   def send_request(self, request):
     metric = request['metric']
     serialized_request = pickle.dumps(request, protocol=-1)
@@ -250,8 +256,7 @@ class CarbonLinkPool:
          self.connections[host].add(conn)
          if 'error' in result:
            log.cache("CarbonLink error %s" % result['error'])
-         else:
-           results[str(host)] = result
+         results[str(host)] = result
     return results
 
   def recv_response(self, conn):


### PR DESCRIPTION
This patch adds APIs that control carbon-cache mermoty flushing

* /metrics/persist-cache
This allow to ask carbon cache instances to dump their cache memory to disk. This action is executed during carbon-cache shutdown
and at regular interval. This can be force with this API
Sample : curl "http://localhost/metrics/persist-cache" -X POST

* metrics/flush-cache?metric=<regexp>
This allow to ask carbon cache instances to flush queues matching the given regexp
The current cache write strategy is hold during this operation, and restore after all matching queues are flushed
This operation can be cancel by calling the API with DELETE method (without parameters)
Sample : (start flushing) curl "http://localhost/metrics/flush-cache?metric=^carbon" -X POST
         (stop flushing)  curl "http://localhost/metrics/flush-cache" -X DELETE

Note: This patch requires a patch in carbon-cache (https://github.com/graphite-project/carbon/pull/419)