### PR TITLE
Improve axis range and ticmark handling

### DIFF
--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -182,7 +182,7 @@ class _AxisTics:
     elif maxFixed:
       self.minValue = self.maxValue - self.chooseDelta(self.maxValue)
     else:
-      delta = max(abs(self.minValue), abs(self.maxValue))
+      delta = self.chooseDelta(max(abs(self.minValue), abs(self.maxValue)))
       average = (self.minValue + self.maxValue) / 2.0
       self.minValue = average - delta
       self.maxValue = average + delta

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1665,7 +1665,7 @@ def makeLabel(yValue, yStep=None, ySpan=None, yUnitSystem=None):
     return "%.2f %s" % (float(yValue), prefix)
   if ySpan > 10 or spanPrefix != prefix:
     if type(yValue) is float:
-      return "%.1f %s" % (float(yValue), prefix)
+      return "%.1f %s " % (float(yValue), prefix)
     else:
       return "%d %s " % (int(yValue), prefix)
   elif ySpan > 3:

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -157,6 +157,7 @@ class _AxisTics:
 
   def applySettings(self, axisMin=None, axisMax=None, axisLimit=None):
     if axisMin is not None:
+      self.minRoundable = False
       self.minValue = axisMin
 
     if axisMax is not None:

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1137,33 +1137,28 @@ class LineGraph(Graph):
       self.yLabelWidth = 0.0
 
   def setupTwoYAxes(self):
-    # I am Lazy.
-    Ldata = []
-    Rdata = []
-
-    Ldata += self.dataLeft
-    Rdata += self.dataRight
-
     # Lots of coupled lines ahead.  Will operate on Left data first then Right.
 
-    missingValuesL = any(None in series for series in Ldata)
-    missingValuesR = any(None in series for series in Rdata)
+    missingValuesL = any(None in series for series in self.dataLeft)
+    missingValuesR = any(None in series for series in self.dataRight)
 
     if self.params.get('drawNullAsZero') and missingValuesL:
       yMinValueL = 0.0
     else:
-      yMinValueL = safeMin( [safeMin(series) for series in Ldata if not series.options.get('drawAsInfinite')] )
+      yMinValueL = safeMin( [safeMin(series) for series in self.dataLeft
+                             if not series.options.get('drawAsInfinite')] )
     if self.params.get('drawNullAsZero') and missingValuesR:
       yMinValueR = 0.0
     else:
-      yMinValueR = safeMin( [safeMin(series) for series in Rdata if not series.options.get('drawAsInfinite')] )
+      yMinValueR = safeMin( [safeMin(series) for series in self.dataRight
+                             if not series.options.get('drawAsInfinite')] )
 
     if self.areaMode == 'stacked':
-      yMaxValueL = safeSum( [safeMax(series) for series in Ldata] )
-      yMaxValueR = safeSum( [safeMax(series) for series in Rdata] )
+      yMaxValueL = safeSum( [safeMax(series) for series in self.dataLeft] )
+      yMaxValueR = safeSum( [safeMax(series) for series in self.dataRight] )
     else:
-      yMaxValueL = safeMax( [safeMax(series) for series in Ldata] )
-      yMaxValueR = safeMax( [safeMax(series) for series in Rdata] )
+      yMaxValueL = safeMax( [safeMax(series) for series in self.dataLeft] )
+      yMaxValueR = safeMax( [safeMax(series) for series in self.dataRight] )
 
     if yMinValueL is None:
       yMinValueL = 0.0

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1040,20 +1040,20 @@ class LineGraph(Graph):
     missingValues = any(None in series for series in self.data)
     finiteData = [series for series in self.data if not series.options.get('drawAsInfinite')]
 
-    yMinValue = safeMin( [safeMin(series) for series in finiteData] )
+    yMinValue = safeMin(safeMin(series) for series in finiteData)
 
     if yMinValue > 0.0 and self.params.get('drawNullAsZero') and missingValues:
       yMinValue = 0.0
 
     if self.areaMode == 'stacked':
-      length = safeMin( [len(series) for series in finiteData] )
+      length = safeMin(len(series) for series in finiteData)
       sumSeries = []
 
       for i in xrange(0, length):
-        sumSeries.append( safeSum( [series[i] for series in finiteData] ) )
+        sumSeries.append( safeSum(series[i] for series in finiteData) )
       yMaxValue = safeMax( sumSeries )
     else:
-      yMaxValue = safeMax( [safeMax(series) for series in finiteData] )
+      yMaxValue = safeMax(safeMax(series) for series in finiteData)
 
     if yMaxValue < 0.0 and self.params.get('drawNullAsZero') and missingValues:
       yMaxValue = 0.0
@@ -1148,18 +1148,18 @@ class LineGraph(Graph):
     if self.params.get('drawNullAsZero') and missingValuesL:
       yMinValueL = 0.0
     else:
-      yMinValueL = safeMin( [safeMin(series) for series in finiteDataL] )
+      yMinValueL = safeMin(safeMin(series) for series in finiteDataL)
     if self.params.get('drawNullAsZero') and missingValuesR:
       yMinValueR = 0.0
     else:
-      yMinValueR = safeMin( [safeMin(series) for series in finiteDataR] )
+      yMinValueR = safeMin(safeMin(series) for series in finiteDataR)
 
     if self.areaMode == 'stacked':
-      yMaxValueL = safeSum( [safeMax(series) for series in self.dataLeft] )
-      yMaxValueR = safeSum( [safeMax(series) for series in self.dataRight] )
+      yMaxValueL = safeSum(safeMax(series) for series in self.dataLeft)
+      yMaxValueR = safeSum(safeMax(series) for series in self.dataRight)
     else:
-      yMaxValueL = safeMax( [safeMax(series) for series in self.dataLeft] )
-      yMaxValueR = safeMax( [safeMax(series) for series in self.dataRight] )
+      yMaxValueL = safeMax(safeMax(series) for series in self.dataLeft)
+      yMaxValueR = safeMax(safeMax(series) for series in self.dataRight)
 
     if yMinValueL is None:
       yMinValueL = 0.0

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -351,7 +351,6 @@ class _LinearAxisTics(_AxisTics):
           bestStep = step
           bestDivisor = divisor
 
