### PR TITLE
Use settings.LOGOUT_URL in UI

### DIFF
--- a/webapp/graphite/browser/views.py
+++ b/webapp/graphite/browser/views.py
@@ -31,6 +31,7 @@ def header(request):
   context['profile'] = getProfile(request)
   context['documentation_url'] = settings.DOCUMENTATION_URL
   context['login_url'] = settings.LOGIN_URL
+  context['logout_url'] = settings.LOGOUT_URL
   return render_to_response("browserHeader.html", context)
 
 

--- a/webapp/graphite/templates/browserHeader.html
+++ b/webapp/graphite/templates/browserHeader.html
@@ -78,7 +78,7 @@ limitations under the License. -->
         <li><a href="{% url "dashboard" %}" target="_top">Dashboard</a></li>
         <li><a href="{% url "events" %}" target="_top">Events</a></li>
         {% if user.is_authenticated %}
-          <li class="user_state"><a href="/account/logout/" class="logout" target="_top">Logout</a> <b>{{ user.username }}</b> (<a href="/account/edit/" target="_top">profile</a>)</li>
+          <li class="user_state"><a href="{{logout_url}}" class="logout" target="_top">Logout</a> <b>{{ user.username }}</b> (<a href="/account/edit/" target="_top">profile</a>)</li>
         {% else %}
           <li class="user_state login"><a href="{{login_url}}" target="_top">Login</a></li>
         {% endif %}


### PR DESCRIPTION
Now graphite-web hardcodes logout url in template, which doesn't allow easy use of external authentication systems. This PR fixes it.