### PR TITLE
Gracefully handle offline cluster backends

### DIFF
--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -81,6 +81,10 @@ class FindRequest:
       response = self.connection.getresponse(buffering=True)
     except TypeError:  # Python 2.6 and older
       response = self.connection.getresponse()
+    except AttributeError:
+      self.store.fail()
+      if not self.suppressErrors:
+        raise
 
     try:
       assert response.status == 200, "received error response %s - %s" % (response.status, response.reason)


### PR DESCRIPTION
When finding remote metrics, a single unavailable backend causes the
entire tree to be unavailable for two consecutive requests, as
graphite/metrics/views.py's find_view() raises an AttributeError rather
than marking the backend as failed, and continuing with others.

This is ultimately because remote_storage.py's get_results() fails to
check for errors before trying to work with the response from httplib.

This patch enables all other backends' metrics to be shown immediately
after a backend fails.