### PR TITLE
Update to same requirements as master

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 ## Requirements for documentation
-Django==1.4
+Django>=1.4
 django-tagging==0.3.1
 sphinx
+sphinx_rtd_theme
 pytz
 git+git://github.com/graphite-project/whisper.git#egg=whisper


### PR DESCRIPTION
I don't know why, but the RTD build passed on 0.9.x with these changes.

http://graphite-web.readthedocs.org/en/latest/