-    # Scale it back up to the order of variance:
     self.step = bestStep
 
   def chooseLimits(self):

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1037,11 +1037,11 @@ class LineGraph(Graph):
         series.xStep = bestXStep
 
   def setupYAxis(self):
-    seriesWithMissingValues = [ series for series in self.data if None in series ]
+    missingValues = any(None in series for series in self.data)
 
     yMinValue = safeMin( [safeMin(series) for series in self.data if not series.options.get('drawAsInfinite')] )
 
-    if yMinValue > 0.0 and self.params.get('drawNullAsZero') and seriesWithMissingValues:
+    if yMinValue > 0.0 and self.params.get('drawNullAsZero') and missingValues:
       yMinValue = 0.0
 
     if self.areaMode == 'stacked':
@@ -1054,7 +1054,7 @@ class LineGraph(Graph):
     else:
       yMaxValue = safeMax( [safeMax(series) for series in self.data if not series.options.get('drawAsInfinite')] )
 
-    if yMaxValue < 0.0 and self.params.get('drawNullAsZero') and seriesWithMissingValues:
+    if yMaxValue < 0.0 and self.params.get('drawNullAsZero') and missingValues:
       yMaxValue = 0.0
 
     if yMinValue is None:
@@ -1140,22 +1140,20 @@ class LineGraph(Graph):
     # I am Lazy.
     Ldata = []
     Rdata = []
-    seriesWithMissingValuesL = []
-    seriesWithMissingValuesR = []
 
     Ldata += self.dataLeft
     Rdata += self.dataRight
 
     # Lots of coupled lines ahead.  Will operate on Left data first then Right.
 
-    seriesWithMissingValuesL = [ series for series in Ldata if None in series ]
-    seriesWithMissingValuesR = [ series for series in Rdata if None in series ]
+    missingValuesL = any(None in series for series in Ldata)
+    missingValuesR = any(None in series for series in Rdata)
 
-    if self.params.get('drawNullAsZero') and seriesWithMissingValuesL:
+    if self.params.get('drawNullAsZero') and missingValuesL:
       yMinValueL = 0.0
     else:
       yMinValueL = safeMin( [safeMin(series) for series in Ldata if not series.options.get('drawAsInfinite')] )
-    if self.params.get('drawNullAsZero') and seriesWithMissingValuesR:
+    if self.params.get('drawNullAsZero') and missingValuesR:
       yMinValueR = 0.0
     else:
       yMinValueR = safeMin( [safeMin(series) for series in Rdata if not series.options.get('drawAsInfinite')] )

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -241,7 +241,7 @@ class _LinearAxisTics(_AxisTics):
     self.step = None
 
   def setStep(self, step):
-    self.step = step
+    self.step = float(step)
 
   def generateSteps(self, minStep):
     """Generate allowed steps with step >= minStep in increasing order."""
