### PR TITLE
Pin Django <1.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@
 #   deactivate
 #
 
-Django>=1.4
+Django>=1.4,<1.9
 python-memcached==1.47
 txAMQP==0.4
 simplejson==2.1.6


### PR DESCRIPTION
django 1.9 removes the "syncdb" option that graphite's db deploy requires. Django 1.9 also no longer works with django-tagging 0.3.6, which is also a pinned requirement.