### PR TITLE
Fix: wrong metrics data when it takes a lot of time writing to db.

### DIFF
--- a/webapp/graphite/readers.py
+++ b/webapp/graphite/readers.py
@@ -179,6 +179,8 @@ class WhisperReader(object):
 
       try:
         i = int(interval - start) / step
+        if i < 0:
+            continue
         values[i] = value
       except:
         pass


### PR DESCRIPTION
If one metrics stays in carbon-cache for too long(like over 1h
not committing to disk) and when we are querying one metrics within
that time, it's possible `i = int(interval - start) / step` is negative,
hence overwriting the correct value.