### PR TITLE
Ensure WhiteNoise < 2.0.1 not used with Python 2.6

### DIFF
--- a/webapp/graphite/wsgi.py
+++ b/webapp/graphite/wsgi.py
@@ -14,22 +14,29 @@ from graphite.logger import log
 
 application = get_wsgi_application()
 
-# whitenoise working only in python >= 2.7
-if sys.version_info[0] >= 2 and sys.version_info[1] >= 7:
-    try:
-        from whitenoise.django import DjangoWhiteNoise
-    except ImportError:
-        pass
-    else:
-        application = DjangoWhiteNoise(application)
-        prefix = "/".join((settings.URL_PREFIX.strip('/'), 'static'))
-        for directory in settings.STATICFILES_DIRS:
+try:
+    import whitenoise
+except ImportError:
+    whitenoise = False
+else:
+    # WhiteNoise < 2.0.1 does not support Python 2.6
+    if sys.version_info[:2] < (2, 7):
+        whitenoise_version = tuple(map(
+                int, getattr(whitenoise, '__version__', '0').split('.')))
+        if whitenoise_version < (2, 0, 1):
+            whitenoise = False
+
+if whitenoise:
+    from whitenoise.django import DjangoWhiteNoise
+    application = DjangoWhiteNoise(application)
+    prefix = "/".join((settings.URL_PREFIX.strip('/'), 'static'))
+    for directory in settings.STATICFILES_DIRS:
+        application.add_files(directory, prefix=prefix)
+    for app_path in settings.INSTALLED_APPS:
+        module = import_module(app_path)
+        directory = os.path.join(os.path.dirname(module.__file__), 'static')
+        if os.path.isdir(directory):
             application.add_files(directory, prefix=prefix)
-        for app_path in settings.INSTALLED_APPS:
-            module = import_module(app_path)
-            directory = os.path.join(os.path.dirname(module.__file__), 'static')
-            if os.path.isdir(directory):
-                application.add_files(directory, prefix=prefix)
 
 # Initializing the search index can be very expensive. The import below
 # ensures the index is preloaded before any requests are handed to the


### PR DESCRIPTION
WhiteNoise version 2.0.1 onwards now supports Python 2.6