### PR TITLE
render/views: Fix base timezone

### DIFF
--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -293,30 +293,38 @@ def parseOptions(request):
         continue
       graphOptions[opt] = val
 
-  tzinfo = get_current_timezone()
+  # Base Timezone is identical to the Django timezone.
+  # We'll render properly updated graphs with the request Timezone,
+  # if different, in glyph.py, but we need our starting timezone to
+  # convert first.
+  basetz = get_current_timezone()
+  
+  tzinfo = basetz
   if 'tz' in queryParams:
     try:
       tzinfo = pytz.timezone(queryParams['tz'])
     except pytz.UnknownTimeZoneError:
       pass
+
   requestOptions['tzinfo'] = tzinfo
+  requestOptions['basetz'] = basetz
 
   # Get the time interval for time-oriented graph types
   if graphType == 'line' or graphType == 'pie':
     if 'now' in queryParams:
         now = parseATTime(queryParams['now'])
     else:
-        now = datetime.now(get_current_timezone())
+        now = datetime.now(basetz)
 
     if 'until' in queryParams:
-      untilTime = parseATTime(queryParams['until'], get_current_timezone(), now)
+      untilTime = parseATTime(queryParams['until'], basetz, now)
     else:
       untilTime = now
 
     if 'from' in queryParams:
-      fromTime = parseATTime(queryParams['from'], get_current_timezone(), now)
+      fromTime = parseATTime(queryParams['from'], basetz, now)
     else:
-      fromTime = parseATTime('-1d', get_current_timezone(), now)
+      fromTime = parseATTime('-1d', basetz, now)
 
     startTime = min(fromTime, untilTime)
     endTime = max(fromTime, untilTime)

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -306,18 +306,17 @@ def parseOptions(request):
     if 'now' in queryParams:
         now = parseATTime(queryParams['now'])
     else:
-        now = datetime.now(tzinfo)
+        now = datetime.now(get_current_timezone())
 
     if 'until' in queryParams:
-      untilTime = parseATTime(queryParams['until'], tzinfo, now)
+      untilTime = parseATTime(queryParams['until'], get_current_timezone(), now)
     else:
       untilTime = now
+
     if 'from' in queryParams:
-      fromTime = parseATTime(queryParams['from'], tzinfo, now)
+      fromTime = parseATTime(queryParams['from'], get_current_timezone(), now)
     else:
-      fromTime = parseATTime('-1d', tzinfo, now)
-
-
+      fromTime = parseATTime('-1d', get_current_timezone(), now)
 
     startTime = min(fromTime, untilTime)
     endTime = max(fromTime, untilTime)


### PR DESCRIPTION
This fixes requests where the `&tz=` parameter does not match the configured Django timezone. This allows the timezone to be corrected for the x-axis and in a few other places, while retrieving the correct range from whisper and remote hosts.

Matching:
```
Tue Nov 24 19:07:58 2015 :: Default timezone: America/New_York
Tue Nov 24 19:07:58 2015 :: Selected Timezone: America/New_York
Tue Nov 24 19:07:58 2015 :: ATTime input: s=-1h, tzinfo=America/New_York, now=2015-11-24 19:07:58.849006-05:00
Tue Nov 24 19:07:58 2015 :: ATTime return: 2015-11-24 18:07:58.849051-05:00 (ref=2015-11-24 19:07:58.849293, offset=-1 day, 23:00:00)
Tue Nov 24 19:07:58 2015 :: now: 2015-11-24 19:07:58.849006-05:00 | untilTime: 2015-11-24 19:07:58.849006-05:00 | fromTime 2015-11-24 18:07:58.849051-05:00
Tue Nov 24 19:07:58 2015 :: Request TZ is None
Tue Nov 24 19:07:58 2015 :: Acting TZ is America/New_York
Tue Nov 24 19:07:58 2015 :: Request start time: 1448406480 & request end time: 1448410020
Tue Nov 24 19:07:58 2015 :: Request TZ-converted timerange: 2015-11-24 18:08:00-05:00, 2015-11-24 19:07:00-05:00
```

Not matching:
```
Tue Nov 24 19:08:04 2015 :: Default timezone: America/New_York
Tue Nov 24 19:08:04 2015 :: Selected Timezone: UTC
Tue Nov 24 19:08:04 2015 :: ATTime input: s=-1h, tzinfo=America/New_York, now=2015-11-24 19:08:04.357317-05:00
Tue Nov 24 19:08:04 2015 :: ATTime return: 2015-11-24 18:08:04.357354-05:00 (ref=2015-11-24 19:08:04.357910, offset=-1 day, 23:00:00)
Tue Nov 24 19:08:04 2015 :: now: 2015-11-24 19:08:04.357317-05:00 | untilTime: 2015-11-24 19:08:04.357317-05:00 | fromTime 2015-11-24 18:08:04.357354-05:00
Tue Nov 24 19:08:04 2015 :: Request TZ is UTC
Tue Nov 24 19:08:04 2015 :: Acting TZ is UTC
Tue Nov 24 19:08:04 2015 :: Request start time: 1448406540 & request end time: 1448410080
Tue Nov 24 19:08:04 2015 :: Request TZ-converted timerange: 2015-11-24 23:09:00+00:00, 2015-11-25 00:08:00+00:00
```

This may fix #1407 - see the issue for a lot more context and investigation.