### PR TITLE
Removing unnecessary call to log function when no handler

### DIFF
--- a/webapp/graphite/logger.py
+++ b/webapp/graphite/logger.py
@@ -63,13 +63,22 @@ class GraphiteLogger:
     return self.exceptionLogger.exception(msg,**kwargs)
 
   def cache(self,msg,*args,**kwargs):
-    return self.cacheLogger.log(30,msg,*args,**kwargs)
+    if settings.LOG_CACHE_PERFORMANCE:
+      return self.cacheLogger.log(30,msg,*args,**kwargs)
+    else:
+      return
 
   def rendering(self,msg,*args,**kwargs):
-    return self.renderingLogger.log(30,msg,*args,**kwargs)
+    if settings.LOG_RENDERING_PERFORMANCE:
+      return self.renderingLogger.log(30,msg,*args,**kwargs)
+    else:
+      return
 
   def metric_access(self,msg,*args,**kwargs):
-    return self.metricAccessLogger.log(30,msg,*args,**kwargs)
+    if settings.LOG_METRIC_ACCESS:
+      return self.metricAccessLogger.log(30,msg,*args,**kwargs)
+    else:
+      return
 
 
 log = GraphiteLogger() # import-shared logger instance


### PR DESCRIPTION
The function log function is getting called with or without the handler (which is setup based on the settings). The problem is that if LOGGING is set to false and the function is getting called, it will show an error about missing handler.

This was the simplest fix for that, it should apply to 0.9.14 (had issues committing it to the tags/0.9.14 so I'm committing to this branch instead (it should apply to the whole branch anyhow).