### PR TITLE
Implement groupByNodes() function

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -3066,20 +3066,7 @@ def groupByNode(requestContext, seriesList, nodeNum, callback):
     sumSeries(ganglia.by-function.server1.*.cpu.load5),sumSeries(ganglia.by-function.server2.*.cpu.load5),...
 
   """
-  metaSeries = {}
-  keys = []
-  for series in seriesList:
-    key = series.name.split(".")[nodeNum]
-    if key not in metaSeries:
-      metaSeries[key] = [series]
-      keys.append(key)
-    else:
-      metaSeries[key].append(series)
-  for key in metaSeries.keys():
-    metaSeries[key] = SeriesFunctions[callback](requestContext,
-        metaSeries[key])[0]
-    metaSeries[key].name = key
-  return [ metaSeries[key] for key in keys ]
+  return groupByNodes(requestContext, seriesList, callback, nodeNum)
 
 def groupByNodes(requestContext, seriesList, callback, *nodes):
   """

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -3081,6 +3081,39 @@ def groupByNode(requestContext, seriesList, nodeNum, callback):
     metaSeries[key].name = key
   return [ metaSeries[key] for key in keys ]
 
+def groupByNodes(requestContext, seriesList, callback, *nodes):
+  """
+  Takes a serieslist and maps a callback to subgroups within as defined by multiple nodes
+
+  .. code-block:: none
+
+    &target=groupByNodes(ganglia.server*.*.cpu.load*,"sumSeries",1,4)
+
+  Would return multiple series which are each the result of applying the "sumSeries" function
+  to groups joined on the nodes' list (0 indexed) resulting in a list of targets like
+
+  .. code-block :: none
+
+    sumSeries(ganglia.server1.*.cpu.load5),sumSeries(ganglia.server1.*.cpu.load10),sumSeries(ganglia.server1.*.cpu.load15),sumSeries(ganglia.server2.*.cpu.load5),sumSeries(ganglia.server2.*.cpu.load10),sumSeries(ganglia.server2.*.cpu.load15),...
+
+  """
+  metaSeries = {}
+  keys = []
+  if isinstance(nodes, int):
+    nodes=[nodes]
+  for series in seriesList:
+    key = '.'.join(series.name.split(".")[n] for n in nodes)
+    if key not in metaSeries:
+      metaSeries[key] = [series]
+      keys.append(key)
+    else:
+      metaSeries[key].append(series)
+  for key in metaSeries.keys():
+    metaSeries[key] = SeriesFunctions[callback](requestContext,
+        metaSeries[key])[0]
+    metaSeries[key].name = key
+  return [ metaSeries[key] for key in keys ]
+
 def exclude(requestContext, seriesList, pattern):
   """
   Takes a metric or a wildcard seriesList, followed by a regular expression
@@ -3651,6 +3684,7 @@ SeriesFunctions = {
   'reduceSeries': reduceSeries,
   'applyByNode': applyByNode,
   'groupByNode': groupByNode,
+  'groupByNodes' : groupByNodes,
   'constantLine': constantLine,
   'stacked': stacked,
   'areaBetween': areaBetween,

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -819,6 +819,60 @@ class FunctionsTest(TestCase):
         with self.assertRaises(IndexError):
             verify_node_name(10000)
 
+    def test_groupByNode(self):
+        seriesList, inputList = self._generate_mr_series()
+
+        def verify_groupByNode(expectedResult, nodeNum):
+            results = functions.groupByNode({}, copy.deepcopy(seriesList), nodeNum, "keepLastValue")
+
+            for i, series in enumerate(results):
+                self.assertEqual(series.name, expectedResult[i].name)
+            self.assertEqual(results, expectedResult)
+
+        expectedResult   = [
+            TimeSeries('group',0,1,1,[None]),
+        ]
+        verify_groupByNode(expectedResult, 0)
+
+        expectedResult   = [
+            TimeSeries('server1',0,1,1,[None]),
+            TimeSeries('server2',0,1,1,[None]),
+        ]
+        verify_groupByNode(expectedResult, 1)
+
+    def test_groupByNodes(self):
+        seriesList, inputList = self._generate_mr_series()
+
+        def verify_groupByNodes(expectedResult, *nodes):
+            if isinstance(nodes, int):
+                node_number = [nodes]
+
+            results = functions.groupByNodes({}, copy.deepcopy(seriesList), "keepLastValue", *nodes)
+
+            for i, series in enumerate(results):
+                self.assertEqual(series.name, expectedResult[i].name)
+            self.assertEqual(results, expectedResult)
+
+        expectedResult = [
+            TimeSeries('server1',0,1,1,[None]),
+            TimeSeries('server2',0,1,1,[None]),
+        ]
+        verify_groupByNodes(expectedResult, 1)
+
+        expectedResult = [
+            TimeSeries('server1.metric1',0,1,1,[None]),
+            TimeSeries('server1.metric2',0,1,1,[None]),
+            TimeSeries('server2.metric1',0,1,1,[None]),
+            TimeSeries('server2.metric2',0,1,1,[None]),
+        ]
+        verify_groupByNodes(expectedResult, 1, 2)
+
+        expectedResult = [
+            TimeSeries('server1.group',0,1,1,[None]),
+            TimeSeries('server2.group',0,1,1,[None]),
+        ]
+        verify_groupByNodes(expectedResult, 1, 0)
+
     def test_alpha(self):
         seriesList = self._generate_series_list()
         alpha = 0.5


### PR DESCRIPTION
This is essentially a more powerful version of `groupByNode()` that allows grouping by multiple nodes.

We are evaluating graphite (through grafana) by producing various graphs based on our metrics and there some cases where we need to group a series list by multiple nodes. The tests should be clear on when that might be useful.

What concerns me is that we introduce a new version of an already present function, I am not sure if we can extend the functionally of `groupByNode()` to support multiple nodes. That could get tricky because of the parameter order and that might be difficult to express to other libraries that try to autocomplete graphite functions (like grafana).

The first commit adds tests for `groupByNode()` and can be merged as-is to master if you find it ok, I can also create a separate PR for it.