### PR TITLE
Add test coverage support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,7 @@ install:
 
 script:
   - tox -e $TOXENV
+
+after_success:
+  - pip install codecov
+  - codecov

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,11 @@ setenv =
 	GRAPHITE_NO_PREFIX=true
 changedir = webapp
 commands =
-	django-admin.py test
+	coverage run --branch manage.py test
+	coverage xml --include=graphite/*
+	coverage report --include=graphite/*
 deps =
+	coverage
 	cairocffi
 	django-tagging>=0.3.5,<0.4
 	pytz


### PR DESCRIPTION
- Run tests through coverage
- Get Travis-CI to upload them to CodeCov

Coverage will be computed for all test targets thanks to tox.

[See results on CodeCov](https://codecov.io/github/JeanFred/graphite-web)

(I’m usually going for Coveralls but as I quite impressed by CodeCov I thought I would give it a try. I think it’s a good pick but happy to change either way).

Later on we can look at adding some more bells and whistles like badge in ReadMe, posting on Pull Requests and so on :)

See #863 
