### PR TITLE
Remove mock from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,6 @@ simplejson==2.1.6
 django-tagging==0.3.6
 gunicorn
 pytz
-mock
 pyparsing==1.5.7
 cairocffi
 git+git://github.com/graphite-project/whisper.git#egg=whisper


### PR DESCRIPTION
mock is a test dependency and as such should not live in the requirements.txt file.
Its usage is directly specified in tox.ini

This was introduced in 64cf924 (#1157)