### PR TITLE
dynamically collapse navbar on dashboard load

### DIFF
--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -27,6 +27,22 @@ var NAV_BAR_REGION = cookieProvider.get('navbar-region') || 'north';
 
 var CONFIRM_REMOVE_ALL = cookieProvider.get('confirm-remove-all') != 'false';
 
+var currently_setting_hash = false;
+
+function changeHash(hash){
+    currently_setting_hash = true;
+    window.location.hash = hash;
+}
+
+if ("onhashchange" in window) // does the browser support the hashchange event?
+  window.onhashchange = function () {
+    if (currently_setting_hash){
+      currently_setting_hash = false;
+      return;
+    }
+    location.reload();
+  }
+
 /* Nav Bar configuration */
 var navBarNorthConfig = {
   region: 'north',
@@ -755,7 +771,7 @@ function initDashboard () {
   // Load initial dashboard state if it was passed in
   if (initialState) {
     applyState(initialState);
-    navBar.collapse();
+    navBar.collapse(false);
   }
 
   if(window.location.hash != '')
@@ -766,6 +782,7 @@ function initDashboard () {
     } else {
       sendLoadRequest(window.location.hash.substr(1));
     }
+    navBar.collapse(false);
   }
 
   if (initialError) {
@@ -2538,6 +2555,11 @@ function sendSaveRequest(name) {
                if (result.error) {
                  Ext.Msg.alert("Error", "There was an error saving this dashboard: " + result.error);
                }
+               if(newURL) {
+                 window.location = newURL;
+               } else {
+                 changeHash(name);
+               }
              },
     failure: failedAjaxCall
   });
@@ -2552,6 +2574,7 @@ function sendLoadRequest(name) {
                  Ext.Msg.alert("Error Loading Dashboard", result.error);
                } else {
                  applyState(result.state);
+                 navBar.collapse(false);
                }
              },
     failure: failedAjaxCall
@@ -2703,7 +2726,7 @@ function setDashboardName(name) {
     dashboardURL = urlparts.join('/');
 
     document.title = name + " - Graphite Dashboard";
-    window.location.hash = name;
+    changeHash(name);
     navBar.setTitle(name + " - (" + dashboardURL + ")");
     saveButton.setText('Save "' + name + '"');
     saveButton.enable();

--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -50,7 +50,7 @@ var navBarNorthConfig = {
   layoutConfig: { align: 'stretch' },
   collapsible: true,
   collapseMode: 'mini',
-  collapsed: true,
+  collapsed: false,
   split: true,
   title: "untitled",
   height: 350,


### PR DESCRIPTION
North navbar non-collapsed by default.

Collapse the navbar when loading a dashboard from a hash change. Unify the hash change code so loading the dashboard happens and the navbar is collapsed.

Don't animate the collapse of the navbar as it makes the loading of the dashboard more fluid.
