### PR TITLE
Enable CLUSTER_SERVER to talk to each other using HTTPS

### DIFF
--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -216,6 +216,8 @@
 # used.
 #CLUSTER_SERVERS = ["10.0.2.2:80", "10.0.2.3:80"]
 
+# This settings control wether https is used to communicate between cluster members
+#INTRACLUSTER_HTTPS = False
 ## These are timeout values (in seconds) for requests to remote webapps
 #REMOTE_FIND_TIMEOUT = 3.0             # Timeout for metric find requests
 #REMOTE_FETCH_TIMEOUT = 6.0            # Timeout to fetch series data

--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -301,8 +301,8 @@ class HTTPSConnectionWithTimeout(httplib.HTTPSConnection):
           pass
         self.sock.connect(sa)
         self.sock.settimeout(None)
-        ssl = socket.ssl(sock, self.key_file, self.cert_file)
-        self.sock = socket.FakeSocket(sock, ssl)
+        ssl = socket.ssl(self.sock, self.key_file, self.cert_file)
+        self.sock = socket.FakeSocket(self.sock, ssl)
       except socket.error as e:
         msg = e
         if self.sock:

--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -1,4 +1,3 @@
-import socket
 import time
 import httplib
 from urllib import urlencode

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -51,6 +51,8 @@ CLUSTER_SERVERS = []
 
 # Cluster settings
 CLUSTER_SERVERS = []
+# This settings control wether https is used to communicate between cluster members
+INTRACLUSTER_HTTPS = False
 REMOTE_FIND_TIMEOUT = 3.0
 REMOTE_FETCH_TIMEOUT = 6.0
 REMOTE_RETRY_DELAY = 60.0


### PR DESCRIPTION
In cases where each cluster member is using https.  The HTTPS does not attempt to perform any kind of authentication, but simply enables the servers to use https.  This was once asked for in #856.