### PR TITLE
Zope.interface is not needed by webapp

### DIFF
--- a/check-dependencies.py
+++ b/check-dependencies.py
@@ -109,14 +109,6 @@ except ImportError:
     required += 1
 
 
-# Test for zope.interface
-try:
-  from zope.interface import Interface
-except ImportError:
-  sys.stderr.write("[OPTIONAL] Unable to import Interface from zope.interface. Without it, you will be unable to run carbon on this server.\n")
-  optional +=1
-
-
 # Test for python-memcached
 try:
   import memcache

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -15,7 +15,6 @@ Basic Graphite requirements:
 * `Pycairo`_
 * `Django`_ 1.4 or greater
 * `django-tagging`_ 0.3.1 or greater
-* `zope-interface`_
 * `pytz`_
 * `fontconfig`_ and at least one font package (a system package usually)
 * A WSGI server and web server. Popular choices are:
@@ -183,4 +182,3 @@ Despair Not!  Even though running Graphite on Windows is completely unsupported 
 .. _simplejson: http://pypi.python.org/pypi/simplejson/
 .. _txAMQP: https://launchpad.net/txamqp/
 .. _uWSGI: http://projects.unbit.it/uwsgi/
-.. _zope-interface: http://pypi.python.org/pypi/zope.interface/


### PR DESCRIPTION
As mentioned by @brutasse in https://github.com/graphite-project/graphite-web/pull/1343#issuecomment-145383535.