### PR TITLE
Add LDAP user template.

### DIFF
--- a/docs/config-local-settings.rst
+++ b/docs/config-local-settings.rst
@@ -267,6 +267,13 @@ LDAP_USER_QUERY
   Sets the LDAP query to return a user object where ``%s`` substituted with the
   user id. E.g. ``(username=%s)`` or ``(sAMAccountName=%s)`` (Active Directory)
 
+LDAP_USER_DN_TEMPLATE:
+  `Default: ''`
+
+  Is this is set the LDAP query is authenticated with the usename and passowrd
+  supplied from the user.
+
+
 
 Other Authentications
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/config-local-settings.rst
+++ b/docs/config-local-settings.rst
@@ -270,8 +270,10 @@ LDAP_USER_QUERY
 LDAP_USER_DN_TEMPLATE:
   `Default: ''`
 
-  Is this is set the LDAP query is authenticated with the usename and passowrd
-  supplied from the user.
+  Instead of using a hardcoded username and password for the account that binds
+  to the LDAP server you could use the credentials of the user that tries to
+  log in to Graphite. This is the template that creates the full DN to bind
+  with.
 
 
 

--- a/webapp/graphite/account/ldapBackend.py
+++ b/webapp/graphite/account/ldapBackend.py
@@ -19,6 +19,9 @@ from django.contrib.auth.models import User
 
 class LDAPBackend:
   def authenticate(self, username=None, password=None):
+    if settings.LDAP_USER_DN_TEMPLATE is not None:
+      settings.LDAP_BASE_USER = settings.LDAP_USER_DN_TEMPLATE % {'username': username}
+      settings.LDAP_BASE_PASS = password
     try:
       conn = ldap.initialize(settings.LDAP_URI)
       conn.protocol_version = ldap.VERSION3

--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -126,7 +126,10 @@
 #LDAP_BASE_USER = "CN=some_readonly_account,DC=mycompany,DC=com"
 #LDAP_BASE_PASS = "readonly_account_password"
 #LDAP_USER_QUERY = "(username=%s)"  #For Active Directory use "(sAMAccountName=%s)"
-#LDAP_USER_DN_TEMPLATE = "CN=%(username)s,DC=mycompany,DC=com"
+#LDAP_USER_DN_TEMPLATE = "CN=%(username)s,OU=users,DC=mycompany,DC=com"
+# User DN templat to use for binding (and authentication) against
+# the LDAP server. %(username) is replaced with the username supplied at
+# graphite login.
 #
 # If you want to further customize the ldap connection options you should
 # directly use ldap.set_option to set the ldap module's global options.

--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -126,10 +126,11 @@
 #LDAP_BASE_USER = "CN=some_readonly_account,DC=mycompany,DC=com"
 #LDAP_BASE_PASS = "readonly_account_password"
 #LDAP_USER_QUERY = "(username=%s)"  #For Active Directory use "(sAMAccountName=%s)"
-#LDAP_USER_DN_TEMPLATE = "CN=%(username)s,OU=users,DC=mycompany,DC=com"
-# User DN templat to use for binding (and authentication) against
+#
+# User DN template to use for binding (and authentication) against
 # the LDAP server. %(username) is replaced with the username supplied at
 # graphite login.
+#LDAP_USER_DN_TEMPLATE = "CN=%(username)s,OU=users,DC=mycompany,DC=com"
 #
 # If you want to further customize the ldap connection options you should
 # directly use ldap.set_option to set the ldap module's global options.

--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -126,6 +126,7 @@
 #LDAP_BASE_USER = "CN=some_readonly_account,DC=mycompany,DC=com"
 #LDAP_BASE_PASS = "readonly_account_password"
 #LDAP_USER_QUERY = "(username=%s)"  #For Active Directory use "(sAMAccountName=%s)"
+#LDAP_USER_DN_TEMPLATE = "CN=%(username)s,DC=mycompany,DC=com"
 #
 # If you want to further customize the ldap connection options you should
 # directly use ldap.set_option to set the ldap module's global options.


### PR DESCRIPTION
This allows graphite to authorize to LDAP with the user supplied in the login
window instead of static user, similar to how Django LDAP does it.