### PR TITLE
Datalib: continue instead of break when we already have best-series

### DIFF
--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -458,14 +458,14 @@ def fetchData(requestContext, pathExpr):
               seriesList[known.name] = ts
           else:
               # In case if we are merging data - the existing series has no gaps and there is nothing to merge
-              # together.  Save ourselves some work here.
+              # together.
               #
               # OR - if we picking best serie:
               #
               # We already have this series in the seriesList, and the
               # candidate is 'worse' than what we already have, we don't need
-              # to compare anything else. Save ourselves some work here.
-              break
+              # to compare anything else.
+              continue
 
         # If we looked at this series above, and it matched a 'known'
         # series already, then it's already in the series list (or ignored).


### PR DESCRIPTION
The 'else' condition in this statement needed to be a `break` statement when `seriesList` was a list we were iterating, to break out of the `seriesList` iteration. However, in https://github.com/graphite-project/graphite-web/commit/3a7e1a88cae0a7af5e850bbf4153d237428cd8cb `seriesList` was changed to be a `dict`. Unfortunately, the `break` statement was not removed, so we'd give up pulling in the results of our fetches if our series were consistent.

I changed the break to a `continue` because I liked the comment in the `else` block describing what it "means" to be there. We could alternately just remove the entire conditional.

With a `break` and some debug logging:

```
Wed Nov 18 14:03:27 2015 :: [stats_counts.worker.worker*.sessions.processed_per_min, 10.144.251.222:8180] 
Results found: 60
Wed Nov 18 14:03:27 2015 :: Merging multiple TimeSeries for stats_counts.worker.worker2001.sessions.processed_per_min
Wed Nov 18 14:03:27 2015 :: Merging multiple TimeSeries for stats_counts.worker.worker2004.sessions.processed_per_min
Wed Nov 18 14:03:27 2015 :: Merging multiple TimeSeries for stats_counts.worker.worker2008.sessions.processed_per_min
Wed Nov 18 14:03:27 2015 :: Already have 'best series': TimeSeries(name=stats_counts.worker.worker2013.sessions.processed_per_min, start=1447859040, end=1447873440, step=60) disregarding: TimeSeries(name=stats_counts.worker.worker2013.sessions.processed_per_min, start=1447859040, end=1447873440, step=60)
--BREAK--
```

With a `continue`

```
Wed Nov 18 14:03:27 2015 :: [stats_counts.worker.worker*.sessions.processed_per_min, 10.144.251.222:8180]
Results found: 60
Wed Nov 18 14:03:27 2015 :: Merging multiple TimeSeries for stats_counts.worker.worker2001.sessions.processed_per_min
Wed Nov 18 14:03:27 2015 :: Merging multiple TimeSeries for stats_counts.worker.worker2004.sessions.processed_per_min
Wed Nov 18 14:03:27 2015 :: Merging multiple TimeSeries for stats_counts.worker.worker2008.sessions.processed_per_min
Wed Nov 18 14:03:27 2015 :: Already have 'best series': TimeSeries(name=stats_counts.worker.worker2013.sessions.processed_per_min, start=1447859040, end=1447873440, step=60) disregarding: TimeSeries(name=stats_counts.worker.worker2013.sessions.processed_per_min, start=1447859040, end=1447873440, step=60)
--CONTINUE--
Wed Nov 18 14:03:27 2015 :: Merging multiple TimeSeries for stats_counts.worker.worker2017.sessions.processed_per_min
Wed Nov 18 14:03:27 2015 :: Merging multiple TimeSeries for stats_counts.worker.worker2019.sessions.processed_per_min
...etc...
Wed Nov 18 14:03:27 2015 :: Merging multiple TimeSeries for stats_counts.worker.worker2059.sessions.processed_per_min
Wed Nov 18 14:03:27 2015 :: Already have 'best series': TimeSeries(name=stats_counts.worker.worker2063.sessions.processed_per_min, start=1447859040, end=1447873440, step=60) disregarding: TimeSeries(name=stats_counts.worker.worker2063.sessions.processed_per_min, start=1447859040, end=1447873440, step=60)
--CONTINUE--
Wed Nov 18 14:03:27 2015 :: Merging multiple TimeSeries for stats_counts.worker.worker2072.sessions.processed_per_min
Wed Nov 18 14:03:27 2015 :: Merging multiple TimeSeries for stats_counts.worker.worker2073.sessions.processed_per_min
...etc...
```