### PR TITLE
Docs: functions page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,13 @@ os.environ['DJANGO_SETTINGS_MODULE'] = "graphite.settings"
 from graphite import settings
 settings.LOG_DIR = os.path.abspath('.')
 
+try:
+    from django import setup
+except ImportError:
+    pass
+else:
+    setup()
+
 # Bring in the new ReadTheDocs sphinx theme
 import sphinx_rtd_theme
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 ## Requirements for documentation
-Django>=1.4
+Django>=1.4,<1.9
 django-tagging==0.3.1
 sphinx
 sphinx_rtd_theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 ## Requirements for documentation
-Django>=1.4,<1.9
+Django>=1.4,<1.8
 django-tagging==0.3.1
 sphinx
 sphinx_rtd_theme


### PR DESCRIPTION
Another attempt…

Django 1.9 doesn't work yet because it needs django-tagging.
Django 1.8 either because some incompatible django-tagging forms are being imported.

So, fallback to Django 1.7 and still call `django.setup()` to avoid the `AppRegistryNotReady` error when loading the functions page.

My build: http://graphite-web.readthedocs.org/en/latest/functions.html