### PR TITLE
'%l' can fail silently, updated percent_l_supported test

### DIFF
--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -80,10 +80,13 @@ YEAR = DAY * 365
 
 # Set a flag to indicate whether the '%l' option can be used safely.
 # On Windows, in particular the %l option in strftime is not supported.
-#(It is not one of the documented Python formatters).
+# '%l' can also fail silently in Linux.
+# (It is not one of the documented Python formatters).
 try:
-    datetime.now().strftime("%a %l%p")
-    percent_l_supported = True
+    if datetime.now().strftime("%a %l%p"):
+        percent_l_supported = True
+    else:
+        percent_l_supported = False
 except ValueError as e:
     percent_l_supported = False
 


### PR DESCRIPTION
Here is a test showing that `%l` in `strftime` can fail silently:
```
# python
Python 2.7.10 (default, Aug 13 2015, 12:27:27) 
[GCC 4.9.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from datetime import datetime
>>> datetime.now().strftime("%a %l%p")
''
>>> 
```
The existing test does not catch this case. This patch fixes that.