### PR TITLE
Travis container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python: 2.7
+sudo: false
 
 env:
   - TOXENV=py26-django14-pyparsing2
@@ -13,8 +14,10 @@ env:
   - TOXENV=docs
   - TOXENV=lint
 
-before_install:
-  - sudo apt-get -y install libcairo2-dev
+addons:
+  apt:
+    packages:
+      - libcairo2-dev
 
 install:
   - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,8 @@ deps =
 	cairocffi
 	django-tagging>=0.3.5,<0.4
 	pytz
-	mock
+	py26: mock<1.1.0
+	py27: mock
 	git+git://github.com/graphite-project/whisper.git#egg=whisper
 	git+git://github.com/graphite-project/ceres.git#egg=ceres
 	pyparsing1: pyparsing==1.5.7


### PR DESCRIPTION
This should speed up travis builds. An update of the `mock` library also broke all python2.6 builds.