@@ -271,7 +271,7 @@ class _LinearAxisTics(_AxisTics):
 
     """
 
-    bottom = step * math.floor(self.minValue / step + EPSILON)
+    bottom = step * math.floor(self.minValue / float(step) + EPSILON)
     top = bottom + step * divisor
 
     if top >= self.maxValue - EPSILON * step:
@@ -341,7 +341,7 @@ class _LinearAxisTics(_AxisTics):
     bestSlop = None
     bestStep = None
     bestDivisor = None
-    for step in self.generateSteps(variance / max(divisors)):
+    for step in self.generateSteps(variance / float(max(divisors))):
       if bestSlop is not None and step * min(divisors) >= 2 * bestSlop + variance:
         break
       for divisor in divisors:

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1076,12 +1076,13 @@ class LineGraph(Graph):
     if yMaxValue <= yMinValue:
       yMaxValue = yMinValue + 1
 
-    yDivisors = str(self.params.get('yDivisors', '4,5,6'))
-    yDivisors = [int(d) for d in yDivisors.split(',')]
-    binary = 'yUnitSystem' in self.params and self.params['yUnitSystem'] == 'binary'
-    self.yStep = chooseAxisStep(yMinValue, yMaxValue, divisors=yDivisors, binary=binary)
     if 'yStep' in self.params:
       self.yStep = self.params['yStep']
+    else:
+      yDivisors = str(self.params.get('yDivisors', '4,5,6'))
+      yDivisors = [int(d) for d in yDivisors.split(',')]
+      binary = 'yUnitSystem' in self.params and self.params['yUnitSystem'] == 'binary'
+      self.yStep = chooseAxisStep(yMinValue, yMaxValue, divisors=yDivisors, binary=binary)
 
     self.yBottom = self.yStep * math.floor( yMinValue / self.yStep ) #start labels at the greatest multiple of yStep <= yMinValue
     self.yTop = self.yStep * math.ceil( yMaxValue / self.yStep ) #Extend the top of our graph to the lowest yStep multiple >= yMaxValue

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1038,21 +1038,22 @@ class LineGraph(Graph):
 
   def setupYAxis(self):
     missingValues = any(None in series for series in self.data)
+    finiteData = [series for series in self.data if not series.options.get('drawAsInfinite')]
 
-    yMinValue = safeMin( [safeMin(series) for series in self.data if not series.options.get('drawAsInfinite')] )
+    yMinValue = safeMin( [safeMin(series) for series in finiteData] )
 
     if yMinValue > 0.0 and self.params.get('drawNullAsZero') and missingValues:
       yMinValue = 0.0
 
     if self.areaMode == 'stacked':
-      length = safeMin( [len(series) for series in self.data if not series.options.get('drawAsInfinite')] )
+      length = safeMin( [len(series) for series in finiteData] )
       sumSeries = []
 
       for i in xrange(0, length):
-        sumSeries.append( safeSum( [series[i] for series in self.data if not series.options.get('drawAsInfinite')] ) )
+        sumSeries.append( safeSum( [series[i] for series in finiteData] ) )
       yMaxValue = safeMax( sumSeries )
     else:
-      yMaxValue = safeMax( [safeMax(series) for series in self.data if not series.options.get('drawAsInfinite')] )
+      yMaxValue = safeMax( [safeMax(series) for series in finiteData] )
 
     if yMaxValue < 0.0 and self.params.get('drawNullAsZero') and missingValues:
       yMaxValue = 0.0
@@ -1138,6 +1139,8 @@ class LineGraph(Graph):
 
   def setupTwoYAxes(self):
     # Lots of coupled lines ahead.  Will operate on Left data first then Right.
+    finiteDataL = [series for series in self.dataLeft if not series.options.get('drawAsInfinite')]
+    finiteDataR = [series for series in self.dataRight if not series.options.get('drawAsInfinite')]
 
     missingValuesL = any(None in series for series in self.dataLeft)
     missingValuesR = any(None in series for series in self.dataRight)
@@ -1145,13 +1148,11 @@ class LineGraph(Graph):
     if self.params.get('drawNullAsZero') and missingValuesL:
       yMinValueL = 0.0
     else:
-      yMinValueL = safeMin( [safeMin(series) for series in self.dataLeft
-                             if not series.options.get('drawAsInfinite')] )
+      yMinValueL = safeMin( [safeMin(series) for series in finiteDataL] )
     if self.params.get('drawNullAsZero') and missingValuesR:
       yMinValueR = 0.0
     else:
-      yMinValueR = safeMin( [safeMin(series) for series in self.dataRight
-                             if not series.options.get('drawAsInfinite')] )
+      yMinValueR = safeMin( [safeMin(series) for series in finiteDataR] )
 
     if self.areaMode == 'stacked':
       yMaxValueL = safeSum( [safeMax(series) for series in self.dataLeft] )

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -202,6 +202,15 @@ class _AxisTics:
       if axisLimit < self.maxValue:
         self.maxValue = axisLimit
         self.maxValueSource = 'limit'
+        # The limit has already been imposed, so there is no need to
+        # remember it:
+        self.axisLimit = None
+      else:
+        # We still need to remember axisLimit to avoid rounding top to
+        # a value larger than axisLimit:
+        self.axisLimit = axisLimit
+    else:
+      self.axisLimit = None
 
     if not (self.minValue < self.maxValue):
       self.reconcileLimits()
@@ -354,6 +363,9 @@ class _LinearAxisTics(_AxisTics):
     if self.maxValueSource == 'data':
       # Extend the top of our graph to the lowest step multiple >= maxValue:
       self.top = self.step * math.ceil(self.maxValue / self.step - EPSILON)
+      # ...but never exceed a user-specified limit:
+      if self.axisLimit is not None and self.top > self.axisLimit + EPSILON * self.step:
+        self.top = self.axisLimit
     else:
       self.top = self.maxValue
 

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -168,7 +168,7 @@ class _AxisTics:
     if abs(x) < 1.0e-9:
       return 1.0
     else:
-      return 0.1 * math.abs(x)
+      return 0.1 * abs(x)
 
   def reconcileLimits(self):
     minFixed = (self.minValueSource in ['min'])

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -158,25 +158,25 @@ class GraphError(Exception):
 class _AxisTics:
   def __init__(self, minValue, maxValue, unitSystem=None):
     self.minValue = minValue
-    self.minRoundable = True
+    self.minValueSource = 'data'
     self.maxValue = maxValue
-    self.maxRoundable = True
+    self.maxValueSource = 'data'
     self.unitSystem = unitSystem
 
   def applySettings(self, axisMin=None, axisMax=None, axisLimit=None):
     if axisMin is not None:
-      self.minRoundable = False
+      self.minValueSource = 'setting'
       self.minValue = axisMin
 
     if axisMax is not None:
-      self.maxRoundable = False
+      self.maxValueSource = 'setting'
       if axisMax != 'max':
         self.maxValue = axisMax
 
     if axisLimit is not None:
       if axisLimit < self.maxValue:
         self.maxValue = axisLimit
-        self.maxRoundable = False
+        self.maxValueSource = 'setting'
 
     if self.maxValue <= self.minValue:
       self.maxValue = self.minValue + 1.0
@@ -320,13 +320,13 @@ class _LinearAxisTics(_AxisTics):
     self.step = bestStep
 
   def chooseLimits(self):
-    if self.minRoundable:
+    if self.minValueSource == 'data':
       # Start labels at the greatest multiple of step <= minValue:
       self.bottom = self.step * math.floor(self.minValue / self.step + EPSILON)
     else:
       self.bottom = self.minValue
 
-    if self.maxRoundable:
+    if self.maxValueSource == 'data':
       # Extend the top of our graph to the lowest step multiple >= maxValue:
       self.top = self.step * math.ceil(self.maxValue / self.step - EPSILON)
     else:

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1092,9 +1092,6 @@ class LineGraph(Graph):
       self.yTop += 1
       self.ySpan += 1
 
-    self.graphHeight = self.area['ymax'] - self.area['ymin']
-    self.yScaleFactor = float(self.graphHeight) / float(self.ySpan)
-
     if not self.params.get('hideAxes',False):
       #Create and measure the Y-labels
 
@@ -1176,10 +1173,6 @@ class LineGraph(Graph):
     if self.ySpanR == 0:
       self.yTopR += 1
       self.ySpanR += 1
-
-    self.graphHeight = self.area['ymax'] - self.area['ymin']
-    self.yScaleFactorL = float(self.graphHeight) / float(self.ySpanL)
-    self.yScaleFactorR = float(self.graphHeight) / float(self.ySpanR)
 
     #Create and measure the Y-labels
     self.yLabelValuesL = self.getYLabelValues(self.yBottomL, self.yTopL, self.yStepL)

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1115,38 +1115,11 @@ class LineGraph(Graph):
       self.yLabelWidth = 0.0
 
   def setupTwoYAxes(self):
-    # Lots of coupled lines ahead.  Will operate on Left data first then Right.
-    finiteDataL = [series for series in self.dataLeft if not series.options.get('drawAsInfinite')]
-    finiteDataR = [series for series in self.dataRight if not series.options.get('drawAsInfinite')]
+    drawNullAsZero = self.params.get('drawNullAsZero')
+    stacked = (self.areaMode == 'stacked')
 
-    missingValuesL = any(None in series for series in self.dataLeft)
-    missingValuesR = any(None in series for series in self.dataRight)
-
-    if self.params.get('drawNullAsZero') and missingValuesL:
-      yMinValueL = 0.0
-    else:
-      yMinValueL = safeMin(safeMin(series) for series in finiteDataL)
-    if self.params.get('drawNullAsZero') and missingValuesR:
-      yMinValueR = 0.0
-    else:
-      yMinValueR = safeMin(safeMin(series) for series in finiteDataR)
-
-    if self.areaMode == 'stacked':
-      yMaxValueL = safeSum(safeMax(series) for series in self.dataLeft)
-      yMaxValueR = safeSum(safeMax(series) for series in self.dataRight)
-    else:
-      yMaxValueL = safeMax(safeMax(series) for series in self.dataLeft)
-      yMaxValueR = safeMax(safeMax(series) for series in self.dataRight)
-
-    if yMinValueL is None:
-      yMinValueL = 0.0
-    if yMinValueR is None:
-      yMinValueR = 0.0
-
-    if yMaxValueL is None:
-      yMaxValueL = 1.0
-    if yMaxValueR is None:
-      yMaxValueR = 1.0
+    [yMinValueL, yMaxValueL] = dataLimits(self.dataLeft, drawNullAsZero, stacked)
+    [yMinValueR, yMaxValueR] = dataLimits(self.dataRight, drawNullAsZero, stacked)
 
     if 'yMaxLeft' in self.params:
       yMaxValueL = self.params['yMaxLeft']

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -165,18 +165,19 @@ class _AxisTics:
 
   def applySettings(self, axisMin=None, axisMax=None, axisLimit=None):
     if axisMin is not None:
-      self.minValueSource = 'setting'
+      self.minValueSource = 'min'
       self.minValue = axisMin
 
-    if axisMax is not None:
-      self.maxValueSource = 'setting'
-      if axisMax != 'max':
-        self.maxValue = axisMax
+    if axisMax == 'max':
+      self.maxValueSource = 'extremum'
+    elif axisMax is not None:
+      self.maxValueSource = 'max'
+      self.maxValue = axisMax
 
     if axisLimit is not None:
       if axisLimit < self.maxValue:
         self.maxValue = axisLimit
-        self.maxValueSource = 'setting'
+        self.maxValueSource = 'limit'
 
     if self.maxValue <= self.minValue:
       self.maxValue = self.minValue + 1.0

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1142,8 +1142,6 @@ class LineGraph(Graph):
     Rdata = []
     seriesWithMissingValuesL = []
     seriesWithMissingValuesR = []
-    self.yLabelsL = []
-    self.yLabelsR = []
 
     Ldata += self.dataLeft
     Rdata += self.dataRight
@@ -1253,10 +1251,11 @@ class LineGraph(Graph):
     #Create and measure the Y-labels
     self.yLabelValuesL = self.getYLabelValues(self.yBottomL, self.yTopL, self.yStepL)
     self.yLabelValuesR = self.getYLabelValues(self.yBottomR, self.yTopR, self.yStepR)
-    for value in self.yLabelValuesL: #can't use map() here self.yStepL and self.ySpanL are not iterable
-      self.yLabelsL.append( makeLabel(value, self.yStepL, self.ySpanL, self.params.get('yUnitSystem')))
-    for value in self.yLabelValuesR:
-      self.yLabelsR.append( makeLabel(value, self.yStepR, self.ySpanR, self.params.get('yUnitSystem')) )
+    self.yLabelsL = [makeLabel(value, self.yStepL, self.ySpanL, self.params.get('yUnitSystem'))
+                     for value in self.yLabelValuesL]
+    self.yLabelsR = [makeLabel(value, self.yStepR, self.ySpanR, self.params.get('yUnitSystem'))
+                     for value in self.yLabelValuesR]
+
     self.yLabelWidthL = max([self.getExtents(label)['width'] for label in self.yLabelsL])
     self.yLabelWidthR = max([self.getExtents(label)['width'] for label in self.yLabelsR])
     #scoot the graph over to the left just enough to fit the y-labels

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1116,29 +1116,9 @@ class LineGraph(Graph):
     if not self.params.get('hideAxes',False):
       #Create and measure the Y-labels
 
-      def makeLabel(yValue):
-        yValue, prefix = format_units(yValue, self.yStep,
-                system=self.params.get('yUnitSystem'))
-        ySpan, spanPrefix = format_units(self.ySpan, self.yStep,
-                system=self.params.get('yUnitSystem'))
-        if yValue < 0.1:
-          return "%g %s" % (float(yValue), prefix)
-        elif yValue < 1.0:
-          return "%.2f %s" % (float(yValue), prefix)
-        if ySpan > 10 or spanPrefix != prefix:
-          if type(yValue) is float:
-            return "%.1f %s" % (float(yValue), prefix)
-          else:
-            return "%d %s " % (int(yValue), prefix)
-        elif ySpan > 3:
-          return "%.1f %s " % (float(yValue), prefix)
-        elif ySpan > 0.1:
-          return "%.2f %s " % (float(yValue), prefix)
-        else:
-          return "%g %s" % (float(yValue), prefix)
-
       self.yLabelValues = self.getYLabelValues(self.yBottom, self.yTop, self.yStep)
-      self.yLabels = map(makeLabel,self.yLabelValues)
+      self.yLabels = [makeLabel(value, self.yStep, self.ySpan, self.params.get('yUnitSystem'))
+                      for value in self.yLabelValues]
       self.yLabelWidth = max([self.getExtents(label)['width'] for label in self.yLabels])
 
       if not self.params.get('hideYAxis'):
@@ -1648,6 +1628,7 @@ def sort_stacked(series_list):
   not_stacked = [s for s in series_list if 'stacked' not in s.options]
   return stacked + not_stacked
 
+
 def format_units(v, step=None, system="si"):
   """Format the given value in standardized units.
 
