### PR TITLE
Remove mock from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,6 @@ gunicorn
 pytz
 sphinx
 sphinx_rtd_theme
-mock
 cairocffi
 git+git://github.com/graphite-project/whisper.git@0.9.13#egg=whisper
 whitenoise


### PR DESCRIPTION
mock is a test dependency and as such should not
live in the requirements.txt file. Its usage
is directly specified in tox.ini

This was introduced in c9360fa

Port of #1351 to 0.9.x branch.

cc @brutasse 