### PR TITLE
Set timeout in RemoteReader.fetch to be REMOTE_FETCH_TIMEOUT instead of REMOTE_FIND_TIMEOUT

### DIFF
--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -171,7 +171,7 @@ class RemoteReader(object):
         log.info("RemoteReader.request_data :: requesting %s" % url)
         connector_class = connector_class_selector(settings.INTRACLUSTER_HTTPS)
         self.connection = connector_class(self.store.host)
-        self.connection.timeout = settings.REMOTE_FIND_TIMEOUT
+        self.connection.timeout = settings.REMOTE_FETCH_TIMEOUT
         self.connection.request('GET', urlpath)
       except:
         completion_event.set()


### PR DESCRIPTION
Commit 3d378b2f528d0040256055b2af85839813006411 changed it to REMOTE_FIND_TIMEOUT which I believe to be an error.