### PR TITLE
Offical project exists here. Brightcove is deprecated.

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -292,7 +292,7 @@ Other
 .. _Cyanite: http://cyanite.io/
 .. _D3.js: http://mbostock.github.com/d3
 .. _Descartes: https://github.com/obfuscurity/descartes
-.. _Diamond: http://opensource.brightcove.com/project/Diamond
+.. _Diamond: https://diamond.readthedocs.io/en/latest/
 .. _Dusk: https://github.com/obfuscurity/dusk
 .. _Esper: http://esper.codehaus.org
 .. _Evenflow: https://github.com/github/evenflow


### PR DESCRIPTION
From their site: https://diamond.readthedocs.io/en/latest/#repos

Historically Diamond was a brightcove project and hosted at BrightcoveOS. However none of the active developers are brightcove employees and so the development has moved to python-diamond. We request that any new pull requests and issues be cut against python-diamond. We will keep BrightcoveOS updated and still honor issues/tickets cut on that repo.

Wasn't sure if the docs (exists in this PR) or their Github repo (https://github.com/python-diamond/diamond) was more appropriate. Happy to update the PR if you'd like it to point to the repo instead.
