### PR TITLE
Allow for rendering PDF files

### DIFF
--- a/docs/render_api.rst
+++ b/docs/render_api.rst
@@ -207,7 +207,7 @@ Data Display Formats
 ====================
 
 Along with rendering an image, the api can also generate
-`SVG <http://www.w3.org/Graphics/SVG/>`_  with embedded metadata or return the raw data in various
+`SVG <http://www.w3.org/Graphics/SVG/>`_  with embedded metadata, PDF, or return the raw data in various
 formats for external graphing, analysis or monitoring.
 
 format
@@ -225,6 +225,7 @@ Examples:
   &format=csv
   &format=json
   &format=svg
+  &format=pdf
 
 png
 ^^^
@@ -321,6 +322,10 @@ an object describing the graph
       }
     ]]>
   </script>
+
+pdf
+^^^
+Renders the graph as a PDF of size determined by width_ and height_.
 
 pickle
 ^^^^^^

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -167,6 +167,8 @@ class Graph:
     if self.margin < 0:
       self.margin = 10
 
+    self.setupCairo( params.get('outputFormat','png').lower() )
+
     self.area = {
       'xmin' : self.margin + 10, # Need extra room when the time is near the left edge
       'xmax' : self.width - self.margin,
@@ -175,8 +177,6 @@ class Graph:
     }
 
     self.loadTemplate( params.get('template','default') )
-
-    self.setupCairo( params.get('outputFormat','png').lower() )
 
     opts = self.ctx.get_font_options()
     opts.set_antialias( cairo.ANTIALIAS_NONE )
@@ -205,6 +205,10 @@ class Graph:
     elif outputFormat == 'pdf':
       self.surfaceData = StringIO.StringIO()
       self.surface = cairo.PDFSurface(self.surfaceData, self.width, self.height)
+      res_x, res_y = self.surface.get_fallback_resolution()
+      self.width = float(self.width / res_x) * 72
+      self.height = float(self.height / res_y) * 72
+      self.surface.set_size(self.width, self.height)
     self.ctx = cairo.Context(self.surface)
 
   def setColor(self, value, alpha=1.0, forceAlpha=False):

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -199,9 +199,12 @@ class Graph:
     self.outputFormat = outputFormat
     if outputFormat == 'png':
       self.surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, self.width, self.height)
-    else:
+    elif outputFormat == 'svg':
       self.surfaceData = StringIO.StringIO()
       self.surface = cairo.SVGSurface(self.surfaceData, self.width, self.height)
+    elif outputFormat == 'pdf':
+      self.surfaceData = StringIO.StringIO()
+      self.surface = cairo.PDFSurface(self.surfaceData, self.width, self.height)
     self.ctx = cairo.Context(self.surface)
 
   def setColor(self, value, alpha=1.0, forceAlpha=False):
@@ -443,6 +446,11 @@ class Graph:
   def output(self, fileObj):
     if self.outputFormat == 'png':
       self.surface.write_to_png(fileObj)
+    elif self.outputFormat == 'pdf':
+      self.surface.finish()
+      pdfData = self.surfaceData.getvalue()
+      self.surfaceData.close()
+      fileObj.write(pdfData)
     else:
       metaData = {
         'x': {

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -198,6 +198,9 @@ def renderView(request):
     if format == 'svg':
       graphOptions['outputFormat'] = 'svg'
 
+    if format == 'pdf':
+      graphOptions['outputFormat'] = 'pdf'
+
     if format == 'pickle':
       response = HttpResponse(content_type='application/pickle')
       seriesInfo = [series.getInfo() for series in data]
@@ -219,6 +222,8 @@ def renderView(request):
     response = HttpResponse(
       content="%s(%s)" % (requestOptions['jsonp'], json.dumps(image)),
       content_type='text/javascript')
+  elif graphOptions.get('outputFormat') == 'pdf':
+    response = buildResponse(image, 'application/x-pdf')
   else:
     response = buildResponse(image, useSVG and 'image/svg+xml' or 'image/png')
 


### PR DESCRIPTION
This is a very simple commit to allow for rendering PDF files through the render API. The documentation has been updated to reflect it.

I do a little hacky conversion from pixels to points so that the API is always using pixels instead of points.

Let me know if I forgot anything.