### PR TITLE
add optional parameter referenceSeries to transformNull

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2633,10 +2633,11 @@ def threshold(requestContext, value, label=None, color=None):
 
 def transformNull(requestContext, seriesList, default=0):
   """
-  Takes a metric or wild card seriesList and an optional value
-  to transform Nulls to. Default is 0. This method compliments
-  drawNullAsZero flag in graphical mode but also works in text only
-  mode.
+  Takes a metric or wildcard seriesList and replaces null values with the value
+  specified by `default`.  The value 0 used if not specified.  This method
+  compliments the drawNullAsZero function in graphical mode, but also works in
+  text-only mode.
+
   Example:
 
   .. code-block:: none

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2661,10 +2661,9 @@ def transformNull(requestContext, seriesList, default=0):
 
 def isNonNull(requestContext, seriesList):
   """
-  Takes a metric or wild card seriesList and counts up how many
-  non-null values are specified. This is useful for understanding
-  which metrics have data at a given point in time (ie, to count
-  which servers are alive).
+  Takes a metric or wildcard seriesList and counts up the number of non-null
+  values.  This is useful for understanding the number of metrics that have data
+  at a given point in time (i.e. to count which servers are alive).
 
   Example:
 

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2631,12 +2631,15 @@ def threshold(requestContext, value, label=None, color=None):
 
   return [series]
 
-def transformNull(requestContext, seriesList, default=0):
+def transformNull(requestContext, seriesList, default=0, referenceSeries=None):
   """
   Takes a metric or wildcard seriesList and replaces null values with the value
-  specified by `default`.  The value 0 used if not specified.  This method
-  compliments the drawNullAsZero function in graphical mode, but also works in
-  text-only mode.
+  specified by `default`.  The value 0 used if not specified.  The optional
+  referenceSeries, if specified, is a metric or wildcard series list that governs
+  which time intervals nulls should be replaced.  If specified, nulls are replaced
+  only in intervals where a non-null is found for the same interval in any of
+  referenceSeries.  This method compliments the drawNullAsZero function in
+  graphical mode, but also works in text-only mode.
 
   Example:
 
@@ -2647,14 +2650,25 @@ def transformNull(requestContext, seriesList, default=0):
   This would take any page that didn't have values and supply negative 1 as a default.
   Any other numeric value may be used as well.
   """
-  def transform(v):
-    if v is None: return default
+  def transform(v, d):
+    if v is None: return d
     else: return v
 
+  if referenceSeries:
+    defaults = [default if any(v is not None for v in x) else None for x in izip(*referenceSeries)]
+  else:
+    defaults = None
+
   for series in seriesList:
-    series.name = "transformNull(%s,%g)" % (series.name, default)
+    if referenceSeries:
+      series.name = "transformNull(%s,%g,referenceSeries)" % (series.name, default)
+    else:
+      series.name = "transformNull(%s,%g)" % (series.name, default)
     series.pathExpression = series.name
-    values = [transform(v) for v in series]
+    if defaults:
+      values = [transform(v, d) for v, d in izip(series, defaults)]
+    else:
+      values = [transform(v, default) for v in series]
     series.extend(values)
     del series[:len(values)]
   return seriesList


### PR DESCRIPTION
This commit adds an optional third parameter, ~~keySeries~~ referenceSeries, to transformNull().
This argument, if specified, governs that transformation of nulls should not
happen unconditionally on every data interval, but rather, on the condition
that the same data interval in any series of keySeries is also non-null.

The motivation for this functionality stems from the need to differentiate
between nulls that represent "zero" and those that represent "no data".
The parameter keySeries is used to identify the data intervals to which
there are data, so that transformNulls() can transforms nulls in such
intervals as unequivocal zeros.