### PR TITLE
Adding test coverage for render/glyph.py mark ii

### DIFF
--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -165,6 +165,12 @@ class _AxisTics:
 
   @staticmethod
   def checkFinite(value, name='value'):
+    """Check that value is a finite number.
+
+    If it is, return it. If not, raise GraphError describing the
+    problem, using name in the error message.
+    """
+
     if math.isnan(value):
       raise GraphError('Encountered NaN %s' % (name,))
     elif math.isinf(value):
@@ -173,12 +179,26 @@ class _AxisTics:
 
   @staticmethod
   def chooseDelta(x):
+    """Choose a reasonable axis range given that one limit is x.
+
+    Given that end of the axis range (i.e., minValue or maxValue) is
+    x, choose a reasonable distance to the other limit.
+    """
+
     if abs(x) < 1.0e-9:
       return 1.0
     else:
       return 0.1 * abs(x)
 
   def reconcileLimits(self):
+    """Fix the problem that self.minValue is not less than self.maxValue.
+
+    Adjust self.minValue and/or self.maxValue (depending on which was
+    not specified explicitly by the user) to make self.minValue <
+    self.maxValue. If the user specified both limits explicitly, then
+    raise GraphError.
+    """
+
     minFixed = (self.minValueSource in ['min'])
     maxFixed = (self.maxValueSource in ['max', 'limit'])
 
@@ -196,6 +216,26 @@ class _AxisTics:
       self.maxValue = average + delta
 
   def applySettings(self, axisMin=None, axisMax=None, axisLimit=None):
+    """Apply the specified settings to this axis.
+
+    Set self.minValue, self.minValueSource, self.maxValue,
+    self.maxValueSource, and self.axisLimit reasonably based on the
+    parameters provided.
+
+    Arguments:
+
+    axisMin -- a finite number, or None to choose a round minimum
+        limit that includes all of the data.
+
+    axisMax -- a finite number, 'max' to use the maximum value
+        contained in the data, or None to choose a round maximum limit
+        that includes all of the data.
+
+    axisLimit -- a finite number to use as an upper limit on maxValue,
+        or None to impose no upper limit.
+
+    """
+
     if axisMin is not None and not math.isnan(axisMin):
       self.minValueSource = 'min'
       self.minValue = self.checkFinite(axisMin, 'axis min')
@@ -226,6 +266,13 @@ class _AxisTics:
       self.reconcileLimits()
 
   def makeLabel(self, value):
+    """Create a label for the specified value.
+
+    Create a label string containing the value and its units (if any),
+    based on the values of self.step, self.span, and self.unitSystem.
+
+    """
+
     value, prefix = format_units(value, self.step, system=self.unitSystem)
     span, spanPrefix = format_units(self.span, self.step, system=self.unitSystem)
     if prefix:
@@ -248,6 +295,8 @@ class _AxisTics:
 
 
 class _LinearAxisTics(_AxisTics):
+  """Axis ticmarks with uniform spacing."""
+
   def __init__(self, minValue, maxValue, unitSystem=None):
     _AxisTics.__init__(self, minValue, maxValue, unitSystem=unitSystem)
     self.step = None
@@ -255,6 +304,8 @@ class _LinearAxisTics(_AxisTics):
     self.binary = None
 
   def setStep(self, step):
+    """Set the size of steps between ticmarks."""
+
     self.step = self.checkFinite(float(step), 'axis step')
 
   def generateSteps(self, minStep):
@@ -283,7 +334,7 @@ class _LinearAxisTics(_AxisTics):
     """Compute the slop that would result from step and divisor.
 
     Return the slop, or None if this combination can't cover the full
-    range.
+    range. See chooseStep() for the definition of "slop".
 
     """
 

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -249,6 +249,8 @@ class _LinearAxisTics(_AxisTics):
   def __init__(self, minValue, maxValue, unitSystem=None):
     _AxisTics.__init__(self, minValue, maxValue, unitSystem=unitSystem)
     self.step = None
+    self.span = None
+    self.binary = None
 
   def setStep(self, step):
     self.step = self.checkFinite(float(step), 'axis step')
@@ -419,6 +421,8 @@ class _LogAxisTics(_AxisTics):
     if base <= 1.0:
       raise GraphError('Logarithmic base must be greater than one')
     self.base = self.checkFinite(base, 'log base')
+    self.step = None
+    self.span = None
 
   def setStep(self, step):
     # step is ignored for Logarithmic tics:
@@ -1862,6 +1866,9 @@ def format_units(v, step=None, system="si"):
     http://en.wikipedia.org/wiki/Binary_prefix
   """
 
+  if v is None:
+    return v, ""
+
   if step is None:
     condition = lambda size: abs(v) >= size
   else:
@@ -1880,6 +1887,11 @@ def format_units(v, step=None, system="si"):
 
 
 def find_x_times(start_dt, unit, step):
+  if not isinstance(start_dt, datetime):
+    raise ValueError("Invalid start_dt: %s" % start_dt)
+  if not isinstance(step, int) or not step > 0:
+    raise ValueError("Invalid step value: %s" % step)
+
   if unit == SEC:
     dt = start_dt.replace(second=start_dt.second - (start_dt.second % step))
     x_delta = timedelta(seconds=step)

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -191,13 +191,18 @@ class _AxisTics:
       return 0.1 * abs(x)
 
   def reconcileLimits(self):
-    """Fix the problem that self.minValue is not less than self.maxValue.
+    """If self.minValue is not less than self.maxValue, fix the problem.
 
-    Adjust self.minValue and/or self.maxValue (depending on which was
-    not specified explicitly by the user) to make self.minValue <
+    If self.minValue is not less than self.maxValue, adjust
+    self.minValue and/or self.maxValue (depending on which was not
+    specified explicitly by the user) to make self.minValue <
     self.maxValue. If the user specified both limits explicitly, then
     raise GraphError.
     """
+
+    if self.minValue < self.maxValue:
+      # The limits are already OK.
+      return
 
     minFixed = (self.minValueSource in ['min'])
     maxFixed = (self.maxValueSource in ['max', 'limit'])
@@ -262,8 +267,7 @@ class _AxisTics:
       # a value larger than axisLimit:
       self.axisLimit = axisLimit
 
-    if not (self.minValue < self.maxValue):
-      self.reconcileLimits()
+    self.reconcileLimits()
 
   def makeLabel(self, value):
     """Create a label for the specified value.

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -206,19 +206,21 @@ class _AxisTics:
       self.maxValueSource = 'max'
       self.maxValue = self.checkFinite(axisMax, 'axis max')
 
-    if axisLimit is not None and not math.isnan(axisLimit):
-      if axisLimit < self.maxValue:
-        self.maxValue = self.checkFinite(axisLimit, 'axis limit')
-        self.maxValueSource = 'limit'
-        # The limit has already been imposed, so there is no need to
-        # remember it:
-        self.axisLimit = None
-      elif not math.isinf(axisLimit):
-        # We still need to remember axisLimit to avoid rounding top to
-        # a value larger than axisLimit:
-        self.axisLimit = axisLimit
-    else:
+    if axisLimit is None or math.isnan(axisLimit):
       self.axisLimit = None
+    elif axisLimit < self.maxValue:
+      self.maxValue = self.checkFinite(axisLimit, 'axis limit')
+      self.maxValueSource = 'limit'
+      # The limit has already been imposed, so there is no need to
+      # remember it:
+      self.axisLimit = None
+    elif math.isinf(axisLimit):
+      # It must be positive infinity, which is the same as no limit:
+      self.axisLimit = None
+    else:
+      # We still need to remember axisLimit to avoid rounding top to
+      # a value larger than axisLimit:
+      self.axisLimit = axisLimit
 
     if not (self.minValue < self.maxValue):
       self.reconcileLimits()

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1784,7 +1784,7 @@ def toSeconds(t):
 
 
 def safeArgs(args):
-  """Iterate over valid, finite values an in iterable.
+  """Iterate over valid, finite values in an iterable.
 
   Skip any items that are None, NaN, or infinite.
   """

