### PR TITLE
Deprecate python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ python: 2.7
 sudo: false
 
 env:
-  - TOXENV=py26-django14-pyparsing2
-  - TOXENV=py26-django15-pyparsing2
-  - TOXENV=py26-django16-pyparsing2
   - TOXENV=py27-django14-pyparsing2
   - TOXENV=py27-django15-pyparsing2
   - TOXENV=py27-django16-pyparsing2

--- a/check-dependencies.py
+++ b/check-dependencies.py
@@ -5,9 +5,9 @@ import sys
 # Simple python version test
 major,minor = sys.version_info[:2]
 py_version = sys.version.split()[0]
-if major != 2 or minor < 6:
+if major != 2 or minor < 7:
   # SystemExit defaults to returning 1 when printing a string to stderr
-  raise SystemExit("You are using python %s, but version 2.6 or greater is required" % py_version)
+  raise SystemExit("You are using python %s, but version 2.7 or greater is required" % py_version)
 
 required = 0
 optional = 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,6 @@
 [tox]
 envlist =
-# Django 1.4, 1.5 and 1.6 support Python 2.6+
-	py2{6,7}-django1{4,5,6}-pyparsing2,
-# Django 1.7+ supports python 2.7
-	py27-django1{7,8}-pyparsing2,
+	py27-django1{4,5,6,7,8}-pyparsing2,
 	py27-django16-pyparsing1, lint, docs
 
 [testenv]
@@ -13,6 +10,7 @@ setenv =
 	DJANGO_SETTINGS_MODULE=tests.settings
 	PYTHONPATH={toxinidir}/webapp
 	GRAPHITE_NO_PREFIX=true
+basepython = python2.7
 changedir = webapp
 commands =
 	django-admin.py test
@@ -20,9 +18,7 @@ deps =
 	cairocffi
 	django-tagging>=0.3.5,<0.4
 	pytz
-	py26: mock<1.1.0
-	py27: mock
-	py26: unittest2
+	mock
 	git+git://github.com/graphite-project/whisper.git#egg=whisper
 	git+git://github.com/graphite-project/ceres.git#egg=ceres
 	pyparsing1: pyparsing==1.5.7
@@ -33,9 +29,6 @@ deps =
 	django17: Django>=1.7,<1.8
 	django18: Django>=1.8,<1.9
 	django14,django15: django-discover-runner
-basepython =
-	py26: python2.6
-	py27: python2.7
 
 [testenv:docs]
 basepython = python2.7


### PR DESCRIPTION
Twisted 15.5 officially breaks Python 2.6 support so let's stop testing it. Also updating `check-dependencies.py` to require 2.7.

refs https://github.com/graphite-project/carbon/issues/482