### PR TITLE
0.9.x timeouts buffers

### DIFF
--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -345,13 +345,10 @@ def fetchRemoteData(requestContext, pathExpr, usePrefetchCache=settings.REMOTE_P
 
   # Once the remote_fetches have started, wait for them all to finish. Assuming an
   # upper bound of REMOTE_STORE_FETCH_TIMEOUT per thread, this should take about that
-  # amount of time (6s by default) at the longest. If every thread blocks permanently,
-  # then this could take a horrible REMOTE_STORE_FETCH_TIMEOUT * num(remote_fetches),
-  # but then that would imply that remote_storage's HTTPConnectionWithTimeout class isn't
-  # working correctly :-)
+  # amount of time (6s by default) at the longest.
   for fetch_thread in remote_fetches:
     try:
-      fetch_thread.join(settings.REMOTE_STORE_FETCH_TIMEOUT)
+      fetch_thread.join()
     except:
       log.exception("Failed to join remote_fetch thread within %ss" % (settings.REMOTE_STORE_FETCH_TIMEOUT))
 


### PR DESCRIPTION
Timeouts were not functioning on my Graphite setup with Python 2.7 and the joining of the fetch threads was hitting the worst case scenario where I was waiting FETCH_TIMEOUT * number of servers.

If we can assume that the thread's HTTP timeout feature actually works then the timeouts on the joins become unneeded.  I also found that I was silently losing data points for queries when the thread didn't join.

This requires Python 2.6.  I'm not sure if that's a planned requirement for 0.9.13 or not.