### PR TITLE
Backport of #1188 "Serve staticfiles in the webapp if whitenoise is installed" to 0.9.x

### DIFF
--- a/check-dependencies.py
+++ b/check-dependencies.py
@@ -157,6 +157,14 @@ except:
   print "Note that txamqp requires python 2.5 or greater."
   warning += 1
 
+# Test for whitenoise
+try:
+  import whitenoise
+except ImportError:
+  print "[INFO]"
+  print "Unable to import the 'whitenoise' module."
+  print "This is useful for serving static files."
+
 
 if fatal:
   print "%d necessary dependencies not met. Graphite will not function until these dependencies are fulfilled." % fatal

--- a/conf/graphite.wsgi.example
+++ b/conf/graphite.wsgi.example
@@ -14,22 +14,29 @@ from graphite.logger import log
 
 application = get_wsgi_application()
 
-# whitenoise working only in python >= 2.7
-if sys.version_info[0] >= 2 and sys.version_info[1] >= 7:
-    try:
-        from whitenoise.django import DjangoWhiteNoise
-    except ImportError:
-        pass
-    else:
-        application = DjangoWhiteNoise(application)
-        prefix = "/".join((settings.URL_PREFIX.strip('/'), 'static'))
-        for directory in settings.STATICFILES_DIRS:
+try:
+    import whitenoise
+except ImportError:
+    whitenoise = False
+else:
+    # WhiteNoise < 2.0.1 does not support Python 2.6
+    if sys.version_info[:2] < (2, 7):
+        whitenoise_version = tuple(map(
+                int, getattr(whitenoise, '__version__', '0').split('.')))
+        if whitenoise_version < (2, 0, 1):
+            whitenoise = False
+
+if whitenoise:
+    from whitenoise.django import DjangoWhiteNoise
+    application = DjangoWhiteNoise(application)
+    prefix = "/".join((settings.URL_PREFIX.strip('/'), 'static'))
+    for directory in settings.STATICFILES_DIRS:
+        application.add_files(directory, prefix=prefix)
+    for app_path in settings.INSTALLED_APPS:
+        module = import_module(app_path)
+        directory = os.path.join(os.path.dirname(module.__file__), 'static')
+        if os.path.isdir(directory):
             application.add_files(directory, prefix=prefix)
-        for app_path in settings.INSTALLED_APPS:
-            module = import_module(app_path)
-            directory = os.path.join(os.path.dirname(module.__file__), 'static')
-            if os.path.isdir(directory):
-                application.add_files(directory, prefix=prefix)
 
 # Initializing the search index can be very expensive. The import below
 # ensures the index is preloaded before any requests are handed to the

--- a/conf/graphite.wsgi.example
+++ b/conf/graphite.wsgi.example
@@ -1,25 +1,38 @@
-import os, sys
-sys.path.append('/opt/graphite/webapp')
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'graphite.settings')
+import os
+import sys
 
-import django
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 
-if django.VERSION < (1, 4):
-    from django.core.handlers.wsgi import WSGIHandler
-    application = WSGIHandler()
-else:
-    # From 1.4 wsgi support was improved and since 1.7 old style WSGI script
-    # causes AppRegistryNotReady exception
-    # https://docs.djangoproject.com/en/dev/releases/1.7/#wsgi-scripts
-    from django.core.wsgi import get_wsgi_application
-    application = get_wsgi_application()
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'graphite.settings')  # noqa
 
-
-# READ THIS
-# Initializing the search index can be very expensive, please include
-# the WSGIImportScript directive pointing to this script in your vhost
-# config to ensure the index is preloaded before any requests are handed
-# to the process.
+from django.conf import settings
+from django.core.wsgi import get_wsgi_application
 from graphite.logger import log
+
+application = get_wsgi_application()
+
+# whitenoise working only in python >= 2.7
+if sys.version_info[0] >= 2 and sys.version_info[1] >= 7:
+    try:
+        from whitenoise.django import DjangoWhiteNoise
+    except ImportError:
+        pass
+    else:
+        application = DjangoWhiteNoise(application)
+        prefix = "/".join((settings.URL_PREFIX.strip('/'), 'static'))
+        for directory in settings.STATICFILES_DIRS:
+            application.add_files(directory, prefix=prefix)
+        for app_path in settings.INSTALLED_APPS:
+            module = import_module(app_path)
+            directory = os.path.join(os.path.dirname(module.__file__), 'static')
+            if os.path.isdir(directory):
+                application.add_files(directory, prefix=prefix)
+
+# Initializing the search index can be very expensive. The import below
+# ensures the index is preloaded before any requests are handed to the
+# process.
 log.info("graphite.wsgi - pid %d - reloading search index" % os.getpid())
-import graphite.metrics.search
+import graphite.metrics.search  # noqa

--- a/docs/config-local-settings.rst
+++ b/docs/config-local-settings.rst
@@ -112,6 +112,9 @@ STATIC_ROOT
           alias /opt/graphite/static/;
       }
 
+  Alternatively, static files can be served directly by the Graphite webapp if
+  you install the ``whitenoise`` Python package.
+
 DASHBOARD_CONF
   `Default: CONF_DIR/dashboard.conf`
   The location of the Graphite-web Dashboard configuration

--- a/examples/example-graphite-vhost.conf
+++ b/examples/example-graphite-vhost.conf
@@ -36,6 +36,13 @@ WSGISocketPrefix run/wsgi
         # file in this directory that you can safely use, just copy it to graphite.wgsi
         WSGIScriptAlias / /opt/graphite/conf/graphite.wsgi 
 
+        # XXX To serve static files, either:
+        # django-admin.py collectstatic --noinput --settings=graphite.settings
+        # * Install the whitenoise Python package (pip install whitenoise)
+        # or
+        # * Collect static files in a directory by running:
+        #     django-admin.py collectstatic --noinput --settings=graphite.settings
+        #   And set an alias to serve static files with Apache:
         Alias /content/ /opt/graphite/webapp/content/
         <Location "/content/">
                 SetHandler None

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ sphinx
 sphinx_rtd_theme
 cairocffi
 git+git://github.com/graphite-project/whisper.git@0.9.13#egg=whisper
+whitenoise


### PR DESCRIPTION
This avoids the collectstatic step & apache configuration. It's probably slightly less optimal than serving files with apache/nginx but much easier to start with.
Whitenoise is compatible with Django 1.4 and above, but before version 2.0.2 it was compatible only with python 2.7, so in this version safecheck is included.

Tested with synthesize and manual whitenoise installation, but please check more.

Rebase of https://github.com/graphite-project/graphite-web/pull/1209