### PR TITLE
Update attime to use timezones properly

### DIFF
--- a/webapp/graphite/render/attime.py
+++ b/webapp/graphite/render/attime.py
@@ -45,11 +45,11 @@ def parseATTime(s, tzinfo=None, now=None):
     offset = '-' + offset
   else:
     ref,offset = s,''
-  return tzinfo.localize((parseTimeReference(ref) + parseTimeOffset(offset)), daylight)
+  return tzinfo.normalize(parseTimeReference(ref).astimezone(tzinfo) + parseTimeOffset(offset))
 
 
 def parseTimeReference(ref):
-  if not ref or ref == 'now': return datetime.now()
+  if not ref or ref == 'now': return datetime.now(pytz.utc)
   #Time-of-day reference
   i = ref.find(':')
   hour,min = 0,0
@@ -71,7 +71,7 @@ def parseTimeReference(ref):
     hour,min = 16,0
     ref = ref[7:]
 
-  refDate = datetime.now().replace(hour=hour,minute=min,second=0)
+  refDate = datetime.now(pytz.utc).replace(hour=hour,minute=min,second=0)
 
   #Day reference
   if ref in ('yesterday','today','tomorrow'): #yesterday, today, tomorrow
@@ -119,6 +119,7 @@ def parseTimeReference(ref):
     refDate -= timedelta(days=dayOffset)
   elif ref:
     raise Exception, "Unknown day reference"
+
   return refDate
 
 


### PR DESCRIPTION
**The problem**: `parseTimeReference` is not time-zone aware, preventing users from rendering graphs with their requested time zone on the x-axis properly. See #1407 for more.

**The yak**: `parseTimeReference` does some ... *timezone unfriendly* ... manipulations of a naive time object, preventing us from simply passing `tzinfo` into it in lots of edge cases.

**The solution**: make `parseTimeReference` internally work in UTC, and then have `parseATTime` localize the output into the requested (or default) timezone. (as recommended by http://pythonhosted.org/pytz/#problems-with-localtime)