### PR TITLE
Docs tweaks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+First of all, Welcome, and Thank You!
+
+Graphite has been a community project for years, and it only gets better by the efforts of people who volunteer.  We sincerely appreciate that you care enough to see a problem, take the time to make this project better.  Whether it's in the form of a bug report, code fix, or documentation improvement, we - the Graphite team - appreciate your help.
+
+This is a collection of practices that will make it easier for us to accept your contributions.
+
+
+### Issues
+
+While not mandatory, opening an Issue against the appropriate repo is seldom a bad thing.  We prefer that you have searched through the existing issues.  It's entirely possible that the issue has already been reported.  It may have already been solved.
+
+If your issue in in-fact new, please write a descriptive report.  Terse but complete is best.  You should describe:
+
+* What you attempted
+* Expected Result
+* Witnessed Result
+* System Details
+  * OS / Version
+  * Python Version
+  * Django Version (a frequent cause of issues)
+  * Graphite Component Versions (or commit hash if running directly from the repo)
+
+
+### Tests
+
+We would absolutely love to improve our test coverage.  If you see a gap, and can write a test for that, we'd eat that up.
+
+
+### Code
+
+If you see a mistake, have a feature, or a performance gain, we'd love to see it.  It's _strongly_ encouraged for contributions that aren't already covered by tests to come with them.  We're not trying to foist work on to you, but it makes it much easier for us to accept your contributions.
+
+
+### Documentation
+
+Graphite has historically not had great docs.  It still doesn't.  The good news is that docs are easy to contribute.
+
+Even if you don't know the intricacies of ReStructured Text (ReST), even bare unformatted paragraphs is better than nothing.
+
+English not your primary language?  We'll work with you.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,15 @@
 First of all, Welcome, and Thank You!
 
-Graphite has been a community project for years, and it only gets better by the efforts of people who volunteer.  We sincerely appreciate that you care enough to see a problem, take the time to make this project better.  Whether it's in the form of a bug report, code fix, or documentation improvement, we - the Graphite team - appreciate your help.
+Graphite has been a community project for years, and it only gets better by the efforts of people who volunteer.  We sincerely appreciate that you care enough to see a problem and take the time to make this project better.  Whether it's in the form of a bug report, code fix, or documentation improvement, we - the Graphite team - appreciate your help.
 
 This is a collection of practices that will make it easier for us to accept your contributions.
 
 
 ### Issues
 
-While not mandatory, opening an Issue against the appropriate repo is seldom a bad thing.  We prefer that you have searched through the existing issues.  It's entirely possible that the issue has already been reported.  It may have already been solved.
+While not mandatory, opening an Issue against the appropriate repo is seldom a bad thing.  However, we would love if you would take a moment to search through the existing issues first.  It's entirely possible that the issue has already been reported, or even resolved.
 
-If your issue in in-fact new, please write a descriptive report.  Terse but complete is best.  You should describe:
+When opening a new issue, please write a descriptive report.  Terse but complete is best.  You should describe:
 
 * What you attempted
 * Expected Result
@@ -19,11 +19,13 @@ If your issue in in-fact new, please write a descriptive report.  Terse but comp
   * Python Version
   * Django Version (a frequent cause of issues)
   * Graphite Component Versions (or commit hash if running directly from the repo)
+    * If the graphite components were installed via pip, `pip list` will show the versions.
+    * Graphite-Web has a `/version/` endpoint that returns the version.  For example `curl http://mygraphite/version/`
 
 
 ### Tests
 
-We would absolutely love to improve our test coverage.  If you see a gap, and can write a test for that, we'd eat that up.
+We are always looking to improve our test coverage.  New tests will be appreciated and quickly reviewed for inclusion.
 
 
 ### Code
@@ -35,6 +37,6 @@ If you see a mistake, have a feature, or a performance gain, we'd love to see it
 
 Graphite has historically not had great docs.  It still doesn't.  The good news is that docs are easy to contribute.
 
-Even if you don't know the intricacies of ReStructured Text (ReST), even bare unformatted paragraphs is better than nothing.
+Even if you don't know the intricacies of ReStructured Text (ReST), bare unformatted paragraphs are better than nothing!
 
 English not your primary language?  We'll work with you.

--- a/CONTRIBUTING_FOR_COMMITTERS.md
+++ b/CONTRIBUTING_FOR_COMMITTERS.md
@@ -1,0 +1,12 @@
+First of all, Welcome, and Thank You!
+
+I don't know about you, but I'm in it for all of the glory that Obfuscurity promised...
+
+The team has grown some in the last year or so, so let's get some ground rules:
+
+* Be polite to the community.
+* We are part of the community.
+* Don't commit directly to the public repo.  Please Fork and PR.
+* Unless things are publicly broken and nobody else is around to validate, don't merge your own PR.
+* If you're going to do something directly on the main repo, or something Meta (tags, releases, etc), other people should probably know about it. When in doubt, check with Obfuscurity or MLeinart.
+* Be polite to the community.

--- a/docs/storage-backends.rst
+++ b/docs/storage-backends.rst
@@ -10,8 +10,8 @@ The default graphite setup consists of:
 * A carbon daemon writing data to the database
 * Graphite-web reading and graphing data from the database
 
-It is possible to switch the storage layer to something different than
-Whisper to accommodate specific needs. The setup above would become:
+It is possible to use an alternate storage layer than the default, Whisper, in
+order to accommodate specific needs. The setup above would become:
 
 * An alternative database
 * A carbon daemon or alternative daemon for writing to the database

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -8,9 +8,6 @@ Collection
 `Brubeck`_
   A statsd-compatible stats aggregator written in C.
 