--- a/webapp/tests/test_render_glyph.py
+++ b/webapp/tests/test_render_glyph.py
@@ -405,42 +405,69 @@ class LinearAxisTicsTest(TestCase):
 
     def test_LinearAxisTics_reconcileLimits_defaults(self):
       y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
-      self.assertEqual(y.reconcileLimits(), None)
+      y.applySettings()
+      self.assertAlmostEqual(y.minValue, 0.0, places=4)
+      self.assertAlmostEqual(y.maxValue, 100.0, places=4)
 
     def test_LinearAxisTics_reconcileLimits_ymin_and_ymax_assert(self):
       y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
       y.applySettings(axisMin=0, axisMax=10, axisLimit=100)
-      self.assertEqual(y.reconcileLimits(), None)
+      self.assertAlmostEqual(y.minValue, 0.0, places=4)
+      self.assertAlmostEqual(y.maxValue, 100.0, places=4)
 
     def test_LinearAxisTics_reconcileLimits_ymin_0(self):
       y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
       y.applySettings(axisMin=0, axisMax=None, axisLimit=100)
-      self.assertEqual(y.reconcileLimits(), None)
+      self.assertAlmostEqual(y.minValue, 0.0, places=4)
+      self.assertAlmostEqual(y.maxValue, 100.0, places=4)
 
     def test_LinearAxisTics_reconcileLimits_ymax_10(self):
       y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
       y.applySettings(axisMin=None, axisMax=10, axisLimit=100)
-      self.assertEqual(y.reconcileLimits(), None)
+      self.assertAlmostEqual(y.minValue, 0.0, places=4)
+      self.assertAlmostEqual(y.maxValue, 100.0, places=4)
 
     def test_LinearAxisTics_reconcileLimits_ymax_max(self):
       y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
       y.applySettings(axisMin=None, axisMax='max', axisLimit=100)
-      self.assertEqual(y.reconcileLimits(), None)
-
-    def test_LinearAxisTics_reconcileLimits_axisLimit_None(self):
-      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
-      y.applySettings(axisMin=None, axisMax=None, axisLimit=None)
-      self.assertEqual(y.reconcileLimits(), None)
+      self.assertAlmostEqual(y.minValue, 0.0, places=4)
+      self.assertAlmostEqual(y.maxValue, 100.0, places=4)
 
     def test_LinearAxisTics_reconcileLimits_axisLimit_below_max(self):
       y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
       y.applySettings(axisMin=None, axisMax=100, axisLimit=10)
-      self.assertEqual(y.reconcileLimits(), None)
+      self.assertAlmostEqual(y.minValue, 0.0, places=4)
+      self.assertAlmostEqual(y.maxValue, 10.0, places=4)
 
     def test_LinearAxisTics_reconcileLimits_axisLimit_above_max(self):
       y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
       y.applySettings(axisMin=None, axisMax=10, axisLimit=float('inf'))
-      self.assertEqual(y.reconcileLimits(), None)
+      self.assertAlmostEqual(y.minValue, 0.0, places=4)
+      self.assertAlmostEqual(y.maxValue, 10.0, places=4)
+
+    def test_LinearAxisTics_reconcileLimits_ymax_0(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMax=0)
+      self.assertAlmostEqual(y.minValue, -1.0, places=4)
+      self.assertAlmostEqual(y.maxValue, 0.0, places=4)
+
+    def test_LinearAxisTics_reconcileLimits_ymax_negative(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMax=-10)
+      self.assertAlmostEqual(y.minValue, -9.0, places=4)
+      self.assertAlmostEqual(y.maxValue, -10.0, places=4)
+
+    def test_LinearAxisTics_reconcileLimits_ymin_100(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=100)
+      self.assertAlmostEqual(y.minValue, 100.0, places=4)
+      self.assertAlmostEqual(y.maxValue, 110.0, places=4)
+
+    def test_LinearAxisTics_reconcileLimits_ymin_200(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=200)
+      self.assertAlmostEqual(y.minValue, 200.0, places=4)
+      self.assertAlmostEqual(y.maxValue, 220.0, places=4)
 
     #
     # Testing _LinearAxisTics.makeLabel()

--- a/webapp/tests/test_render_glyph.py
+++ b/webapp/tests/test_render_glyph.py
@@ -412,8 +412,7 @@ class LinearAxisTicsTest(TestCase):
     def test_LinearAxisTics_reconcileLimits_ymin_and_ymax_assert(self):
       y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
       y.applySettings(axisMin=0, axisMax=10, axisLimit=100)
-      with self.assertRaises(glyph.GraphError):
-          y.reconcileLimits()
+      self.assertEqual(y.reconcileLimits(), None)
 
     def test_LinearAxisTics_reconcileLimits_ymin_0(self):
       y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')

--- a/webapp/tests/test_render_glyph.py
+++ b/webapp/tests/test_render_glyph.py
@@ -578,41 +578,25 @@ class LinearAxisTicsTest(TestCase):
 
     def test_LinearAxisTics_generateSteps_1(self):
       y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
-      results = []
-      for i in y.generateSteps(1):
-        results.append(i)
-        if i > 10:
-          break
-      self.assertEqual(results, [1.0,2.0,5.0,10.0,20.0])
+      for (results, expected) in zip(y.generateSteps(1), [1.0, 2.0, 5.0, 10.0, 20.0]):
+        self.assertAlmostEqual(results, expected, places=4)
 
     def test_LinearAxisTics_generateSteps_binary_1(self):
       y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
       y.binary=True
-      results = []
-      for i in y.generateSteps(1):
-        results.append(i)
-        if i > 10:
-          break
-      self.assertEqual(results, [1.0, 2.0, 4.0, 8.0, 16.0])
+      for (results, expected) in zip(y.generateSteps(1), [1.0, 2.0, 4.0, 8.0, 16.0]):
+        self.assertAlmostEqual(results, expected, places=4)
 
     def test_LinearAxisTics_generateSteps_5(self):
       y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
-      results = []
-      for i in y.generateSteps(5):
-        results.append(i)
-        if i > 10:
-          break
-      self.assertEqual(results, [5.0, 10.0, 20.0])
+      for (results, expected) in zip(y.generateSteps(5), [5.0, 10.0, 20.0]):
+        self.assertAlmostEqual(results, expected, places=4)
 
     def test_LinearAxisTics_generateSteps_binary_5(self):
       y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
       y.binary=True
-      results = []
-      for i in y.generateSteps(5):
-        results.append(i)
-        if i > 10:
-          break
-      self.assertEqual(results, [8.0, 16.0])
+      for (results, expected) in zip(y.generateSteps(5), [8.0, 16.0]):
+        self.assertAlmostEqual(results, expected, places=4)
 
     def test_LinearAxisTics_generateSteps_0(self):
       y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')

--- a/webapp/tests/test_render_glyph.py
+++ b/webapp/tests/test_render_glyph.py
@@ -413,7 +413,7 @@ class LinearAxisTicsTest(TestCase):
       y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
       y.applySettings(axisMin=0, axisMax=10, axisLimit=100)
       self.assertAlmostEqual(y.minValue, 0.0, places=4)
-      self.assertAlmostEqual(y.maxValue, 100.0, places=4)
+      self.assertAlmostEqual(y.maxValue, 10.0, places=4)
 
     def test_LinearAxisTics_reconcileLimits_ymin_0(self):
       y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
@@ -425,7 +425,7 @@ class LinearAxisTicsTest(TestCase):
       y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
       y.applySettings(axisMin=None, axisMax=10, axisLimit=100)
       self.assertAlmostEqual(y.minValue, 0.0, places=4)
-      self.assertAlmostEqual(y.maxValue, 100.0, places=4)
+      self.assertAlmostEqual(y.maxValue, 10.0, places=4)
 
     def test_LinearAxisTics_reconcileLimits_ymax_max(self):
       y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
@@ -454,7 +454,7 @@ class LinearAxisTicsTest(TestCase):
     def test_LinearAxisTics_reconcileLimits_ymax_negative(self):
       y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
       y.applySettings(axisMax=-10)
