### PR TITLE
Continue on IndexError for removeAbovePercentile and removeBelowPercentile

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1835,7 +1835,10 @@ def removeAbovePercentile(requestContext, seriesList, n):
   for s in seriesList:
     s.name = 'removeAbovePercentile(%s, %d)' % (s.name, n)
     s.pathExpression = s.name
-    percentile = nPercentile(requestContext, [s], n)[0][0]
+    try:
+      percentile = nPercentile(requestContext, [s], n)[0][0]
+    except IndexError:
+      continue
     for (index, val) in enumerate(s):
       if val > percentile:
         s[index] = None
@@ -1864,7 +1867,10 @@ def removeBelowPercentile(requestContext, seriesList, n):
   for s in seriesList:
     s.name = 'removeBelowPercentile(%s, %d)' % (s.name, n)
     s.pathExpression = s.name
-    percentile = nPercentile(requestContext, [s], n)[0][0]
+    try:
+      percentile = nPercentile(requestContext, [s], n)[0][0]
+    except IndexError:
+      continue
     for (index, val) in enumerate(s):
       if val < percentile:
         s[index] = None


### PR DESCRIPTION
This fixes `removeAbovePercentile()` and `removeAbovePercentile()` when we encounter an IndexError (caused by a lack of data). As @toote mentions in #1394, the 95th percentile of nulls is still null.