### PR TITLE
Enable buffering in HTTPResponse objects

### DIFF
--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -78,7 +78,7 @@ class FindRequest:
       self.send()
 
     try:
-      response = self.connection.getresponse()
+      response = self.connection.getresponse(buffering=True)
       assert response.status == 200, "received error response %s - %s" % (response.status, response.reason)
       result_data = response.read()
       results = unpickle.loads(result_data)
@@ -139,7 +139,7 @@ class RemoteNode:
       connection.request('POST', '/render/', query_string)
     else:
       connection.request('GET', '/render/?' + query_string)
-    response = connection.getresponse()
+    response = connection.getresponse(buffering=True)
     assert response.status == 200, "Failed to retrieve remote data: %d %s" % (response.status, response.reason)
     rawData = response.read()
 


### PR DESCRIPTION
This improves performance of downloading data from the storage backends
quite a bit.

This requires Python 2.7.  I should probably test to see if this API exists before using it. Hmm...