-      self.assertAlmostEqual(y.minValue, -9.0, places=4)
+      self.assertAlmostEqual(y.minValue, -11.0, places=4)
       self.assertAlmostEqual(y.maxValue, -10.0, places=4)
 
     def test_LinearAxisTics_reconcileLimits_ymin_100(self):
@@ -758,12 +758,6 @@ class LogAxisTicsTest(TestCase):
     def test_LogAxisTics_reconcileLimits_defaults(self):
       y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
       self.assertEqual(y.reconcileLimits(), None)
-
-    def test_LogAxisTics_reconcileLimits_ymin_and_ymax_assert(self):
-      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
-      y.applySettings(axisMin=0, axisMax=10, axisLimit=100)
-      with self.assertRaises(glyph.GraphError):
-          y.reconcileLimits()
 
     def test_LogAxisTics_reconcileLimits_ymin_0(self):
       y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')

--- a/webapp/tests/test_render_glyph.py
+++ b/webapp/tests/test_render_glyph.py
@@ -349,6 +349,34 @@ class glyphStandaloneFunctionTest(TestCase):
           glyph.find_x_times(self.dt, glyph.SEC, 1.0)
 
 
+class AxisTicsTest(TestCase):
+
+    #
+    # Testing _AxisTics.checkFinite()
+    #
+
+    def test_AxisTics_checkFinite_nan(self):
+      with self.assertRaises(glyph.GraphError):
+          glyph._AxisTics.checkFinite(float('nan'))
+
+    def test_AxisTics_checkFinite_inf(self):
+      with self.assertRaises(glyph.GraphError):
+          glyph._AxisTics.checkFinite(float('inf'))
+
+    def test_AxisTics_checkFinite_100(self):
+      self.assertEqual(glyph._AxisTics.checkFinite(100), 100)
+
+    #
+    # Testing _AxisTics.chooseDelta()
+    #
+
+    def test_AxisTics_chooseDelta_0_1(self):
+      self.assertEqual(glyph._AxisTics.chooseDelta(1), 0.1)
+
+    def test_AxisTics_chooseDelta_very_small(self):
+      self.assertEqual(glyph._AxisTics.chooseDelta(1.0e-10), 1.0)
+
+
 class LinearAxisTicsTest(TestCase):
 
     def test_LinearAxisTics_valid_input(self):
@@ -361,36 +389,6 @@ class LinearAxisTicsTest(TestCase):
     def test_LinearAxisTics_invalid_max_value(self):
       with self.assertRaises(glyph.GraphError):
           glyph._LinearAxisTics(0.0, float('inf'), unitSystem='binary')
-
-    #
-    # Testing _LinearAxisTics.checkFinite()
-    #
-
-    def test_LinearAxisTics_checkFinite_nan(self):
-      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
-      with self.assertRaises(glyph.GraphError):
-          y.checkFinite(float('nan'))
-
-    def test_LinearAxisTics_checkFinite_inf(self):
-      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
-      with self.assertRaises(glyph.GraphError):
-          y.checkFinite(float('inf'))
-
-    def test_LinearAxisTics_checkFinite_100(self):
-      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
-      self.assertEqual(y.checkFinite(100), 100)
-
-    #
-    # Testing _LinearAxisTics.chooseDelta()
-    #
-
-    def test_LinearAxisTics_chooseDelta_0_1(self):
-      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
-      self.assertEqual(y.chooseDelta(1), 0.1)
-
-    def test_LinearAxisTics_chooseDelta_very_small(self):
-      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
-      self.assertEqual(y.chooseDelta(1.0e-10), 1.0)
 
     #
     # Testing _LinearAxisTics.applySettings()
@@ -732,36 +730,6 @@ class LogAxisTicsTest(TestCase):
     def test_LogAxisTics_invalid_max_value(self):
       with self.assertRaises(glyph.GraphError):
           glyph._LogAxisTics(0.0, float('inf'), unitSystem='binary')
-
-    #
-    # Testing _LogAxisTics.checkFinite()
-    #
-
-    def test_LogAxisTics_checkFinite_nan(self):
-      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
-      with self.assertRaises(glyph.GraphError):
-          y.checkFinite(float('nan'))
-
-    def test_LogAxisTics_checkFinite_inf(self):
-      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
-      with self.assertRaises(glyph.GraphError):
-          y.checkFinite(float('inf'))
-
-    def test_LogAxisTics_checkFinite_100(self):
-      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
-      self.assertEqual(y.checkFinite(100), 100)
-
-    #
-    # Testing _LogAxisTics.chooseDelta()
-    #
-
-    def test_LogAxisTics_chooseDelta_0_1(self):
-      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
-      self.assertEqual(y.chooseDelta(1), 0.1)
-
-    def test_LogAxisTics_chooseDelta_very_small(self):
-      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
-      self.assertEqual(y.chooseDelta(1.0e-10), 1.0)
 
     #
     # Testing _LogAxisTics.applySettings()

