### PR TITLE
Add unit tests for parseTimeOffset in atttime class

### DIFF
--- a/webapp/tests/test_attime.py
+++ b/webapp/tests/test_attime.py
@@ -6,7 +6,7 @@ except ImportError:
     import unittest
 from django.test import TestCase
 from django.utils import timezone
-from graphite.render.attime import parseTimeReference, parseATTime
+from graphite.render.attime import parseTimeReference, parseATTime, parseTimeOffset, getUnitString
 
 MOCK_DATE = datetime.datetime(2015, 1, 1, 11, 00)
 
@@ -120,6 +120,157 @@ class parseTimeReferenceTest(parseTimeTest):
         time_ref = parseTimeReference("monday")
         expected = datetime.datetime(2014, 12, 29, 0, 0)
         self.assertEquals(time_ref, expected)
+
+
+class parseTimeOffsetTest(TestCase):
+
+    def test_parse_None_returns_empty_timedelta(self):
+        time_ref = parseTimeOffset(None)
+        expected = datetime.timedelta(0)
+        self.assertEquals(time_ref, expected)
+
+    def test_parse_integer_raises_TypeError(self):
+        with self.assertRaises(TypeError):
+            time_ref = parseTimeOffset(1)
+
+    def test_parse_string_starting_neither_with_minus_nor_digit_raises_KeyError(self):
+        with self.assertRaises(KeyError):
+            time_ref = parseTimeOffset("Something")
+
+    def test_parse_m_as_unit_raises_Exception(self):
+        with self.assertRaises(Exception):
+            time_ref = parseTimeOffset("1m")
+
+    def test_parse_digits_only_raises_exception(self):
+        with self.assertRaises(Exception):
+            time_ref = parseTimeOffset("10")
+
+    def test_parse_alpha_only_raises_KeyError(self):
+        with self.assertRaises(KeyError):
+            time_ref = parseTimeOffset("month")
+
+    def test_parse_minus_only_returns_zero(self):
+        time_ref = parseTimeOffset("-")
+        expected = datetime.timedelta(0)
+        self.assertEquals(time_ref, expected)
+
+    def test_parse_plus_only_returns_zero(self):
+        time_ref = parseTimeOffset("+")
+        expected = datetime.timedelta(0)
+        self.assertEquals(time_ref, expected)
+
+    def test_parse_ten_days(self):
+        time_ref = parseTimeOffset("10days")
+        expected = datetime.timedelta(10)
+        self.assertEquals(time_ref, expected)
+
+    def test_parse_zero_days(self):
+        time_ref = parseTimeOffset("0days")
+        expected = datetime.timedelta(0)
+        self.assertEquals(time_ref, expected)
+
+    def test_parse_minus_ten_days(self):
+        time_ref = parseTimeOffset("-10days")
+        expected = datetime.timedelta(-10)
+        self.assertEquals(time_ref, expected)
+
+    def test_parse_five_seconds(self):
+        time_ref = parseTimeOffset("5seconds")
+        expected = datetime.timedelta(seconds=5)
+        self.assertEquals(time_ref, expected)
+
+    def test_parse_five_minutes(self):
+        time_ref = parseTimeOffset("5minutes")
+        expected = datetime.timedelta(minutes=5)
+        self.assertEquals(time_ref, expected)
+
+    def test_parse_five_hours(self):
+        time_ref = parseTimeOffset("5hours")
+        expected = datetime.timedelta(hours=5)
+        self.assertEquals(time_ref, expected)
+
+    def test_parse_five_weeks(self):
+        time_ref = parseTimeOffset("5weeks")
+        expected = datetime.timedelta(weeks=5)
+        self.assertEquals(time_ref, expected)
+
+    def test_parse_one_month_returns_thirty_days(self):
+        time_ref = parseTimeOffset("1month")
+        expected = datetime.timedelta(30)
+        self.assertEquals(time_ref, expected)
+
+    def test_parse_two_months_returns_sixty_days(self):
+        time_ref = parseTimeOffset("2months")
+        expected = datetime.timedelta(60)
+        self.assertEquals(time_ref, expected)
+
+    def test_parse_twelve_months_returns_360_days(self):
+        time_ref = parseTimeOffset("12months")
+        expected = datetime.timedelta(360)
+        self.assertEquals(time_ref, expected)
+
+    def test_parse_one_year_returns_365_days(self):
+        time_ref = parseTimeOffset("1year")
+        expected = datetime.timedelta(365)
+        self.assertEquals(time_ref, expected)
+
+    def test_parse_two_years_returns_730_days(self):
+        time_ref = parseTimeOffset("2years")
+        expected = datetime.timedelta(730)
+        self.assertEquals(time_ref, expected)
+
+
+class getUnitStringTest(TestCase):
+
+    def test_get_seconds(self):
+        test_cases = ['s', 'se', 'sec', 'second', 'seconds']
+        for test_case in test_cases:
+            result = getUnitString(test_case)
+            self.assertEquals(result, 'seconds')
+
+    def test_get_minutes(self):
+        test_cases = ['min', 'minute', 'minutes']
+        for test_case in test_cases:
+            result = getUnitString(test_case)
+            self.assertEquals(result, 'minutes')
+
+    def test_get_hours(self):
+        test_cases = ['h', 'ho', 'hour', 'hours']
+        for test_case in test_cases:
+            result = getUnitString(test_case)
+            self.assertEquals(result, 'hours')
+
+    def test_get_days(self):
+        test_cases = ['d', 'da', 'day', 'days']
+        for test_case in test_cases:
+            result = getUnitString(test_case)
+            self.assertEquals(result, 'days')
+
+    def test_get_weeks(self):
+        test_cases = ['w', 'we', 'week', 'weeks']
+        for test_case in test_cases:
+            result = getUnitString(test_case)
+            self.assertEquals(result, 'weeks')
+
+    def test_get_months(self):
+        test_cases = ['mon', 'month', 'months']
+        for test_case in test_cases:
+            result = getUnitString(test_case)
+            self.assertEquals(result, 'months')
+
+    def test_get_years(self):
+        test_cases = ['y', 'ye', 'year', 'years']
+        for test_case in test_cases:
+            result = getUnitString(test_case)
+            self.assertEquals(result, 'years')
+
+    def test_m_raises_Exception(self):
+        with self.assertRaises(Exception):
+            result = getUnitString("m")
+
+    def test_integer_raises_Exception(self):
+        with self.assertRaises(Exception):
+            result = getUnitString(1)
 
 
 class parseATTimeTest(parseTimeTest):


### PR DESCRIPTION
Just like for #1276, as I was trying to understand what was going on with `summarize`, I ended up writing a test suite (cc @SEJeff).