### PR TITLE
- correct yDivisor -> yDivisors and add an explanation of 'pretty'

### DIFF
--- a/docs/render_api.rst
+++ b/docs/render_api.rst
@@ -1014,7 +1014,7 @@ Sets the side of the graph on which to render the Y-axis. Accepts values of ``le
 .. _param-yDivisor:
   
 yDivisors
---------
+---------
 *Default: 4,5,6*
 
 Sets the preferred number of intermediate values to display on the Y-axis (Y values between the

--- a/docs/render_api.rst
+++ b/docs/render_api.rst
@@ -1005,13 +1005,15 @@ Sets the side of the graph on which to render the Y-axis. Accepts values of ``le
 
 .. _param-yDivisor:
   
-yDivisor
+yDivisors
 --------
 *Default: 4,5,6*
 
-Supplies the preferred number of intermediate values for the Y-axis to display (Y values between
-the min and max). Note that Graphite will ultimately choose what values (and how many) to display
-based on a set of 'pretty' values. To explicitly set the Y-axis values, see `yStep`_
+Sets the preferred number of intermediate values to display on the Y-axis (Y values between the
+minimum and maximum).  Note that Graphite will ultimately choose what values (and how many) to 
+display based on a 'pretty' factor, which tries to maintain a sensible scale (e.g. preferring 
+intermediary values like 25%,50%,75% over 33.3%,66.6%).  To explicitly set the Y-axis values, 
+see `yStep`_
 
 yLimit
 ------


### PR DESCRIPTION
The documentation uses 'yDivisor' where it should be using 'yDivisors'

This also confused me a little as to what it meant by 'pretty', so I added an explanation of what the codes trying to do in deciding the number of divisors, which I think is what its trying to do but not 100%!