### PR TITLE
Fix Memcache key length error

### DIFF
--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -9,6 +9,7 @@ from graphite.node import LeafNode, BranchNode
 from graphite.readers import FetchInProgress
 from graphite.logger import log
 from graphite.util import unpickle
+from graphite.render.hashing import compactHash
 
 
 
@@ -48,7 +49,7 @@ class FindRequest(object):
     else:
       end = ""
 
-    self.cacheKey = "find:%s:%s:%s:%s" % (store.host, query.pattern, start, end)
+    self.cacheKey = "find:%s:%s:%s:%s" % (store.host, compactHash(query.pattern), start, end)
     self.cachedResult = None
 
   def send(self):


### PR DESCRIPTION
Was receiving MemcachedKeyLengthError: Key length is > 250 with the following stack trace:

Traceback (most recent call last):
  File "/opt/graphite/webapp/graphite/render/datalib.py", line 138, in fetchData
    seriesList = _fetchData(pathExpr,startTime, endTime, requestContext, seriesList)
  File "/opt/graphite/webapp/graphite/render/datalib.py", line 101, in _fetchData
    fetches = [(node, node.fetch(startTime, endTime)) for node in matching_nodes if node.is_leaf]
  File "/opt/graphite/webapp/graphite/storage.py", line 41, in find
    remote_requests = [ r.find(query) for r in self.remote_stores if r.available ]
  File "/opt/graphite/webapp/graphite/remote_storage.py", line 24, in find
    request.send()
  File "/opt/graphite/webapp/graphite/remote_storage.py", line 57, in send
    self.cachedResult = cache.get(self.cacheKey)
  File "/usr/lib/python2.7/site-packages/django/core/cache/backends/memcached.py", line 64, in get
    val = self._cache.get(key)
  File "/usr/lib/python2.7/site-packages/memcache.py", line 793, in get
    return self._get('get', key)
  File "/usr/lib/python2.7/site-packages/memcache.py", line 761, in _get
    self.check_key(key)
  File "/usr/lib/python2.7/site-packages/memcache.py", line 954, in check_key
    % self.server_max_key_length)