### PR TITLE
Bypass incorrect flake8 F401 warning

### DIFF
--- a/webapp/graphite/render/attime.py
+++ b/webapp/graphite/render/attime.py
@@ -15,7 +15,7 @@ limitations under the License."""
 import pytz
 from datetime import datetime,timedelta
 from time import daylight
-from django.utils import timezone
+from django.utils import timezone # noqa
 from django.conf import settings
 
 months = ['jan','feb','mar','apr','may','jun','jul','aug','sep','oct','nov','dec']


### PR DESCRIPTION
Per https://github.com/graphite-project/graphite-web/pull/1180#issuecomment-143607429 flake8 is claiming an F401 but this seems wrong. We're using `timezone` in two locations in the file.

```
/home/travis/build/graphite-project/graphite-web/webapp/graphite/render/attime.py:18:1: F401 'timezone' imported but unused
ERROR: InvocationError: '/home/travis/build/graphite-project/graphite-web/.tox/lint/bin/flake8 /home/travis/build/graphite-project/graphite-web/webapp/graphite'
```