### PR TITLE
Fix browserHeader background fill

### DIFF
--- a/webapp/graphite/templates/browserHeader.html
+++ b/webapp/graphite/templates/browserHeader.html
@@ -17,6 +17,9 @@ limitations under the License. -->
     <meta http-equiv="content-type" content="text/html; charset=ISO-8859-1">
     <title>Graphite Browser Header</title>
     <style>
+      html {
+        height: 100%;
+      }
       body {
         background-color: #000;
         background: #000 url('{% static "img/carbon-fiber.png" %}');


### PR DESCRIPTION
The background effects weren't filling the header frame properly. Before and after screenshots:

<img width="425" alt="screen shot 2015-09-27 at 11 17 41 am" src="https://cloud.githubusercontent.com/assets/494338/10123526/c2823a94-6509-11e5-832d-dd5354d4df9b.png">
<img width="424" alt="screen shot 2015-09-27 at 11 17 52 am" src="https://cloud.githubusercontent.com/assets/494338/10123527/c5b8c82c-6509-11e5-95a2-83e652f8e1f2.png">