--- a/webapp/tests/test_render_glyph.py
+++ b/webapp/tests/test_render_glyph.py
@@ -1,0 +1,1002 @@
+import copy
+
+#from django.conf import settings
+from django.test import TestCase
+
+from graphite.render import glyph
+from graphite.render.datalib import TimeSeries
+
+class glyphStandaloneFunctionTest(TestCase):
+    from datetime import datetime, timedelta
+    dt = datetime(2016, 6, 16, 15, 55, 38)
+    dt2 = datetime(2016, 6, 17, 15, 55, 38)
+
+    # Convenience function
+    def _generate_series_list(self, config=None):
+        seriesList = []
+        if not config:
+            config = [range(101), range(101), [1, None, None, None, None]]
+
+        for i, c in enumerate(config):
+            name = "collectd.test-db{0}.load.value".format(i + 1)
+            seriesList.append(TimeSeries(name, 0, 1, 1, c))
+        return seriesList
+
+    #
+    # Testing toSeconds
+    #
+    def test_toSeconds_invalid_inputs(self):
+      with self.assertRaises(AttributeError):
+        glyph.toSeconds(None)
+      with self.assertRaises(AttributeError):
+        glyph.toSeconds('')
+      with self.assertRaises(AttributeError):
+        glyph.toSeconds(1)
+
+    def test_toSeconds(self):
+      self.assertEqual(glyph.toSeconds(self.dt2 - self.dt), 86400)
+
+    #
+    # Testing safeArgs()
+    #
+    def test_safeArgs_None(self):
+      with self.assertRaises(TypeError):
+        glyph.safeArgs(None)
+
+    def test_safeArgs_number_not_list(self):
+      with self.assertRaises(TypeError):
+        glyph.safeArgs(1)
+
+    def test_safeArgs_all_strings(self):
+      with self.assertRaises(TypeError):
+        list(glyph.safeArgs(['a','b','c']))
+
+    def test_safeArgs_list_with_string(self):
+      with self.assertRaises(TypeError):
+        self.assertEqual(list(glyph.safeArgs(['a',5.1,6])), ['a',5.1,6])
+
+    def test_safeArgs_empty_string(self):
+      self.assertEqual(list(glyph.safeArgs('')), [])
+
+    def test_safeArgs_list_all_numbers(self):
+      self.assertEqual(list(glyph.safeArgs([1,5.1,6,])), [1,5.1,6])
+
+    def test_safeArgs_list_with_nan(self):
+      self.assertEqual(list(glyph.safeArgs([1,5.1,6,float('Nan')])), [1,5.1,6])
+
+    def test_safeArgs_list_with_inf(self):
+      self.assertEqual(list(glyph.safeArgs([1,5.1,6,float('inf')])), [1,5.1,6])
+
+    def test_safeArgs_list_with_None(self):
+      self.assertEqual(list(glyph.safeArgs([1,5.1,6,None])), [1,5.1,6])
+
+    #
+    # Testing safeMin()
+    #
+    def test_safeMin_None(self):
+      with self.assertRaises(TypeError):
+        glyph.safeMin(None)
+
+    def test_safeMin_number_not_list(self):
+      with self.assertRaises(TypeError):
+        glyph.safeMin(1)
+
+    def test_safeMin_empty_string(self):
+      self.assertEqual(glyph.safeMin(''), None)
+
+    def test_safeMin_list_with_string(self):
+      with self.assertRaises(TypeError):
+        glyph.safeMin(['a',10,30])
+
+    def test_safeMin_list_all_numbers(self):
+      self.assertEqual(glyph.safeMin([1,5.1,6,]), 1)
+
+    def test_safeMin_list_with_nan(self):
+      self.assertEqual(glyph.safeMin([1,5.1,6,float('Nan')]), 1)
+
+    #
+    # Testing safeMax()
+    #
+    def test_safeMax_None(self):
+      with self.assertRaises(TypeError):
+        glyph.safeMax(None)
+
+    def test_safeMax_number_not_list(self):
+      with self.assertRaises(TypeError):
+        glyph.safeMax(1)
+
+    def test_safeMax_empty_string(self):
+      self.assertEqual(glyph.safeMax(''), None)
+
+    def test_safeMax_list_with_string(self):
+      with self.assertRaises(TypeError):
+        glyph.safeMax(['a',10,30])
+
+    def test_safeMax_list_all_numbers(self):
+      self.assertEqual(glyph.safeMax([1,5.1,6,]), 6)
+
+    def test_safeMax_list_with_nan(self):
+      self.assertEqual(glyph.safeMax([1,5.1,6,float('Nan')]), 6)
+
+    #
+    # Testing safeSum()
+    #
+    def test_safeSum_None(self):
+      with self.assertRaises(TypeError):
+        glyph.safeSum(None)
+
+    def test_safeSum_number_not_list(self):
+      with self.assertRaises(TypeError):
+        glyph.safeSum(1)
+
+    def test_safeSum_empty_string(self):
+      self.assertEqual(glyph.safeSum(''), 0)
+
+    def test_safeSum_list_with_string(self):
+      with self.assertRaises(TypeError):
+        glyph.safeSum(['a',10,30])
+
+    def test_safeSum_list_all_numbers(self):
+      self.assertEqual(glyph.safeSum([1,5.1,6,]), 12.1)
+
+    def test_safeSum_list_with_nan(self):
+      self.assertEqual(glyph.safeSum([1,5.1,6,float('Nan')]), 12.1)
+
+    #
+    # Testing any()
+    #
+    def test_any_None(self):
+      with self.assertRaises(TypeError):
+        glyph.any(None)
+
+    def test_any_number_not_list(self):
+      with self.assertRaises(TypeError):
+        glyph.any(1)
+
+    def test_any_empty_string(self):
+      self.assertFalse(glyph.any(''))
+
+    def test_any_list_with_false(self):
+      self.assertFalse(glyph.any([False]))
+
+    def test_any_list_with_0(self):
+      self.assertFalse(glyph.any([0]))
+
+    def test_any_list_with_string(self):
+      self.assertTrue(glyph.any(['a',10,30]))
+
+    def test_any_list_all_numbers(self):
+      self.assertTrue(glyph.any([1,5.1,6,]))
+
+    def test_any_list_with_nan(self):
+      self.assertTrue(glyph.any([1,5.1,6,float('Nan')]), 12.1)
+
+    #
+    # Testing dataLimits
+    #
+    def test_dataLimits_defaults(self):
+        seriesList = self._generate_series_list()
+        self.assertEqual(glyph.dataLimits(seriesList), (0,100))
+
+    def test_dataLimits_defaults_ymin_positive(self):
+        config = [range(10, 101), range(10, 101), [1, None, None, None, None]]
+        seriesList = self._generate_series_list(config)
+        self.assertEqual(glyph.dataLimits(seriesList), (1,100))
+
+    def test_dataLimits_empty_list(self):
+        self.assertEqual(glyph.dataLimits([]), (0.0, 1.0))
+
+    def test_dataLimits_drawNull(self):
+        seriesList = self._generate_series_list()
+        self.assertEqual(glyph.dataLimits(seriesList, True, False), (0,100))
+
+    def test_dataLimits_stacked(self):
+        seriesList = self._generate_series_list()
+        self.assertEqual(glyph.dataLimits(seriesList, False, True), (0, 8))
+
+    def test_dataLimits_drawNull_stacked(self):
+        seriesList = self._generate_series_list()
+        self.assertEqual(glyph.dataLimits(seriesList, True, True), (0, 8))
+
+    def test_dataLimits_drawNull_stacked_no_missing(self):
+        config = [range(10, 101), range(10, 101), range(100,300)]
+        seriesList = self._generate_series_list(config)
+        self.assertEqual(glyph.dataLimits(seriesList, True, True), (10, 390))
+
+    def test_dataLimits_drawNull_ymin_positive_missing_data(self):
+        config = [range(10, 101), range(10, 101), [1, None, None, None, None]]
+        seriesList = self._generate_series_list(config)
+        self.assertEqual(glyph.dataLimits(seriesList, True, False), (0.0, 100))
+
+    def test_dataLimits_drawNull_ymax_negative_missing_data(self):
+        config = [range(-10, -101), range(-10, -101), [-50, None, None, None, None]]
+        seriesList = self._generate_series_list(config)
+        self.assertEqual(glyph.dataLimits(seriesList, True, False), (-50, 0.0))
+
+    #
+    # Testing sort_stacked
+    #
+    def test_sort_stacked_invalid_inputs(self):
+      with self.assertRaises(TypeError):
+        glyph.sort_stacked(None)
+
+      with self.assertRaises(TypeError):
+        glyph.sort_stacked(1)
+
+      with self.assertRaises(AttributeError):
+        glyph.sort_stacked('string')
+
+    def test_sort_stacked_empty_input(self):
+        self.assertEqual(glyph.sort_stacked(''), [])
+
+    def test_sort_stacked_no_stack(self):
+        seriesList = self._generate_series_list()
+        self.assertEqual(glyph.sort_stacked(seriesList), seriesList)
+
+    def test_sort_stacked_only_stack(self):
+        seriesList = self._generate_series_list()
+        seriesList[0].options='stacked'
+        seriesList[1].options='stacked'
+        seriesList[2].options='stacked'
+        self.assertEqual(glyph.sort_stacked(copy.deepcopy(seriesList)), seriesList)
+
+    def test_sort_stacked_stack_and_no_stack(self):
+        seriesList = self._generate_series_list()
+        seriesList[0].options='stacked'
+        seriesList[2].options='stacked'
+        self.assertEqual(glyph.sort_stacked(copy.deepcopy(seriesList)), [seriesList[0],seriesList[2],seriesList[1]])
+
+    #
+    # Testing of format_units
+    #
+    def test_format_units_defaults(self):
+      # Tests (input, result, 'Error String')
+      tests = [
+               (1, 1, 'format_units(1) != 1'),
+               (1.0, 1.0, 'format_units(1.0) != 1.0'),
+               (0.001, 0.001, 'format_units(0.001) != 0.001')
+              ]
+      for (t,r,e) in tests:
+          self.assertEqual(glyph.format_units(t), (r, ''), e)
+
+    def test_format_units_val_None_defaults(self):
+      # Tests (input, result, 'Error String')
+      tests = [
+               (1, 1, 'format_units(1, None) != 1'),
+               (1.0, 1.0, 'format_units(1.0, None) != 1.0'),
+               (0.001, 0.001, 'format_units(0.001, None) != 0.001')
+              ]
+      for (t,r,e) in tests:
+          self.assertEqual(glyph.format_units(t, None), (r, ''), e)
+
+    def test_format_units_v_None_si(self):
+      # Tests (input, result, 'Error String')
+      tests = [
+               (1, 1, 'format_units(1, None, \'si\') != 1'),
+               (1.0, 1.0, 'format_units(1.0, None, \'si\') != 1.0'),
+               (0.001, 0.001, 'format_units(0.001, None, \'si\') != 0.001')
+              ]
+      for (t,r,e) in tests:
+          self.assertEqual(glyph.format_units(t, None, 'si'), (r, ''), e)
+
+    def test_format_units_v_step_si(self):
+      # Tests (input, step, result, 'Error String')
+      tests = [
+               (1, 100, 1, 'format_units(1, 100, \'si\') != 1'),
+               (1.0, 100, 1.0, 'format_units(1.0, 100, \'si\') != 1.0'),
+               (0.001, 100, 0.001, 'format_units(0.001, 100, \'si\') != 0.001')
+              ]
+      for (t,s,r,e) in tests:
+          self.assertEqual(glyph.format_units(t, s, 'si'), (r, ''), e)
+
+    #
+    # Testing of find_x_times()
+    #
+    def test_find_x_times_SEC(self):
+      (dt_out, delta_out) = glyph.find_x_times(self.dt, glyph.SEC, 1)
+      expected_dt = self.datetime(self.dt.year, self.dt.month, self.dt.day, self.dt.hour, self.dt.minute, self.dt.second)
+      expected_delta = self.timedelta(0, 1)
+      self.assertEquals(dt_out, expected_dt)
+      self.assertEquals(delta_out, expected_delta)
+
+    def test_find_x_times_MIN(self):
+      (dt_out, delta_out) = glyph.find_x_times(self.dt, glyph.MIN, 1)
+      expected_dt = self.datetime(self.dt.year, self.dt.month, self.dt.day, self.dt.hour, self.dt.minute+1)
+      expected_delta = self.timedelta(0, 60)
+      self.assertEquals(dt_out, expected_dt)
+      self.assertEquals(delta_out, expected_delta)
+
+    def test_find_x_times_HOUR(self):
+      (dt_out, delta_out) = glyph.find_x_times(self.dt, glyph.HOUR, 1)
+      expected_dt = self.datetime(self.dt.year, self.dt.month, self.dt.day, self.dt.hour+1, 0)
+      expected_delta = self.timedelta(0, 3600)
+      self.assertEquals(dt_out, expected_dt)
+      self.assertEquals(delta_out, expected_delta)
+
+    def test_find_x_times_DAY(self):
+      (dt_out, delta_out) =  glyph.find_x_times(self.dt, glyph.DAY, 1)
+      expected_dt = self.datetime(self.dt.year, self.dt.month, self.dt.day+1, 0, 0)
+      expected_delta = self.timedelta(1)
+      self.assertEquals(dt_out, expected_dt)
+      self.assertEquals(delta_out, expected_delta)
+
+    def test_find_x_times_invalid_input(self):
+      with self.assertRaises(ValueError):
+          glyph.find_x_times(None, glyph.SEC, 1.0)
+
+      with self.assertRaises(ValueError):
+          glyph.find_x_times(self.dt, None, 1.0)
+
+      with self.assertRaises(ValueError):
+          glyph.find_x_times(self.dt, glyph.SEC, None)
+
+      with self.assertRaises(ValueError):
+          glyph.find_x_times('', glyph.SEC, 1.0)
+
+      with self.assertRaises(ValueError):
+          glyph.find_x_times(self.dt, '', 1.0)
+
+      with self.assertRaises(ValueError):
+          glyph.find_x_times(self.dt, glyph.SEC, '')
+
+      with self.assertRaises(ValueError):
+          glyph.find_x_times(self.dt, glyph.YEAR, 1)
+
+      with self.assertRaises(ValueError):
+          glyph.find_x_times(self.dt, glyph.SEC, 0)
+
+      with self.assertRaises(ValueError):
+          glyph.find_x_times(self.dt, glyph.SEC, 1.0)
+
+
+class LinearAxisTicsTest(TestCase):
+
+    def test_LinearAxisTics_valid_input(self):
+      self.assertTrue(glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary'))
+
+    def test_LinearAxisTics_invalid_min_value(self):
+      with self.assertRaises(glyph.GraphError):
+          glyph._LinearAxisTics(float('NaN'), 100.0, unitSystem='binary')
+
+    def test_LinearAxisTics_invalid_max_value(self):
+      with self.assertRaises(glyph.GraphError):
+          glyph._LinearAxisTics(0.0, float('inf'), unitSystem='binary')
+
+    #
+    # Testing _LinearAxisTics.checkFinite()
+    #
+
+    def test_LinearAxisTics_checkFinite_nan(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      with self.assertRaises(glyph.GraphError):
+          y.checkFinite(float('nan'))
+
+    def test_LinearAxisTics_checkFinite_inf(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      with self.assertRaises(glyph.GraphError):
+          y.checkFinite(float('inf'))
+
+    def test_LinearAxisTics_checkFinite_100(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      self.assertEqual(y.checkFinite(100), 100)
+
+    #
+    # Testing _LinearAxisTics.chooseDelta()
+    #
+
+    def test_LinearAxisTics_chooseDelta_0_1(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      self.assertEqual(y.chooseDelta(1), 0.1)
+
+    def test_LinearAxisTics_chooseDelta_very_small(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      self.assertEqual(y.chooseDelta(1.0e-10), 1.0)
+
+    #
+    # Testing _LinearAxisTics.applySettings()
+    #
+
+    def test_LinearAxisTics_applySettings_axisLimit_min_greater_max(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      with self.assertRaises(glyph.GraphError):
+          y.applySettings(axisMin=1000, axisMax=10, axisLimit=None)
+
+    #
+    # Testing _LinearAxisTics.reconcileLimits()
+    #
+
+    def test_LinearAxisTics_reconcileLimits_defaults(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      self.assertEqual(y.reconcileLimits(), None)
+
+    def test_LinearAxisTics_reconcileLimits_ymin_and_ymax_assert(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=0, axisMax=10, axisLimit=100)
+      with self.assertRaises(glyph.GraphError):
+          y.reconcileLimits()
+
+    def test_LinearAxisTics_reconcileLimits_ymin_0(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=0, axisMax=None, axisLimit=100)
+      self.assertEqual(y.reconcileLimits(), None)
+
+    def test_LinearAxisTics_reconcileLimits_ymax_10(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=None, axisMax=10, axisLimit=100)
+      self.assertEqual(y.reconcileLimits(), None)
+
+    def test_LinearAxisTics_reconcileLimits_ymax_max(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=None, axisMax='max', axisLimit=100)
+      self.assertEqual(y.reconcileLimits(), None)
+
+    def test_LinearAxisTics_reconcileLimits_axisLimit_None(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=None, axisMax=None, axisLimit=None)
+      self.assertEqual(y.reconcileLimits(), None)
+
+    def test_LinearAxisTics_reconcileLimits_axisLimit_below_max(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=None, axisMax=100, axisLimit=10)
+      self.assertEqual(y.reconcileLimits(), None)
+
+    def test_LinearAxisTics_reconcileLimits_axisLimit_above_max(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=None, axisMax=10, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+
+    #
+    # Testing _LinearAxisTics.makeLabel()
+    #
+
+    def test_LinearAxisTics_makeLabel(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=None, axisMax=10, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+      self.assertEqual(y.makeLabel(2), '2 ')
+
+    def test_LinearAxisTics_makeLabel_2k(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=None, axisMax=10, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+      self.assertEqual(y.makeLabel(2000), '2.0 Ki ')
+
+    def test_LinearAxisTics_makeLabel_decimal(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=None, axisMax=None, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+      self.assertEqual(y.makeLabel(0.1), '0.10 ')
+
+    def test_LinearAxisTics_makeLabel_small_decimal(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=None, axisMax=None, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+      self.assertEqual(y.makeLabel(0.01), '0.01 ')
+
+    def test_LinearAxisTics_makeLabel_large_span_float(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      y.applySettings(axisMin=None, axisMax=None, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+      y.span=100
+      self.assertEqual(y.makeLabel(51234.1234), '51.2 k ')
+
+    def test_LinearAxisTics_makeLabel_large_span_int(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      y.applySettings(axisMin=None, axisMax=None, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+      y.span=100
+      self.assertEqual(y.makeLabel(int(100000)), '100.0 k ')
+
+    def test_LinearAxisTics_makeLabel_med_span_float(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      y.applySettings(axisMin=None, axisMax=None, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+      y.span=5
+      self.assertEqual(y.makeLabel(50.1234), '50.1 ')
+
+    def test_LinearAxisTics_makeLabel_med_span_int(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      y.applySettings(axisMin=None, axisMax=None, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+      y.span=5
+      self.assertEqual(y.makeLabel(int(10)), '10.0 ')
+
+    def test_LinearAxisTics_makeLabel_small_span_float(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      y.applySettings(axisMin=None, axisMax=None, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+      y.span=1
+      self.assertEqual(y.makeLabel(5.1234), '5.12 ')
+
+    def test_LinearAxisTics_makeLabel_small_span_int(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      y.applySettings(axisMin=None, axisMax=None, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+      y.span=1
+      self.assertEqual(y.makeLabel(int(5)), '5.00 ')
+
+    #
+    # Testing _LinearAxisTics.setStep()
+    #
+
+    def test_LinearAxisTics_setStep_unset(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      self.assertEqual(y.step, None)
+
+    def test_LinearAxisTics_setStep_5(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      y.setStep(5)
+      self.assertEqual(y.step, 5)
+
+    def test_LinearAxisTics_setStep_5_0(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      y.setStep(5.0)
+      self.assertEqual(y.step, 5.0)
+
+    def test_LinearAxisTics_setStep_nan(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      with self.assertRaises(glyph.GraphError):
+          y.setStep(float('nan'))
+
+    def test_LinearAxisTics_setStep_inf(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      with self.assertRaises(glyph.GraphError):
+          y.setStep(float('inf'))
+
+    def test_LinearAxisTics_setStep_None(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      with self.assertRaises(TypeError):
+          y.setStep(None)
+
+    #
+    # Testing _LinearAxisTics.generateSteps()
+    #
+
+    def test_LinearAxisTics_generateSteps_1(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      results = []
+      for i in y.generateSteps(1):
+        results.append(i)
+        if i > 10:
+          break
+      self.assertEqual(results, [1.0,2.0,5.0,10.0,20.0])
+
+    def test_LinearAxisTics_generateSteps_binary_1(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      y.binary=True
+      results = []
+      for i in y.generateSteps(1):
+        results.append(i)
+        if i > 10:
+          break
+      self.assertEqual(results, [1.0, 2.0, 4.0, 8.0, 16.0])
+
+    def test_LinearAxisTics_generateSteps_5(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      results = []
+      for i in y.generateSteps(5):
+        results.append(i)
+        if i > 10:
+          break
+      self.assertEqual(results, [5.0, 10.0, 20.0])
+
+    def test_LinearAxisTics_generateSteps_binary_5(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      y.binary=True
+      results = []
+      for i in y.generateSteps(5):
+        results.append(i)
+        if i > 10:
+          break
+      self.assertEqual(results, [8.0, 16.0])
+
+    def test_LinearAxisTics_generateSteps_0(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      #ValueError: math domain error
+      with self.assertRaises(ValueError):
+        list(y.generateSteps(0))
+
+    #
+    # Testing _LinearAxisTics.computeSlop()
+    #
+
+    def test_LinearAxisTics_computeSlop_10_5(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      self.assertEqual(y.computeSlop(10, 5), None)
+
+    def test_LinearAxisTics_computeSlop_10_3(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      self.assertEqual(y.computeSlop(10, 3), None)
+
+    def test_LinearAxisTics_computeSlop_med_maxValue_50_10(self):
+      y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='si')
+      self.assertEqual(y.computeSlop(50, 10), 400.0)
+
+    def test_LinearAxisTics_computeSlop_low_maxValue_10_3(self):
+      y = glyph._LinearAxisTics(0, 1, unitSystem='si')
+      self.assertEqual(y.computeSlop(10, 3), 29.0)
+
+    #
+    # Testing _LinearAxisTics.chooseStep()
+    #
+
+    def test_LinearAxisTics_chooseStep_default(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      self.assertEqual(y.chooseStep(), None)
+      self.assertEqual(y.step, 200)
+
+    def test_LinearAxisTics_chooseStep_default_divisors(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      self.assertEqual(y.chooseStep([4,5,6]), None)
+      self.assertEqual(y.step, 200)
+
+    def test_LinearAxisTics_chooseStep_bad_divisors(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      with self.assertRaises(glyph.GraphError):
+        y.chooseStep([0,1,2])
+
+    def test_LinearAxisTics_chooseStep_min_max_0_0(self):
+      y = glyph._LinearAxisTics(0.0, 0.0, unitSystem='si')
+      self.assertEqual(y.chooseStep([4,5,6]), None)
+      self.assertEqual(y.step, 0.2)
+
+    def test_LinearAxisTics_chooseStep_min_max_1_0(self):
+      y = glyph._LinearAxisTics(1.0, 1.0, unitSystem='si')
+      self.assertEqual(y.chooseStep([4,5,6]), None)
+      self.assertEqual(y.step, 0.05)
+
+    def test_LinearAxisTics_chooseStep_min_max_neg_1_0(self):
+      y = glyph._LinearAxisTics(-1.0, -1.0, unitSystem='si')
+      self.assertEqual(y.chooseStep([4,5,6]), None)
+      self.assertEqual(y.step, 0.05)
+
+    #
+    # Testing _LinearAxisTics.chooseLimits()
+    # side effects are settings of
+    # self.bottom
+    # self.top
+    # self.span
+
+    def test_LinearAxisTics_chooseLimits_defaults(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      y.applySettings()
+      y.chooseStep()
+      y.chooseLimits()
+      self.assertEqual((y.bottom, y.top, y.span), (0.0, 1000.0, 1000.0))
+
+    def test_LinearAxisTics_chooseLimits_axisMin_0(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      y.applySettings(axisMin=0.0)
+      y.chooseStep()
+      y.chooseLimits()
+      self.assertEqual((y.bottom, y.top, y.span), (0.0, 1000.0, 1000.0))
+
+    def test_LinearAxisTics_chooseLimits_axisMax_0(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      y.applySettings(axisMax=0.0)
+      y.chooseStep()
+      y.chooseLimits()
+      self.assertEqual((y.bottom, y.top, y.span), (-1.0, 0.0, 1.0))
+
+    def test_LinearAxisTics_chooseLimits_yMax_0_axisMax_0_1(self):
+      y = glyph._LinearAxisTics(0.0, 0.0, unitSystem='si')
+      y.applySettings(axisMax=0.1)
+      y.chooseStep()
+      y.chooseLimits()
+      self.assertEqual((y.bottom, y.top, y.span), (0.0, 0.1, 0.1))
+
+    #
+    # Testing _LinearAxisTics.getLabelValues()
+    #
+
+    def test_LinearAxisTics_getLabelValues_defaults(self):
+      y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
+      y.applySettings()
+      y.chooseStep()
+      y.chooseLimits()
+      self.assertEqual(y.getLabelValues(), [0.0, 200.0, 400.0, 600.0, 800.0, 1000.0])
+
+    def test_LinearAxisTics_getLabelValues_neg(self):
+      y = glyph._LinearAxisTics(-1000.0, -1.0, unitSystem='si')
+      y.applySettings()
+      y.chooseStep()
+      y.chooseLimits()
+      self.assertEqual(y.getLabelValues(), [-1000.0, -800.0, -600.0, -400.0, -200.0, 0.0])
+
+    def test_LinearAxisTics_getLabelValues_neg_step(self):
+      y = glyph._LinearAxisTics(-1000.0, -1.0, unitSystem='si')
+      y.applySettings()
+      y.chooseStep()
+      y.step=-1
+      y.chooseLimits()
+      with self.assertRaises(glyph.GraphError):
+        y.getLabelValues()
+
+    def test_LinearAxisTics_getLabelValues_small_step(self):
+      y = glyph._LinearAxisTics(-1000.0, -1.0, unitSystem='si')
+      y.applySettings()
+      y.chooseStep()
+      y.chooseLimits()
+      y.step=0.001
+      self.assertEqual(y.getLabelValues(), [-1000.0, -800.0, -600.0, -400.0, -200.0, 0.0])
+
+
+class LogAxisTicsTest(TestCase):
+
+    def test_LogAxisTics_valid_input(self):
+      self.assertTrue(glyph._LogAxisTics(0.0, 100.0, unitSystem='binary'))
+
+    def test_LogAxisTics_invalid_min_value(self):
+      with self.assertRaises(glyph.GraphError):
+          glyph._LogAxisTics(float('NaN'), 100.0, unitSystem='binary')
+
+    def test_LogAxisTics_invalid_max_value(self):
+      with self.assertRaises(glyph.GraphError):
+          glyph._LogAxisTics(0.0, float('inf'), unitSystem='binary')
+
+    #
+    # Testing _LogAxisTics.checkFinite()
+    #
+
+    def test_LogAxisTics_checkFinite_nan(self):
+      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
+      with self.assertRaises(glyph.GraphError):
+          y.checkFinite(float('nan'))
+
+    def test_LogAxisTics_checkFinite_inf(self):
+      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
+      with self.assertRaises(glyph.GraphError):
+          y.checkFinite(float('inf'))
+
+    def test_LogAxisTics_checkFinite_100(self):
+      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
+      self.assertEqual(y.checkFinite(100), 100)
+
+    #
+    # Testing _LogAxisTics.chooseDelta()
+    #
+
+    def test_LogAxisTics_chooseDelta_0_1(self):
+      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
+      self.assertEqual(y.chooseDelta(1), 0.1)
+
+    def test_LogAxisTics_chooseDelta_very_small(self):
+      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
+      self.assertEqual(y.chooseDelta(1.0e-10), 1.0)
+
+    #
+    # Testing _LogAxisTics.applySettings()
+    #
+
+    def test_LogAxisTics_applySettings_axisLimit_min_greater_max(self):
+      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
+      with self.assertRaises(glyph.GraphError):
+          y.applySettings(axisMin=1000, axisMax=10, axisLimit=None)
+
+    #
+    # Testing _LogAxisTics.reconcileLimits()
+    #
+
+    def test_LogAxisTics_reconcileLimits_defaults(self):
+      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
+      self.assertEqual(y.reconcileLimits(), None)
+
+    def test_LogAxisTics_reconcileLimits_ymin_and_ymax_assert(self):
+      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=0, axisMax=10, axisLimit=100)
+      with self.assertRaises(glyph.GraphError):
+          y.reconcileLimits()
+
+    def test_LogAxisTics_reconcileLimits_ymin_0(self):
+      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=0, axisMax=None, axisLimit=100)
+      self.assertEqual(y.reconcileLimits(), None)
+
+    def test_LogAxisTics_reconcileLimits_ymax_10(self):
+      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=None, axisMax=10, axisLimit=100)
+      self.assertEqual(y.reconcileLimits(), None)
+
+    def test_LogAxisTics_reconcileLimits_ymax_max(self):
+      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=None, axisMax='max', axisLimit=100)
+      self.assertEqual(y.reconcileLimits(), None)
+
+    def test_LogAxisTics_reconcileLimits_axisLimit_None(self):
+      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=None, axisMax=None, axisLimit=None)
+      self.assertEqual(y.reconcileLimits(), None)
+
+    def test_LogAxisTics_reconcileLimits_axisLimit_below_max(self):
+      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=None, axisMax=100, axisLimit=10)
+      self.assertEqual(y.reconcileLimits(), None)
+
+    def test_LogAxisTics_reconcileLimits_axisLimit_above_max(self):
+      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=None, axisMax=10, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+
+    #
+    # Testing _LogAxisTics.makeLabel()
+    #
+
+    def test_LogAxisTics_makeLabel(self):
+      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=None, axisMax=10, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+      self.assertEqual(y.makeLabel(2), '2 ')
+
+    def test_LogAxisTics_makeLabel_2k(self):
+      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=None, axisMax=10, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+      self.assertEqual(y.makeLabel(2000), '2.0 Ki ')
+
+    def test_LogAxisTics_makeLabel_decimal(self):
+      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=None, axisMax=None, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+      self.assertEqual(y.makeLabel(0.1), '0.10 ')
+
+    def test_LogAxisTics_makeLabel_small_decimal(self):
+      y = glyph._LogAxisTics(0.0, 100.0, unitSystem='binary')
+      y.applySettings(axisMin=None, axisMax=None, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+      self.assertEqual(y.makeLabel(0.01), '0.01 ')
+
+    def test_LogAxisTics_makeLabel_large_span_float(self):
+      y = glyph._LogAxisTics(0.0, 1000.0, unitSystem='si')
+      y.applySettings(axisMin=None, axisMax=None, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+      y.span=100
+      self.assertEqual(y.makeLabel(51234.1234), '51.2 k ')
+
+    def test_LogAxisTics_makeLabel_large_span_int(self):
+      y = glyph._LogAxisTics(0.0, 1000.0, unitSystem='si')
+      y.applySettings(axisMin=None, axisMax=None, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+      y.span=100
+      self.assertEqual(y.makeLabel(int(100000)), '100.0 k ')
+
+    def test_LogAxisTics_makeLabel_med_span_float(self):
+      y = glyph._LogAxisTics(0.0, 1000.0, unitSystem='si')
+      y.applySettings(axisMin=None, axisMax=None, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+      y.span=5
+      self.assertEqual(y.makeLabel(50.1234), '50.1 ')
+
+    def test_LogAxisTics_makeLabel_med_span_int(self):
+      y = glyph._LogAxisTics(0.0, 1000.0, unitSystem='si')
+      y.applySettings(axisMin=None, axisMax=None, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+      y.span=5
+      self.assertEqual(y.makeLabel(int(10)), '10.0 ')
+
+    def test_LogAxisTics_makeLabel_small_span_float(self):
+      y = glyph._LogAxisTics(0.0, 1000.0, unitSystem='si')
+      y.applySettings(axisMin=None, axisMax=None, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+      y.span=1
+      self.assertEqual(y.makeLabel(5.1234), '5.12 ')
+
+    def test_LogAxisTics_makeLabel_small_span_int(self):
+      y = glyph._LogAxisTics(0.0, 1000.0, unitSystem='si')
+      y.applySettings(axisMin=None, axisMax=None, axisLimit=float('inf'))
+      self.assertEqual(y.reconcileLimits(), None)
+      y.span=1
+      self.assertEqual(y.makeLabel(int(5)), '5.00 ')
+
+    #
+    # Testing _LogAxisTics.setStep()
+    #
+
+    def test_LogAxisTics_setStep_unset(self):
+      y = glyph._LogAxisTics(0.0, 1000.0, unitSystem='si')
+      self.assertEqual(y.step, None)
+
+    def test_LogAxisTics_setStep_5(self):
+      y = glyph._LogAxisTics(0.0, 1000.0, unitSystem='si')
+      y.setStep(5)
+      self.assertEqual(y.step, None)
+
+    def test_LogAxisTics_setStep_5_0(self):
+      y = glyph._LogAxisTics(0.0, 1000.0, unitSystem='si')
+      y.setStep(5.0)
+      self.assertEqual(y.step, None)
+
+    def test_LogAxisTics_setStep_nan(self):
+      y = glyph._LogAxisTics(0.0, 1000.0, unitSystem='si')
+      y.setStep(float('nan'))
+      self.assertEqual(y.step, None)
+
+    def test_LogAxisTics_setStep_inf(self):
+      y = glyph._LogAxisTics(0.0, 1000.0, unitSystem='si')
+      y.setStep(float('inf'))
+      self.assertEqual(y.step, None)
+
+    def test_LogAxisTics_setStep_None(self):
+      y = glyph._LogAxisTics(0.0, 1000.0, unitSystem='si')
+      y.setStep(None)
+      self.assertEqual(y.step, None)
+
+    #
+    # Testing _LogAxisTics.chooseStep()
+    #
+
+    def test_LogAxisTics_chooseStep_default(self):
+      y = glyph._LogAxisTics(0.0, 1000.0, unitSystem='si')
+      self.assertEqual(y.chooseStep(), None)
+      self.assertEqual(y.step, None)
+
+    def test_LogAxisTics_chooseStep_default_divisors(self):
+      y = glyph._LogAxisTics(0.0, 1000.0, unitSystem='si')
+      self.assertEqual(y.chooseStep([4,5,6]), None)
+      self.assertEqual(y.step, None)
+
+    def test_LogAxisTics_chooseStep_bad_divisors(self):
+      y = glyph._LogAxisTics(0.0, 1000.0, unitSystem='si')
+      self.assertEqual(y.chooseStep([0,1,2]), None)
+      self.assertEqual(y.step, None)
+
+    def test_LogAxisTics_chooseStep_min_max_0_0(self):
+      y = glyph._LogAxisTics(0.0, 0.0, unitSystem='si')
+      self.assertEqual(y.chooseStep([4,5,6]), None)
+      self.assertEqual(y.step, None)
+
+    def test_LogAxisTics_chooseStep_min_max_1_0(self):
+      y = glyph._LogAxisTics(1.0, 1.0, unitSystem='si')
+      self.assertEqual(y.chooseStep([4,5,6]), None)
+      self.assertEqual(y.step, None)
+
+    def test_LogAxisTics_chooseStep_min_max_neg_1_0(self):
+      y = glyph._LogAxisTics(-1.0, -1.0, unitSystem='si')
+      self.assertEqual(y.chooseStep([4,5,6]), None)
+      self.assertEqual(y.step, None)
+
+    #
+    # Testing _LogAxisTics.chooseLimits()
+    # side effects are settings of
+    # self.bottom
+    # self.top
+    # self.span
+
+    def test_LogAxisTics_chooseLimits_defaults(self):
+      y = glyph._LogAxisTics(1.0, 1000, unitSystem='si')
+      y.applySettings()
+      y.chooseLimits()
+      self.assertEqual((y.bottom, y.top, y.span), (1.0, 1000.0, 999.0))
+
+    def test_LogAxisTics_chooseLimits_axisMin_1(self):
+      y = glyph._LogAxisTics(1.0, 1000, unitSystem='si')
+      y.applySettings(axisMin=1.0)
+      y.chooseLimits()
+      self.assertEqual((y.bottom, y.top, y.span), (1.0, 1000.0, 999.0))
+
+    def test_LogAxisTics_chooseLimits_axisMax_0(self):
+      y = glyph._LogAxisTics(1, 1000, unitSystem='si')
+      y.applySettings(axisMax=1.0)
+      y.chooseLimits()
+      self.assertEqual((y.bottom, y.top, y.span), (0.1, 1.0, 0.9))
+
+    def test_LogAxisTics_chooseLimits_yMax_0_axisMax_0_1(self):
+      y = glyph._LogAxisTics(0.0, 0.0, unitSystem='si')
+      y.applySettings(axisMax=0.1)
+      with self.assertRaises(glyph.GraphError):
+        y.chooseLimits()
+
+    #
+    # Testing _LogAxisTics.getLabelValues()
+    #
+
+    def test_LogAxisTics_getLabelValues_defaults(self):
+      y = glyph._LogAxisTics(1, 1000, unitSystem='si')
+      y.applySettings()
+      y.chooseLimits()
+      self.assertEqual(y.getLabelValues(), [1.0, 10.0, 100.0, 1000.0])
+
+    def test_LogAxisTics_getLabelValues_neg(self):
+      y = glyph._LogAxisTics(1, 5, unitSystem='si')
+      y.applySettings()
+      y.chooseLimits()
+      self.assertEqual(y.getLabelValues(), [1.0, 10.0])

--- a/webapp/tests/test_render_glyph.py
+++ b/webapp/tests/test_render_glyph.py
@@ -137,10 +137,10 @@ class glyphStandaloneFunctionTest(TestCase):
         glyph.safeSum(['a',10,30])
 
     def test_safeSum_list_all_numbers(self):
-      self.assertEqual(glyph.safeSum([1,5.1,6,]), 12.1)
+      self.assertAlmostEqual(glyph.safeSum([1,5.1,6,]), 12.1, places=4)
 
     def test_safeSum_list_with_nan(self):
-      self.assertEqual(glyph.safeSum([1,5.1,6,float('Nan')]), 12.1)
+      self.assertAlmostEqual(glyph.safeSum([1,5.1,6,float('Nan')]), 12.1, places=4)
 
     #
     # Testing any()
@@ -371,10 +371,10 @@ class AxisTicsTest(TestCase):
     #
 
     def test_AxisTics_chooseDelta_0_1(self):
-      self.assertEqual(glyph._AxisTics.chooseDelta(1), 0.1)
+      self.assertAlmostEqual(glyph._AxisTics.chooseDelta(1), 0.1, places=4)
 
     def test_AxisTics_chooseDelta_very_small(self):
-      self.assertEqual(glyph._AxisTics.chooseDelta(1.0e-10), 1.0)
+      self.assertAlmostEqual(glyph._AxisTics.chooseDelta(1.0e-10), 1.0, places=4)
 
 
 class LinearAxisTicsTest(TestCase):
@@ -607,11 +607,11 @@ class LinearAxisTicsTest(TestCase):
 
     def test_LinearAxisTics_computeSlop_med_maxValue_50_10(self):
       y = glyph._LinearAxisTics(0.0, 100.0, unitSystem='si')
-      self.assertEqual(y.computeSlop(50, 10), 400.0)
+      self.assertAlmostEqual(y.computeSlop(50, 10), 400.0, places=4)
 
     def test_LinearAxisTics_computeSlop_low_maxValue_10_3(self):
       y = glyph._LinearAxisTics(0, 1, unitSystem='si')
-      self.assertEqual(y.computeSlop(10, 3), 29.0)
+      self.assertAlmostEqual(y.computeSlop(10, 3), 29.0, places=4)
 
     #
     # Testing _LinearAxisTics.chooseStep()
@@ -620,12 +620,12 @@ class LinearAxisTicsTest(TestCase):
     def test_LinearAxisTics_chooseStep_default(self):
       y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
       self.assertEqual(y.chooseStep(), None)
-      self.assertEqual(y.step, 200)
+      self.assertAlmostEqual(y.step, 200, places=4)
 
     def test_LinearAxisTics_chooseStep_default_divisors(self):
       y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
       self.assertEqual(y.chooseStep([4,5,6]), None)
-      self.assertEqual(y.step, 200)
+      self.assertAlmostEqual(y.step, 200, places=4)
 
     def test_LinearAxisTics_chooseStep_bad_divisors(self):
       y = glyph._LinearAxisTics(0.0, 1000.0, unitSystem='si')
@@ -635,17 +635,17 @@ class LinearAxisTicsTest(TestCase):
     def test_LinearAxisTics_chooseStep_min_max_0_0(self):
       y = glyph._LinearAxisTics(0.0, 0.0, unitSystem='si')
       self.assertEqual(y.chooseStep([4,5,6]), None)
-      self.assertEqual(y.step, 0.2)
+      self.assertAlmostEqual(y.step, 0.2, places=5)
 
     def test_LinearAxisTics_chooseStep_min_max_1_0(self):
       y = glyph._LinearAxisTics(1.0, 1.0, unitSystem='si')
       self.assertEqual(y.chooseStep([4,5,6]), None)
-      self.assertEqual(y.step, 0.05)
+      self.assertAlmostEqual(y.step, 0.05, places=6)
 
     def test_LinearAxisTics_chooseStep_min_max_neg_1_0(self):
       y = glyph._LinearAxisTics(-1.0, -1.0, unitSystem='si')
       self.assertEqual(y.chooseStep([4,5,6]), None)
-      self.assertEqual(y.step, 0.05)
+      self.assertAlmostEqual(y.step, 0.05, places=6)
 
     #
     # Testing _LinearAxisTics.chooseLimits()


### PR DESCRIPTION
Code Enhancements:
* Add some defensive input checks in find_x_times and format_units
* Explicitly define self.span and self.binary in class _LinearAxisTics. It was being defined in method calls.
* Add/Improve docstrings
* Adjust logic in applySettings to set axistLimit
* Move minValue<maxValue check to reconcileLimits() from applySettings()

Standalone functions:
* Tests for format_units()
* Tests for find_x_times()
* Tests for toSeconds()
* Tests for sort_stacked()
* Tests for safeArgs()
* Tests for safeMin()
* Tests for safeMax()
* Tests for safeSum()
* Tests for any()

Classes:
* Tests for the _LinearAxisTics Class
* Tests for the _LogAxisTics Class
