### PR TITLE
Update the 0.9.13 release notes (0.9.x)

### DIFF
--- a/docs/releases/0_9_13.rst
+++ b/docs/releases/0_9_13.rst
@@ -59,7 +59,7 @@ Graphite-web
 * Add Composer button to load existing graph url (justino)
 * Add ``maxDataPoints`` to limit number of returned datapoints for json requests (philiphoy, gingerlime)
 * Refactor json responses for clarity (whilp)
-* Adding graphana color scheme (lainSR)
+* New `grafana` color scheme (lainSR)
 * Add optional 'now' parameter to remote node fetch (Kixeye)
 * Graphlot was completely removed (obfuscurity)
 * Use cairocffi instead of pycairo (brutasse, esc)
@@ -67,8 +67,14 @@ Graphite-web
 * Adding tests for Django 1.7 (brutasse, syepes)
 * Bulk-fetch metrics from remote hosts (bmhatfield, deniszh, favoretti)
 * Perform all remote fetches in parallel (bmhatfield)
-* Perform `/metrics/find` queries in parallel (jraby)
+* Perform ``/metrics/find`` queries in parallel (jraby)
 * New prefetch cache for remote queries (jraby)
+* New ``REMOTE_STORE_USE_POST`` setting for remote requests (steve-dave)
+* New single-hue color templates (obfuscurity)
+* New ``sortByName()`` function (jssjr, Krylon360)
+* Namespace request-cache data with the local node (jssjr)
+* Support for retrieving static assets with whitenoise (brutasse, deniszh)
+* Enable buffering in HTTPResponse objects (jjneely, deniszh)
 
 Carbon
 ^^^^^^
@@ -78,10 +84,18 @@ Carbon
 * Configurable files for aggregation and rewrite rules (drawks)
 * New bulk cache query type (huy)
 * Bulk cache query instrumentation (mleinart)
+* Require Twisted >= 13.2.0, adds IPv6 support (obfuscurity)
+* Document how to disable individual listeners (steve-dave)
+* Support backlogs for TCP listeners (jssjr)
+* Improved cache tests (jssjr)
+* New ``--profiler`` option (tail, deniszh)
+* Support for ``DIVERSE_REPLICAS`` (deniszh, dctrwatson)
 
 Whisper
 ^^^^^^^
 * New whisper-fill utility imported from Carbonate project (jssjr, grobian, deniszh)
+* Add ``--estimate`` option to whisper-create (steve-dave)
+* New whisper-diff utility (bheilman, deniszh)
 
 Bug fixes
 ---------
@@ -120,13 +134,25 @@ Graphite-web
 * Updating the copyright notice (gwaldo)
 * CACHE_* settings are deprecated in Django 1.3, so, was replaced with CACHES setting (brutasse, deniszh)
 * Fix data cache invalidation (esc, deniszh)
-* Fixing documentation for divideSeries (gwaldo)
+* Fix documentation for divideSeries (gwaldo)
 * Make HTTP clients only cache graphs as long as we keep them in memcached (aroben, deniszh)
 * DST fixes, backport from graphite-api (brutasse, deniszh)
 * HttpRequest.raw_post_data was deprecated in Django 1.4 (obfuscurity)
-* Fixing XSS in browser and composer (illicium, deniszh)
+* XSS fixes for browser and composer (illicium, piotr1212, deniszh)
 * Docs: Python Dev Headers needed for custom install location (gwaldo)
 * Fix pytz install dependency (deniszh)
+* Javascript compatibility fixes for Internet Explorer (piotr1212)
+* Timezone fixes and tests (brutasse, MFAnderson, deniszh)
+* Fix for remote fetch threads (deniszh)
+* Fixes for ``normalize()`` (g76r, jstangroome)
+* Avoid exceptions when ``CARBONLINK_HOSTS`` is an empty list (jstangroome)
+* Lock django-tagging to fix Travis CI (jstangroome)
+* Set default timezone (jjneely)
+* Never attempt to write empty data to request-cache (apg-pk)
+* Never merge CarbonLink results with Whisper rollups (penpen, obfuscurity)
+* Fix for SVG graphs (grobian, obfuscurity)
+* Skip empty target parameters (obfuscurity)
+* Remove unnecessary dependencies (obfuscurity)
 
 Carbon
 ^^^^^^
@@ -144,10 +170,19 @@ Carbon
 * Document the fact that one can use regexps in the aggregation-rules (ctavan)
 * Move tests to tox (jssr)
 * Add hup signal handler (jssr)
-* Fixing instrumentation (avishai-ish-shalom, jssr)
+* Fix instrumentation (avishai-ish-shalom, jssr)
 * Fix exception handling (steve-dave)
 * Fix CACHE_WRITE_STRATEGY (jssr)
 * Fix aggregated metrics (pgul, ctavan)
+* Logging fixes (obfuscurity, piotr1212)
+* Fix race condition for full queues (mleinart)
+* Default value for ``MAX_UPDATES_PER_SECOND_ON_SHUTDOWN`` (jssjr)
+* Never cache empty aggregation results (mleinart)
+* Fixes for MetricsCache size leak (jssjr, deniszh)
+* Documentation fix for relay-rules (obfuscurity)
+* Fix test assertions (obfuscurity)
+* Fix for ``--profile`` arg (tail, deniszh)
+* Move Red Hat initscripts to examples (deniszh, bmhatfield)
 
 Whisper
 ^^^^^^^
@@ -155,3 +190,5 @@ Whisper
 * Add optional ``now`` parameter to fetch for graphite-web compatibility (jcsp, steve-dave)
 * Remove unused Tox configuration (steve-dave)
 * TravisCI no longer supports Python 2.5 (steve-dave)
+* Unlink Whisper file if empty/corrupted (jraby)
+* Enforce closing of Whisper files (AstromechZA, jjneely)


### PR DESCRIPTION
Starting in 0.9.x, then I'll cherry-pick over to master. This bears the question, should these be added to `docs/releases/0_9_13.rst`, or should we move these to a fresh `docs/releases/0_9_14.rst`? If we're really going to release the next version as **0.9.14**, I'm inclined to pretend that 0.9.13 never happened and just `git mv docs/releases/0_9_13.rst docs/releases/0_9_14.rst`.

/cc @deniszh @brutasse @jssjr @SEJeff @mleinart 