### PR TITLE
Never merge CarbonLink results with Whisper rollups

### DIFF
--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -464,8 +464,6 @@ def mergeResults(dbResults, cacheResults):
 
   if not dbResults:
     return cacheResults
-  elif not cacheResults:
-    return dbResults
 
   (timeInfo,values) = dbResults
   (start,end,step) = timeInfo

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -384,7 +384,9 @@ def fetchData(requestContext, pathExpr):
         else:
           cachedResults = CarbonLink.query(dbFile.real_metric)
         if cachedResults:
-          dbResults = mergeResults(dbResults, cachedResults)
+          meta_info = dbFile.getInfo()
+          lowest_step = min([i['secondsPerPoint'] for i in meta_info['archives']])
+          dbResults = mergeResults(dbResults, cachedResults, lowest_step)
       except:
         log.exception("Failed CarbonLink query '%s'" % dbFile.real_metric)
 
@@ -459,7 +461,7 @@ def fetchData(requestContext, pathExpr):
   return sorted(seriesList, key=lambda series: series.name)
 
 
-def mergeResults(dbResults, cacheResults):
+def mergeResults(dbResults, cacheResults, lowest_step):
   cacheResults = list(cacheResults)
 
   if not dbResults:
@@ -467,6 +469,10 @@ def mergeResults(dbResults, cacheResults):
 
   (timeInfo,values) = dbResults
   (start,end,step) = timeInfo
+
+  # we're pulling from archive, shouldn't be merging cacheResults
+  if not step == lowest_step:
+    return dbResults
 
   for (timestamp, value) in cacheResults:
     interval = timestamp - (timestamp % step)

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -328,6 +328,9 @@ class WhisperFile(Leaf):
     end = max( os.stat(self.fs_path).st_mtime, start )
     return [ (start, end) ]
 
+  def getInfo(self):
+    return whisper.info(self.fs_path)
+
   def fetch(self, startTime, endTime, now=None):
     return whisper.fetch(self.fs_path, startTime, endTime, now)
 


### PR DESCRIPTION
We shouldn't merge CarbonLink results with Whisper results if the latter is pulled from a rollup archive. Proposed fix was merged to master in #1002, this is an attempt to port the same logic to 0.9.x.

/cc @penpen @jssjr @deniszh 