### PR TITLE
Remove install section on RTD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open('setup.cfg', 'r') as f:
 cf = ConfigParser.ConfigParser()
 cf.readfp(BytesIO(orig_setup_cfg), 'setup.cfg')
 
-if os.environ.get('GRAPHITE_NO_PREFIX'):
+if os.environ.get('GRAPHITE_NO_PREFIX') or os.environ.get('READTHEDOCS'):
     cf.remove_section('install')
 else:
     try:


### PR DESCRIPTION
This removes the permission error caused by RTD's build environment changes.