@@ -1673,6 +1654,26 @@ def format_units(v, step=None, system="si"):
   if (v - math.floor(v)) < 0.00000000001 and v > 1 :
     v = math.floor(v)
   return v, ""
+
+
+def makeLabel(yValue, yStep=None, ySpan=None, yUnitSystem=None):
+  yValue, prefix = format_units(yValue, yStep, system=yUnitSystem)
+  ySpan, spanPrefix = format_units(ySpan, yStep, system=yUnitSystem)
+  if yValue < 0.1:
+    return "%g %s" % (float(yValue), prefix)
+  elif yValue < 1.0:
+    return "%.2f %s" % (float(yValue), prefix)
+  if ySpan > 10 or spanPrefix != prefix:
+    if type(yValue) is float:
+      return "%.1f %s" % (float(yValue), prefix)
+    else:
+      return "%d %s " % (int(yValue), prefix)
+  elif ySpan > 3:
+    return "%.1f %s " % (float(yValue), prefix)
+  elif ySpan > 0.1:
+    return "%.2f %s " % (float(yValue), prefix)
+  else:
+    return "%g %s" % (float(yValue), prefix)
 
 
 def find_x_times(start_dt, unit, step):

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1080,7 +1080,7 @@ class LineGraph(Graph):
     else:
       yDivisors = str(self.params.get('yDivisors', '4,5,6'))
       yDivisors = [int(d) for d in yDivisors.split(',')]
