### PR TITLE
Support for Django 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - TOXENV=py27-django16-pyparsing2
   - TOXENV=py27-django17-pyparsing2
   - TOXENV=py27-django18-pyparsing2
+  - TOXENV=py27-django19-pyparsing2
   - TOXENV=py27-django16-pyparsing1
   - TOXENV=docs
   - TOXENV=lint

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@
 #   deactivate
 #
 
-Django>=1.4,<1.9
+Django>=1.4
 python-memcached==1.47
 txAMQP==0.4
 simplejson==2.1.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [bdist_rpm]
 requires = Django => 1.4
-           Django < 1.9
            django-tagging
            carbon
            whisper

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ deps =
 	pytz
 	git+git://github.com/graphite-project/whisper.git#egg=whisper
 	git+git://github.com/graphite-project/ceres.git#egg=ceres
-	Django<1.9
+	Django
 	pyparsing
 	Sphinx
 	sphinx_rtd_theme

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-	py27-django1{4,5,6,7,8}-pyparsing2,
+	py27-django1{4,5,6,7,8,9}-pyparsing2,
 	py27-django16-pyparsing1, lint, docs
 
 [testenv]
@@ -28,6 +28,7 @@ deps =
 	django16: Django>=1.6,<1.7
 	django17: Django>=1.7,<1.8
 	django18: Django>=1.8,<1.9
+        django19: Django>=1.9,<1.10
 	django14,django15: django-discover-runner
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,8 @@ commands =
 	django-admin.py test
 deps =
 	cairocffi
-	django-tagging>=0.3.5,<0.4
+	django1{4,5,6}: django-tagging>=0.3.5,<0.4
+	django1{7,8,9}: django-tagging
 	pytz
 	mock
 	git+git://github.com/graphite-project/whisper.git#egg=whisper

--- a/webapp/graphite/browser/views.py
+++ b/webapp/graphite/browser/views.py
@@ -244,7 +244,7 @@ def userGraphLookup(request):
 
 def json_response(nodes, request=None):
   if request:
-    jsonp = request.REQUEST.get('jsonp', False)
+    jsonp = request.GET.get('jsonp', False) or request.POST.get('jsonp', False)
   else:
     jsonp = False
   #json = str(nodes) #poor man's json encoder for simple types

--- a/webapp/graphite/events/views.py
+++ b/webapp/graphite/events/views.py
@@ -2,7 +2,11 @@ import datetime
 
 import pytz
 
-from django.contrib.sites.models import RequestSite
+try:
+    from django.contrib.sites.requests import RequestSite
+except ImportError:  # Django < 1.9
+    from django.contrib.sites.models import RequestSite
+
 from django.shortcuts import render_to_response, get_object_or_404
 from django.utils.timezone import now, make_aware
 

--- a/webapp/graphite/events/views.py
+++ b/webapp/graphite/events/views.py
@@ -62,7 +62,7 @@ def post_event(request):
 
 
 def get_data(request):
-    if 'jsonp' in request.REQUEST:
+    if 'jsonp' in request.GET or 'jsonp' in request.POST:
         response = HttpResponse(
           "%s(%s)" % (request.REQUEST.get('jsonp'),
               json.dumps(fetch(request), cls=EventEncoder)),

--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -68,22 +68,26 @@ def index_json(request):
 def find_view(request):
   "View for finding metrics matching a given pattern"
   profile = getProfile(request)
-  format = request.REQUEST.get('format', 'treejson')
-  local_only = int( request.REQUEST.get('local', 0) )
-  wildcards = int( request.REQUEST.get('wildcards', 0) )
-  fromTime = int( request.REQUEST.get('from', -1) )
-  untilTime = int( request.REQUEST.get('until', -1) )
-  jsonp = request.REQUEST.get('jsonp', False)
+
+  queryParams = request.GET.copy()
+  queryParams.update(request.POST)
+
+  format = queryParams.get('format', 'treejson')
+  local_only = int( queryParams.get('local', 0) )
+  wildcards = int( queryParams.get('wildcards', 0) )
+  fromTime = int( queryParams.get('from', -1) )
+  untilTime = int( queryParams.get('until', -1) )
+  jsonp = queryParams.get('jsonp', False)
 
   if fromTime == -1:
     fromTime = None
   if untilTime == -1:
     untilTime = None
 
-  automatic_variants = int( request.REQUEST.get('automatic_variants', 0) )
+  automatic_variants = int( queryParams.get('automatic_variants', 0) )
 
   try:
-    query = str( request.REQUEST['query'] )
+    query = str( queryParams['query'] )
   except:
     return HttpResponseBadRequest(content="Missing required parameter 'query'",
                                   content_type="text/plain")

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -223,7 +223,8 @@ def renderView(request):
 
 
 def parseOptions(request):
-  queryParams = request.REQUEST
+  queryParams = request.GET.copy()
+  queryParams.update(request.POST)
 
   # Start with some defaults
   graphOptions = {'width' : 330, 'height' : 250}

--- a/webapp/graphite/urls.py
+++ b/webapp/graphite/urls.py
@@ -17,12 +17,8 @@ from django.conf import settings
 from django.conf.urls import patterns, include, url
 from django.contrib import admin
 
-try:
-    from django.template.base import add_to_builtins
-except ImportError:  # Django < 1.7
-    from django.template.loader import add_to_builtins
-
 if django.VERSION < (1, 5):  # load the "future" {% url %} tag
+    from django.template.loader import add_to_builtins
     add_to_builtins('django.templatetags.future')
 
 if django.VERSION < (1, 7):


### PR DESCRIPTION
I made the required changes to have it work with Django 1.9. Travis builds OK with Django 1.9 and I have been using this updated version on my own deployment. Here is an overview of the changes:

1. Update Travis build files (`.travis.yml` and `tox.ini`) to build with Django 1.9. Update django-tagging version as well.
2. Fix moved or removed references in Django like `django.contrib.sites.requests.RequestSite` and `django.template.base.add_to_builtins`
3. Replace `request.REQUEST` with `request.GET` and `request.POST` on a case-by-case basis.
4. Update Django version in `requirements.txt` and `setup.cfg`

This solves #1467