### PR TITLE
Fix Ceres Finder to allow curly braces in metrics find requests

### DIFF
--- a/webapp/graphite/finders/__init__.py
+++ b/webapp/graphite/finders/__init__.py
@@ -28,6 +28,18 @@ def _deduplicate(entries):
       yield entry
 
 
+def extract_variants(pattern):
+  """Extract the pattern variants (ie. {foo,bar}baz = foobaz or barbaz)."""
+  v1, v2 = pattern.find('{'), pattern.find('}')
+  if v1 > -1 and v2 > v1:
+    variations = pattern[v1+1:v2].split(',')
+    variants = [ pattern[:v1] + v + pattern[v2+1:] for v in variations ]
+
+  else:
+    variants = [ pattern ]
+  return list( _deduplicate(variants) )
+
+
 def match_entries(entries, pattern):
   """A drop-in replacement for fnmatch.filter that supports pattern
   variants (ie. {foo,bar}baz = foobaz or barbaz)."""

--- a/webapp/graphite/finders/ceres.py
+++ b/webapp/graphite/finders/ceres.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from graphite.node import BranchNode, LeafNode
 from graphite.readers import CeresReader
 
-from . import get_real_metric_path
+from . import get_real_metric_path, extract_variants
 
 
 class CeresFinder:
@@ -18,16 +18,20 @@ class CeresFinder:
     self.tree = CeresTree(directory)
 
   def find_nodes(self, query):
-    for fs_path in glob( self.tree.getFilesystemPath(query.pattern) ):
-      metric_path = self.tree.getNodePath(fs_path)
 
-      if CeresNode.isNodeDir(fs_path):
-        ceres_node = self.tree.getNode(metric_path)
+    variants = extract_variants(query.pattern)
 
-        if ceres_node.hasDataForInterval(query.startTime, query.endTime):
-          real_metric_path = get_real_metric_path(fs_path, metric_path)
-          reader = CeresReader(ceres_node, real_metric_path)
-          yield LeafNode(metric_path, reader)
+    for variant in variants:
+      for fs_path in glob( self.tree.getFilesystemPath(variant)):
+        metric_path = self.tree.getNodePath(fs_path)
 
-      elif os.path.isdir(fs_path):
-        yield BranchNode(metric_path)
+        if CeresNode.isNodeDir(fs_path):
+          ceres_node = self.tree.getNode(metric_path)
+
+          if ceres_node.hasDataForInterval(query.startTime, query.endTime):
+            real_metric_path = get_real_metric_path(fs_path, metric_path)
+            reader = CeresReader(ceres_node, real_metric_path)
+            yield LeafNode(metric_path, reader)
+
+        elif os.path.isdir(fs_path):
+          yield BranchNode(metric_path)


### PR DESCRIPTION
Using curly braces resulted in failed lookups with the Ceres finder because the python glob function doesn't handle them.

Mentioned in #1218 and #256 