### PR TITLE
Enable buffering in HTTPResponse objects (with python 2.6 fallback)

### DIFF
--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -77,12 +77,15 @@ class FindRequest:
     if not self.connection:
       self.send()
 
-    try:
+    try:  # Python 2.7+, use buffering of HTTP responses
+      response = self.connection.getresponse(buffering=True)
+    except TypeError:  # Python 2.6 and older
       response = self.connection.getresponse()
+
+    try:
       assert response.status == 200, "received error response %s - %s" % (response.status, response.reason)
       result_data = response.read()
       results = unpickle.loads(result_data)
-
     except:
       self.store.fail()
       if not self.suppressErrors:
@@ -139,7 +142,10 @@ class RemoteNode:
       connection.request('POST', '/render/', query_string)
     else:
       connection.request('GET', '/render/?' + query_string)
-    response = connection.getresponse()
+    try:  # Python 2.7+, use buffering of HTTP responses
+      response = connection.getresponse(buffering=True)
+    except TypeError:  # Python 2.6 and older
+      response = connection.getresponse()
     assert response.status == 200, "Failed to retrieve remote data: %d %s" % (response.status, response.reason)
     rawData = response.read()
 


### PR DESCRIPTION
Same as https://github.com/graphite-project/graphite-web/pull/1308 but with python 2.6 fallback