### PR TITLE
Skip empty target params

### DIFF
--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -119,6 +119,8 @@ def renderView(request):
         requestContext['prefetchedRemoteData'] = prefetchRemoteData(requestContext, pathExpressions)
         log.rendering("Prefetching remote data took %.6f" % (time() - t))
       for target in targets:
+        if not target.strip():
+          continue
         t = time()
         seriesList = evaluateTarget(requestContext, target)
         log.rendering("Retrieval of %s took %.6f" % (target, time() - t))


### PR DESCRIPTION
Check that we have an actual `target` string or skip it. The `master` branch already has this fix, brought in during the megacarbon-ceres merge. Fixes #427 (or the master commit already did).