-      binary = 'yUnitSystem' in self.params and self.params['yUnitSystem'] == 'binary'
+      binary = self.params.get('yUnitSystem') == 'binary'
       self.yStep = chooseAxisStep(yMinValue, yMaxValue, divisors=yDivisors, binary=binary)
 
     self.yBottom = self.yStep * math.floor( yMinValue / self.yStep ) #start labels at the greatest multiple of yStep <= yMinValue

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -243,10 +243,10 @@ class _LinearAxisTics(_AxisTics):
   def setStep(self, step):
     self.step = step
 
-  def generateSteps(self, minStep, binary=False):
+  def generateSteps(self, minStep):
     """Generate allowed steps with step >= minStep in increasing order."""
 
-    if binary:
+    if self.binary:
       base = 2.0
       mantissas = [1.0]
       exponent = math.floor(math.log(minStep, 2) - EPSILON)
@@ -322,6 +322,7 @@ class _LinearAxisTics(_AxisTics):
 
     """
 
+    self.binary = binary
     if divisors is None:
       divisors = [4,5,6]
 
@@ -340,7 +341,7 @@ class _LinearAxisTics(_AxisTics):
     bestSlop = None
     bestStep = None
     bestDivisor = None
-    for step in self.generateSteps(variance / max(divisors), binary=binary):
+    for step in self.generateSteps(variance / max(divisors)):
       if bestSlop is not None and step * min(divisors) >= 2 * bestSlop + variance:
         break
       for divisor in divisors:

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1219,41 +1219,18 @@ class LineGraph(Graph):
     if yMaxValueR <= yMinValueR:
       yMaxValueR = yMinValueR + 1
 
-    yVarianceL = yMaxValueL - yMinValueL
-    yVarianceR = yMaxValueR - yMinValueR
-    orderL = math.log10(yVarianceL)
-    orderR = math.log10(yVarianceR)
-    orderFactorL = 10 ** math.floor(orderL)
-    orderFactorR = 10 ** math.floor(orderR)
-    vL = yVarianceL / orderFactorL #we work with a scaled down yVariance for simplicity
-    vR = yVarianceR / orderFactorR
-
     yDivisors = str(self.params.get('yDivisors', '4,5,6'))
     yDivisors = [int(d) for d in yDivisors.split(',')]
 
-    prettyValues = (0.1,0.2,0.25,0.5,1.0,1.2,1.25,1.5,2.0,2.25,2.5)
-    divisorInfoL = []
-    divisorInfoR = []
-
-    for d in yDivisors:
-      qL = vL / d #our scaled down quotient, must be in the open interval (0,10)
-      qR = vR / d
-      pL = closest(qL, prettyValues) #the prettyValue our quotient is closest to
-      pR = closest(qR, prettyValues)
-      divisorInfoL.append( ( pL,abs(qL-pL)) ) #make a list so we can find the prettiest of the pretty
-      divisorInfoR.append( ( pR,abs(qR-pR)) )
-
-    divisorInfoL.sort(key=lambda i: i[1]) #sort our pretty values by "closeness to a factor"
-    divisorInfoR.sort(key=lambda i: i[1])
-    prettyValueL = divisorInfoL[0][0] #our winner! Y-axis will have labels placed at multiples of our prettyValue
-    prettyValueR = divisorInfoR[0][0]
-    self.yStepL = prettyValueL * orderFactorL #scale it back up to the order of yVariance
-    self.yStepR = prettyValueR * orderFactorR
-
     if 'yStepLeft' in self.params:
       self.yStepL = self.params['yStepLeft']
+    else:
+      self.yStepL = chooseAxisStep(yMinValueL, yMaxValueL, divisors=yDivisors)
+
     if 'yStepRight' in self.params:
       self.yStepR = self.params['yStepRight']
+    else:
+      self.yStepR = chooseAxisStep(yMinValueR, yMaxValueR, divisors=yDivisors)
 
     self.yBottomL = self.yStepL * math.floor( yMinValueL / self.yStepL ) #start labels at the greatest multiple of yStepL <= yMinValue
     self.yBottomR = self.yStepR * math.floor( yMinValueR / self.yStepR ) #start labels at the greatest multiple of yStepR <= yMinValue

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -204,6 +204,16 @@ class _LinearAxisTics(_AxisTics):
     if divisors is None:
       divisors = [4,5,6]
 
+    if self.minValue == self.maxValue:
+      if self.minValue == 0.0:
+        self.maxValue = 1.0
+      elif self.minValue < 0.0:
+        self.minValue *= 1.1
+        self.maxValue *= 0.9
+      else:
+        self.minValue *= 0.9
+        self.maxValue *= 1.1
+
     variance = self.maxValue - self.minValue
 
     if binary:

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1755,11 +1755,14 @@ def toSeconds(t):
   return (t.days * 86400) + t.seconds
 
 
-# Iterate over the values in an iterable that are neither None nor
-# INFINITY
 def safeArgs(args):
-  invalid = (None, INFINITY)
-  return (arg for arg in args if arg not in invalid)
+  """Iterate over valid, finite values an in iterable.
+
+  Skip any items that are None, NaN, or infinite.
+  """
+
+  return (arg for arg in args
+          if arg is not None and not math.isnan(arg) and not math.isinf(arg))
 
 
 def safeMin(args):

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1037,7 +1037,7 @@ class LineGraph(Graph):
         series.xStep = bestXStep
 
   def setupYAxis(self):
-    [yMinValue, yMaxValue] = dataLimits(self.data,
+    (yMinValue, yMaxValue) = dataLimits(self.data,
                                         drawNullAsZero=self.params.get('drawNullAsZero'),
                                         stacked=(self.areaMode == 'stacked'))
 
@@ -1118,8 +1118,8 @@ class LineGraph(Graph):
     drawNullAsZero = self.params.get('drawNullAsZero')
     stacked = (self.areaMode == 'stacked')
 
-    [yMinValueL, yMaxValueL] = dataLimits(self.dataLeft, drawNullAsZero, stacked)
-    [yMinValueR, yMaxValueR] = dataLimits(self.dataRight, drawNullAsZero, stacked)
+    (yMinValueL, yMaxValueL) = dataLimits(self.dataLeft, drawNullAsZero, stacked)
+    (yMinValueR, yMaxValueR) = dataLimits(self.dataRight, drawNullAsZero, stacked)
 
     if 'yMaxLeft' in self.params:
       yMaxValueL = self.params['yMaxLeft']
@@ -1555,7 +1555,7 @@ def any(args):
 
 
 def dataLimits(data, drawNullAsZero=False, stacked=False):
-  """Return the range of values in data as [yMinValue, yMaxValue].
+  """Return the range of values in data as (yMinValue, yMaxValue).
 
   data is an array of TimeSeries objects.
   """
