### PR TITLE
Add Natural Sorting to sortByName function (untested)

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1902,16 +1902,28 @@ def limit(requestContext, seriesList, n):
   """
   return seriesList[0:n]
 
-def sortByName(requestContext, seriesList):
+def sortByName(requestContext, seriesList, natural = False):
   """
   Takes one metric or a wildcard seriesList.
-
-  Sorts the list of metrics by the metric name.
+  Sorts the list of metrics by the metric name using either alphabetical order or natural sorting.
+  Natural sorting allows names containing numbers to be sorted more naturally, e.g:
+  - Alphabetical sorting: server1, server11, server12, server2
+  - Natural sorting: server1, server2, server11, server12
   """
-  def compare(x,y):
+  def paddedName(name):
+    return re.sub("(\d+)", lambda x: "{0:010}".format(int(x.group(0))), name)
+
+  def compare(x, y):
     return cmp(x.name, y.name)
 
-  seriesList.sort(compare)
+  def natSortCompare(x, y):
+    return cmp(paddedName(x.name), paddedName(y.name))
+
+  if natural:
+    seriesList.sort(natSortCompare)
+  else:
+    seriesList.sort(compare)
+
   return seriesList
 
 def sortByTotal(requestContext, seriesList):


### PR DESCRIPTION
Natural sorting allows names containing numbers to be sorted more naturally, e.g:

Normal sort: server1, server11, server12, server2
Natural sorting: server1, server2, server11, server12

To do so we left pad all number sequences within a name with a variable number of
zeros depending on the length of the sequence :

 - server1  -> server0000000001
 - server11 -> server0000000011
 - server2  -> server0000000002

Signed-off-by: Sylvain Rabot <sylvain.rabot@f-secure.com>