### PR TITLE
Fix docs build with Django 1.9

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,13 @@ os.environ['DJANGO_SETTINGS_MODULE'] = "graphite.settings"
 from graphite import settings
 settings.LOG_DIR = os.path.abspath('.')
 
+try:
+    from django import setup
+except ImportError:
+    pass
+else:
+    setup()
+
 # Bring in the new ReadTheDocs sphinx theme
 import sphinx_rtd_theme
 

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ deps =
 	pytz
 	git+git://github.com/graphite-project/whisper.git#egg=whisper
 	git+git://github.com/graphite-project/ceres.git#egg=ceres
-	Django<1.9
+	Django
 	pyparsing
 	Sphinx
 	sphinx_rtd_theme


### PR DESCRIPTION
For a full project build with Django 1.9, we need to wait for a new version of django-tagging. Graphite-web needs to stay on Django<1.9 for now.