-`Bryans' Graphite Tools <https://github.com/linkslice/graphite-tools>`_
-  A collection of miscellaneous scripts for pulling data from various devices, F5, Infoblox, Nutanix, etc.
-  
 `Bucky`_
   A small service implemented in Python for collecting and translating metrics for Graphite. It can currently collect metric data from CollectD daemons and from StatsD clients.
 
@@ -39,9 +36,9 @@ Collection
 `graphite-pollers <https://github.com/phreakocious/graphite-pollers>`_
   A collection of scripts that shovel data into Graphite including a multi-threaded SNMP poller for network interface IF-MIB statistics and another which pulls linux network stack data from files in /proc/net. Add to cron and go.
 
-`Graphite PowerShell Functions <https://github.com/MattHodge/Graphite-PowerShell-Functions>`_ 
+`Graphite PowerShell Functions <https://github.com/MattHodge/Graphite-PowerShell-Functions>`_
   A group of functions that can be used to collect Windows Performance Counters and send them over to the Graphite server. The main function can be run as a Windows service, and everything is configurable via an XML file.
-  
+
 `HoardD`_
   A Node.js app written in CoffeeScript to send data from servers to Graphite, much like collectd does, but aimed at being easier to expand and with less footprint. It comes by default with basic collectors plus Redis and MySQL metrics, and can be expanded with Javascript or CoffeeScript.
 
@@ -64,7 +61,7 @@ Collection
   A monitoring framework that can route metrics to Graphite. Servers subscribe to sets of checks, so getting metrics from a new server to Graphite is as simple as installing the Sensu client and subscribing.
 
 `SqlToGraphite`_
-  An agent for windows written in .net to collect metrics using plugins (WMI, SQL Server, Oracle) by polling an endpoint with a SQL query and pushing the results into graphite. It uses either a local or a centralised configuration over HTTP. 
+  An agent for windows written in .net to collect metrics using plugins (WMI, SQL Server, Oracle) by polling an endpoint with a SQL query and pushing the results into graphite. It uses either a local or a centralised configuration over HTTP.
 
 `SSC Serv`_
   A Windows service (agent) which periodically publishes system metrics, for example CPU, memory and disk usage. It can store data in Graphite using a naming schema that's identical to that used by collectd.
@@ -97,7 +94,7 @@ Forwarding
 `Graphout`_
   A Node.js application that lets you forward Graphite based queries (using the render API) out to different external services. There are built in modules for Zabbix and CloudWatch. Custom modules are very easy to write.
 
-`Grockets`_ 
+`Grockets`_
   A node.js application which provides streaming JSON data over HTTP from Graphite.
 
 `Gruffalo`_
@@ -111,7 +108,7 @@ Forwarding
 
 `statsd`_
   A simple daemon for easy stats aggregation, developed by the folks at Etsy. A list of forks and alternative implementations can be found at <http://joemiller.me/2011/09/21/list-of-statsd-server-implementations/>
-  
+
 Visualization
 -------------
 
@@ -189,7 +186,7 @@ Visualization
   Terminal tool for displaying Graphite metrics.
 
 `Tessera`_
-  A flexible front-end for creating dashboards with a wide variety of data presentations. 
+  A flexible front-end for creating dashboards with a wide variety of data presentations.
 
 `TimeseriesWidget`_
   Adds timeseries graphs to your webpages/dashboards using a simple api, focuses on high interactivity and modern features (realtime zooming, datapoint inspection, annotated events, etc). Supports Graphite, flot, rickshaw and anthracite.
@@ -200,7 +197,7 @@ Monitoring
 
 `Cabot`_
   A self-hosted monitoring and alerting server that watches Graphite metrics and can alert on them by phone, SMS, Hipchat or email. It is designed to be deployed to cloud or physical hardware in minutes and configured via web interface.
-  
+
 `graphite-beacon`_
   A simple alerting application for Graphite. It asynchronous and sends notification alerts based on Graphite metrics.
   It hasn't any dependencies except `Tornado` package. Very light and really very easy deployed.
@@ -246,6 +243,9 @@ Other
 -----
 `bosun`_
   Time Series Alerting Framework. Can use Graphite as time series source.
+
+`Bryans' Graphite Tools <https://github.com/linkslice/graphite-tools>`_
+  A collection of miscellaneous scripts for pulling data from various devices, F5, Infoblox, Nutanix, etc.
 
 `buckytools`_
   Go implementation of useful tools for dealing with Graphite's Whisper DBs and Carbon hashing.

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -244,7 +244,7 @@ Other
 `bosun`_
   Time Series Alerting Framework. Can use Graphite as time series source.
 
-`Bryans' Graphite Tools <https://github.com/linkslice/graphite-tools>`_
+`Bryans-Graphite-Tools`_
   A collection of miscellaneous scripts for pulling data from various devices, F5, Infoblox, Nutanix, etc.
 
 `buckytools`_
@@ -267,6 +267,7 @@ Other
 .. _Backstop: https://github.com/obfuscurity/backstop
 .. _bosun: http://bosun.org
 .. _Brubeck: https://github.com/github/brubeck
+.. _Bryans-Graphite-Tools: https://github.com/linkslice/graphite-tools
 .. _Bucky: http://pypi.python.org/pypi/bucky
 .. _buckytools: https://github.com/jjneely/buckytools
 .. _Cabot: https://github.com/arachnys/cabot


### PR DESCRIPTION
@graphite-project/committers 

* rewording in storage-backends.rst
* placing the `Bryan's Graphite Tools` in the Misc tool section of tools.rst

On a side note, does anyone care for the annotations-style links in the tools doc?  I think I prefer the inline style like what Bryan used.  Thoughts?