### PR TITLE
Fix clustered webapp race condition writing to cache

### DIFF
--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -123,7 +123,7 @@ def renderView(request):
         log.rendering("Retrieval of %s took %.6f" % (target, time() - t))
         data.extend(seriesList)
 
-      if useCache && data:
+      if useCache and data:
         cache.add(dataKey, data, cacheTimeout)
 
     format = requestOptions.get('format')

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -123,7 +123,7 @@ def renderView(request):
         log.rendering("Retrieval of %s took %.6f" % (target, time() - t))
         data.extend(seriesList)
 
-      if useCache:
+      if useCache && data:
         cache.add(dataKey, data, cacheTimeout)
 
     format = requestOptions.get('format')


### PR DESCRIPTION
Check data not empty before adding to cache. Fix for #1278?

