### PR TITLE
Improve render API performance when the `target` includes many metrics.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ deps =
 	git+git://github.com/graphite-project/ceres.git#egg=ceres
 	Django
 	pyparsing
-	Sphinx
+	Sphinx<1.4
 	sphinx_rtd_theme
 commands =
 	mkdir -p {envsitepackagesdir}/../storage/ceres

--- a/webapp/graphite/finders/standard.py
+++ b/webapp/graphite/finders/standard.py
@@ -69,7 +69,7 @@ class StandardFinder:
     pattern = patterns[0]
     patterns = patterns[1:]
 
-    has_wildcard = pattern.find('{') > -1 or pattern.find('[') > -1 or pattern.find('*') > -1
+    has_wildcard = pattern.find('{') > -1 or pattern.find('[') > -1 or pattern.find('*') > -1 or pattern.find('?') > -1
 
     if has_wildcard: # this avoids os.listdir() for performance
       try:


### PR DESCRIPTION
When the `target` includes many metric paths (ex. `avg(test.host0.loadavg5, test.host1.loadavg5, ..., test.host1000.loadavg5)`), render URI API calls `os.listdir` many times and its response is slower.

This PR reduces `os.listdir` calls if the metric paths contain no wildcards.
