### PR TITLE
Fix bug to create event with the specific when datetime

### DIFF
--- a/webapp/graphite/events/views.py
+++ b/webapp/graphite/events/views.py
@@ -49,7 +49,7 @@ def post_event(request):
         values["what"] = event["what"]
         values["tags"] = event.get("tags", None)
         values["when"] = datetime.datetime.fromtimestamp(
-            event.get("when", time.time()))
+            float(event.get("when", time.time())))
         if "data" in event:
             values["data"] = event["data"]
 
@@ -63,7 +63,7 @@ def post_event(request):
 def get_data(request):
     if 'jsonp' in request.REQUEST:
         response = HttpResponse(
-          "%s(%s)" % (request.REQUEST.get('jsonp'), 
+          "%s(%s)" % (request.REQUEST.get('jsonp'),
               json.dumps(fetch(request), cls=EventEncoder)),
           content_type='text/javascript')
     else:


### PR DESCRIPTION
failed to send HTTP request with the specific 'when' datetime to create event

Traceback (most recent call last):
  File &quot;/opt/graphite/webapp/graphite/events/views.py&quot;, line 51, in post_event
    values[&quot;when&quot;] = datetime.datetime.fromtimestamp(event.get(&quot;when&quot;, time.time()))
TypeError: a float is required