@@ -1567,7 +1567,7 @@ def dataLimits(data, drawNullAsZero=False, stacked=False):
 
   if yMinValue is None:
     # This can only happen if there are no valid, non-infinite data.
-    return [0.0, 1.0]
+    return (0.0, 1.0)
 
   if yMinValue > 0.0 and drawNullAsZero and missingValues:
     yMinValue = 0.0
@@ -1585,7 +1585,7 @@ def dataLimits(data, drawNullAsZero=False, stacked=False):
   if yMaxValue < 0.0 and drawNullAsZero and missingValues:
     yMaxValue = 0.0
 
-  return [yMinValue, yMaxValue]
+  return (yMinValue, yMaxValue)
 
 
 def sort_stacked(series_list):

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1083,15 +1083,16 @@ class LineGraph(Graph):
       binary = self.params.get('yUnitSystem') == 'binary'
       self.yStep = chooseAxisStep(yMinValue, yMaxValue, divisors=yDivisors, binary=binary)
 
-    self.yBottom = self.yStep * math.floor( yMinValue / self.yStep ) #start labels at the greatest multiple of yStep <= yMinValue
-    self.yTop = self.yStep * math.ceil( yMaxValue / self.yStep ) #Extend the top of our graph to the lowest yStep multiple >= yMaxValue
-
-    if self.logBase and yMinValue > 0:
-      self.yBottom = math.pow(self.logBase, math.floor(math.log(yMinValue, self.logBase)))
-      self.yTop = math.pow(self.logBase, math.ceil(math.log(yMaxValue, self.logBase)))
-    elif self.logBase and yMinValue <= 0:
+    if self.logBase:
+      if yMinValue <= 0:
         raise GraphError('Logarithmic scale specified with a dataset with a '
                          'minimum value less than or equal to zero')
+      self.yBottom = math.pow(self.logBase, math.floor(math.log(yMinValue, self.logBase)))
+      self.yTop = math.pow(self.logBase, math.ceil(math.log(yMaxValue, self.logBase)))
+    else:
+      self.yBottom = self.yStep * math.floor( yMinValue / self.yStep ) #start labels at the greatest multiple of yStep <= yMinValue
+      self.yTop = self.yStep * math.ceil( yMaxValue / self.yStep ) #Extend the top of our graph to the lowest yStep multiple >= yMaxValue
+
 
     if 'yMax' in self.params:
       if self.params['yMax'] == 'max':
@@ -1231,19 +1232,20 @@ class LineGraph(Graph):
     else:
       self.yStepR = chooseAxisStep(yMinValueR, yMaxValueR, divisors=yDivisors)
 
-    self.yBottomL = self.yStepL * math.floor( yMinValueL / self.yStepL ) #start labels at the greatest multiple of yStepL <= yMinValue
-    self.yBottomR = self.yStepR * math.floor( yMinValueR / self.yStepR ) #start labels at the greatest multiple of yStepR <= yMinValue
-    self.yTopL = self.yStepL * math.ceil( yMaxValueL / self.yStepL ) #Extend the top of our graph to the lowest yStepL multiple >= yMaxValue
-    self.yTopR = self.yStepR * math.ceil( yMaxValueR / self.yStepR ) #Extend the top of our graph to the lowest yStepR multiple >= yMaxValue
-
-    if self.logBase and yMinValueL > 0 and yMinValueR > 0: #TODO: Allow separate bases for L & R Axes.
+    if self.logBase:
+      if yMinValueL <= 0 or yMinValueR <= 0:
+        raise GraphError('Logarithmic scale specified with a dataset with a '
+                         'minimum value less than or equal to zero')
+      #TODO: Allow separate bases for L & R Axes.
       self.yBottomL = math.pow(self.logBase, math.floor(math.log(yMinValueL, self.logBase)))
       self.yTopL = math.pow(self.logBase, math.ceil(math.log(yMaxValueL, self.logBase)))
       self.yBottomR = math.pow(self.logBase, math.floor(math.log(yMinValueR, self.logBase)))
       self.yTopR = math.pow(self.logBase, math.ceil(math.log(yMaxValueR, self.logBase)))
