### PR TITLE
Convert event time to local tz in events function

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -24,7 +24,7 @@ from os import environ
 from graphite.logger import log
 from graphite.render.attime import parseTimeOffset, parseATTime
 from graphite.events import models
-from graphite.util import epoch, utc_to_local
+from graphite.util import epoch
 
 # XXX format_units() should go somewhere else
 if environ.get('READTHEDOCS'):

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -3400,6 +3400,12 @@ def events(requestContext, *tags):
   def to_epoch(datetime_object):
     return int(time.mktime(datetime_object.timetuple()))
 
+  def utc_to_local(timestamp):
+    dt = datetime.fromtimestamp(timestamp)
+    dt = dt.replace(tzinfo=dateutil.tz.tzutc())
+    dt = dt.astimezone(tz=dateutil.tz.tzlocal())
+    return to_epoch(dt)
+
   step = 1
   name = "events(" + ", ".join(tags) + ")"
   if tags == ("*",):
@@ -3419,8 +3425,10 @@ def events(requestContext, *tags):
 
   values = [None] * points
   for event in events:
-    event_timestamp = to_epoch(event.when)
+    event_timestamp_utc = to_epoch(event.when)
+    event_timestamp = utc_to_local(event_timestamp_utc)
     value_offset = (event_timestamp - start_timestamp)/step
+
     if values[value_offset] is None:
       values[value_offset] = 1
     else:


### PR DESCRIPTION
Events times are returned from db in UTC timezone. Convert them in local time to be aligned with query times.