### PR TITLE
Stop testing python 2.6 (0.9.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
 
 env:
@@ -26,8 +25,3 @@ install:
 script:
   - PYTHONPATH=. python graphite/manage.py syncdb --noinput
   - PYTHONPATH=. python graphite/manage.py test --settings=tests.settings -v2
-
-matrix:
-  exclude:
-    - python: "2.6"
-      env: REQUIREMENTS="Django<1.8 django-tagging<0.4"


### PR DESCRIPTION
Twisted 15.5 officially breaks Python 2.6 support so let's stop testing it.

refs https://github.com/graphite-project/carbon/issues/482