-    elif self.logBase and ( yMinValueL <= 0 or yMinValueR <=0 ) :
-        raise GraphError('Logarithmic scale specified with a dataset with a '
-                         'minimum value less than or equal to zero')
+    else:
+      self.yBottomL = self.yStepL * math.floor( yMinValueL / self.yStepL ) #start labels at the greatest multiple of yStepL <= yMinValue
+      self.yTopL = self.yStepL * math.ceil( yMaxValueL / self.yStepL ) #Extend the top of our graph to the lowest yStepL multiple >= yMaxValue
+      self.yBottomR = self.yStepR * math.floor( yMinValueR / self.yStepR ) #start labels at the greatest multiple of yStepR <= yMinValue
+      self.yTopR = self.yStepR * math.ceil( yMaxValueR / self.yStepR ) #Extend the top of our graph to the lowest yStepR multiple >= yMaxValue
 
     if 'yMaxLeft' in self.params:
       self.yTopL = self.params['yMaxLeft']

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -226,19 +226,21 @@ class _AxisTics:
   def makeLabel(self, value):
     value, prefix = format_units(value, self.step, system=self.unitSystem)
     span, spanPrefix = format_units(self.span, self.step, system=self.unitSystem)
+    if prefix:
+      prefix += " "
     if value < 0.1:
       return "%g %s" % (float(value), prefix)
     elif value < 1.0:
       return "%.2f %s" % (float(value), prefix)
     if span > 10 or spanPrefix != prefix:
       if type(value) is float:
-        return "%.1f %s " % (value, prefix)
+        return "%.1f %s" % (value, prefix)
       else:
-        return "%d %s " % (int(value), prefix)
+        return "%d %s" % (int(value), prefix)
     elif span > 3:
-      return "%.1f %s " % (float(value), prefix)
+      return "%.1f %s" % (float(value), prefix)
     elif span > 0.1:
-      return "%.2f %s " % (float(value), prefix)
+      return "%.2f %s" % (float(value), prefix)
     else:
       return "%g %s" % (float(value), prefix)
 

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1700,17 +1700,6 @@ GraphTypes = {
 
 
 #Convience functions
-def closest(number,neighbors):
-  distance = None
-  closestNeighbor = None
-  for neighbor in neighbors:
-    d = abs(neighbor - number)
-    if distance is None or d < distance:
-      distance = d
-      closestNeighbor = neighbor
-  return closestNeighbor
-
-
 def toSeconds(t):
   return (t.days * 86400) + t.seconds
 

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1578,20 +1578,27 @@ def toSeconds(t):
   return (t.days * 86400) + t.seconds
 
 
+# Iterate over the values in an iterable that are neither None nor
+# INFINITY
+def safeArgs(args):
+  invalid = (None, INFINITY)
+  return (arg for arg in args if arg not in invalid)
+
+
 def safeMin(args):
-  args = [arg for arg in args if arg not in (None, INFINITY)]
+  args = list(safeArgs(args))
   if args:
     return min(args)
 
 
 def safeMax(args):
-  args = [arg for arg in args if arg not in (None, INFINITY)]
+  args = list(safeArgs(args))
   if args:
     return max(args)
 
 
 def safeSum(values):
-  return sum([v for v in values if v not in (None, INFINITY)])
+  return sum(safeArgs(values))
 
 
 def any(args):

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1036,22 +1036,26 @@ class LineGraph(Graph):
       else:
         series.xStep = bestXStep
 
+  def _adjustLimits(self, minValue, maxValue, minName, maxName, limitName):
+    if maxName in self.params and self.params[maxName] != 'max':
+      maxValue = self.params[maxName]
+
+    if limitName in self.params and self.params[limitName] < maxValue:
+      maxValue = self.params[limitName]
+
+    if minName in self.params:
+      minValue = self.params[minName]
+
+    if maxValue <= minValue:
+      maxValue = minValue + 1
+
+    return (minValue, maxValue)
+
   def setupYAxis(self):
     (yMinValue, yMaxValue) = dataLimits(self.data,
                                         drawNullAsZero=self.params.get('drawNullAsZero'),
                                         stacked=(self.areaMode == 'stacked'))
-
-    if 'yMax' in self.params and self.params['yMax'] != 'max':
-      yMaxValue = self.params['yMax']
-
-    if 'yLimit' in self.params and self.params['yLimit'] < yMaxValue:
-      yMaxValue = self.params['yLimit']
-
-    if 'yMin' in self.params:
-      yMinValue = self.params['yMin']
-
-    if yMaxValue <= yMinValue:
-      yMaxValue = yMinValue + 1
+    (yMinValue, yMaxValue) = self._adjustLimits(yMinValue, yMaxValue, 'yMin', 'yMax', 'yLimit')
 
     if 'yStep' in self.params:
       self.yStep = self.params['yStep']
@@ -1119,27 +1123,12 @@ class LineGraph(Graph):
     stacked = (self.areaMode == 'stacked')
 
     (yMinValueL, yMaxValueL) = dataLimits(self.dataLeft, drawNullAsZero, stacked)
+    (yMinValueL, yMaxValueL) = self._adjustLimits(yMinValueL, yMaxValueL,
+                                                  'yMinLeft', 'yMaxLeft', 'yLimitLeft')
+
     (yMinValueR, yMaxValueR) = dataLimits(self.dataRight, drawNullAsZero, stacked)
-
-    if 'yMaxLeft' in self.params:
-      yMaxValueL = self.params['yMaxLeft']
-    if 'yMaxRight' in self.params:
-      yMaxValueR = self.params['yMaxRight']
-
-    if 'yLimitLeft' in self.params and self.params['yLimitLeft'] < yMaxValueL:
-      yMaxValueL = self.params['yLimitLeft']
-    if 'yLimitRight' in self.params and self.params['yLimitRight'] < yMaxValueR:
-      yMaxValueR = self.params['yLimitRight']
-
-    if 'yMinLeft' in self.params:
-      yMinValueL = self.params['yMinLeft']
-    if 'yMinRight' in self.params:
-      yMinValueR = self.params['yMinRight']
-
-    if yMaxValueL <= yMinValueL:
-      yMaxValueL = yMinValueL + 1
-    if yMaxValueR <= yMinValueR:
-      yMaxValueR = yMinValueR + 1
+    (yMinValueR, yMaxValueR) = self._adjustLimits(yMinValueR, yMaxValueR,
+                                                  'yMinRight', 'yMaxRight', 'yLimitRight')
 
     yDivisors = str(self.params.get('yDivisors', '4,5,6'))
     yDivisors = [int(d) for d in yDivisors.split(',')]

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1078,11 +1078,11 @@ class LineGraph(Graph):
 
     if 'yMax' in self.params:
       if self.params['yMax'] == 'max':
-        scale = 1.0 * yMaxValue / self.yTop
+        scale = float(yMaxValue) / self.yTop
         self.yStep *= (scale - 0.000001)
         self.yTop = yMaxValue
       else:
-        self.yTop = self.params['yMax'] * 1.0
+        self.yTop = float(self.params['yMax'])
     if 'yMin' in self.params:
       self.yBottom = self.params['yMin']
 

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -246,6 +246,11 @@ class _LinearAxisTics(_AxisTics):
   def generateSteps(self, minStep):
     """Generate allowed steps with step >= minStep in increasing order."""
 
+    if math.isnan(minStep):
+      raise GraphError('NaN encountered')
+    elif math.isinf(minStep):
+      raise GraphError('Infinity encountered')
+
     if self.binary:
       base = 2.0
       mantissas = [1.0]

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1592,6 +1592,10 @@ def dataLimits(data, drawNullAsZero=False, stacked=False):
 
   yMinValue = safeMin(safeMin(series) for series in finiteData)
 
+  if yMinValue is None:
+    # This can only happen if there are no valid, non-infinite data.
+    return [0.0, 1.0]
+
   if yMinValue > 0.0 and drawNullAsZero and missingValues:
     yMinValue = 0.0
 
@@ -1607,12 +1611,6 @@ def dataLimits(data, drawNullAsZero=False, stacked=False):
 
   if yMaxValue < 0.0 and drawNullAsZero and missingValues:
     yMaxValue = 0.0
-
-  if yMinValue is None:
-    yMinValue = 0.0
-
-  if yMaxValue is None:
-    yMaxValue = 1.0
 
   return [yMinValue, yMaxValue]
 

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1063,9 +1063,8 @@ class LineGraph(Graph):
     if yMaxValue is None:
       yMaxValue = 1.0
 
-    if 'yMax' in self.params:
-      if self.params['yMax'] != 'max':
-        yMaxValue = self.params['yMax']
+    if 'yMax' in self.params and self.params['yMax'] != 'max':
+      yMaxValue = self.params['yMax']
 
     if 'yLimit' in self.params and self.params['yLimit'] < yMaxValue:
       yMaxValue = self.params['yLimit']

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1251,31 +1251,12 @@ class LineGraph(Graph):
     self.yScaleFactorR = float(self.graphHeight) / float(self.ySpanR)
 
     #Create and measure the Y-labels
-    def makeLabel(yValue, yStep=None, ySpan=None):
-      yValue, prefix = format_units(yValue,yStep,system=self.params.get('yUnitSystem'))
-      ySpan, spanPrefix = format_units(ySpan,yStep,system=self.params.get('yUnitSystem'))
-      if yValue < 0.1:
-        return "%g %s" % (float(yValue), prefix)
-      elif yValue < 1.0:
-        return "%.2f %s" % (float(yValue), prefix)
-      if ySpan > 10 or spanPrefix != prefix:
-        if type(yValue) is float:
-          return "%.1f %s " % (float(yValue), prefix)
-        else:
-          return "%d %s " % (int(yValue), prefix)
-      elif ySpan > 3:
-        return "%.1f %s " % (float(yValue), prefix)
-      elif ySpan > 0.1:
-        return "%.2f %s " % (float(yValue), prefix)
-      else:
-        return "%g %s" % (float(yValue), prefix)
-
     self.yLabelValuesL = self.getYLabelValues(self.yBottomL, self.yTopL, self.yStepL)
     self.yLabelValuesR = self.getYLabelValues(self.yBottomR, self.yTopR, self.yStepR)
     for value in self.yLabelValuesL: #can't use map() here self.yStepL and self.ySpanL are not iterable
-      self.yLabelsL.append( makeLabel(value,self.yStepL,self.ySpanL))
+      self.yLabelsL.append( makeLabel(value, self.yStepL, self.ySpanL, self.params.get('yUnitSystem')))
     for value in self.yLabelValuesR:
-      self.yLabelsR.append( makeLabel(value,self.yStepR,self.ySpanR) )
+      self.yLabelsR.append( makeLabel(value, self.yStepR, self.ySpanR, self.params.get('yUnitSystem')) )
     self.yLabelWidthL = max([self.getExtents(label)['width'] for label in self.yLabelsL])
     self.yLabelWidthR = max([self.getExtents(label)['width'] for label in self.yLabelsR])
     #scoot the graph over to the left just enough to fit the y-labels


### PR DESCRIPTION
I've noticed that the handling of the y axis range and the choice of tic marks are often a bit strange. For example:

* For linear axes the "pretty values" are often not all that pretty. I don't think a human would usually choose tic marks like [0, 12.5, 25, 37.5, ...]; one would use [0, 10, 20, 30, ...]. And surely nobody would choose [0, 22.5, 45, 67.5, 90, ...] when [0, 20, 40, 60, 80, ...] is so close by.

* The handling of `yMax="max"` is totally broken.

* There are several places where rounding errors could cause labels to be omitted.

* Logarithmic tic marks are totally broken, too.

So I've completely rewritten the axis-handling code while retaining backwards compatibility of the parameters. The new code restricts the mantissas of tic mark steps to be [..., 0.1, 0.2, 0.5, 1, 2, 5, 10, ...], which (in my opinion) is adequate to give really convenient tic marks without wasting too much space on the edges of the graph. I've rewritten the algorithm for optimizing (step, divisor) for the tic marks from scratch (documented in the docstring for `_LinearAxisTics.chooseStep()`. I've eliminated some places where rounding errors could cause problems. And I have fixed the logarithmic tic marks.

I've tested the new `_AxisTics` classes in isolation to some degree and they seem to work. But I haven't tested them together with the `LineGraph` class because I don't have a test setup. (I think the design is sound but there are surely typos and other minor problems.) If somebody could help me figure out some idiot-proof steps and the bare minimum configuration to run tests locally without becoming a django expert or figuring out how to feed data into the system, that would be really helpful.
