### PR TITLE
ATTime: Make TimeZone Aware

### DIFF
--- a/webapp/graphite/render/attime.py
+++ b/webapp/graphite/render/attime.py
@@ -39,11 +39,11 @@ def parseATTime(s, tzinfo=None):
     offset = '-' + offset
   else:
     ref,offset = s,''
-  return tzinfo.localize((parseTimeReference(ref) + parseTimeOffset(offset)), daylight)
+  return tzinfo.normalize(parseTimeReference(ref).astimezone(tzinfo) + parseTimeOffset(offset))
 
 
 def parseTimeReference(ref):
-  if not ref or ref == 'now': return datetime.now()
+  if not ref or ref == 'now': return datetime.now(pytz.utc)
 
   #Time-of-day reference
   i = ref.find(':')
@@ -66,7 +66,7 @@ def parseTimeReference(ref):
     hour,min = 16,0
     ref = ref[7:]
 
-  refDate = datetime.now().replace(hour=hour,minute=min,second=0)
+  refDate = datetime.now(pytz.utc).replace(hour=hour,minute=min,second=0)
 
   #Day reference
   if ref in ('yesterday','today','tomorrow'): #yesterday, today, tomorrow

--- a/webapp/tests/test_attime.py
+++ b/webapp/tests/test_attime.py
@@ -15,8 +15,8 @@ class MockedDateTime(datetime):
     def __new__(cls, *args, **kwargs):
         return datetime.__new__(datetime, *args, **kwargs)
     @classmethod
-    def now(cls):
-        return cls(2015, 3, 8, 12, 0, 0)
+    def now(cls, tzinfo=None):
+        return cls(2015, 3, 8, 12, 0, 0, tzinfo=tzinfo)
 
 @mock.patch('graphite.render.attime.datetime', MockedDateTime)
 class ATTimeTimezoneTests(TestCase):
@@ -24,7 +24,6 @@ class ATTimeTimezoneTests(TestCase):
     specified_tz = pytz.timezone("America/Los_Angeles")
     def test_should_return_absolute_time(self):
         time_string = '12:0020150308'
-
         expected_time = self.default_tz.localize(datetime.strptime(time_string,'%H:%M%Y%m%d'))
         actual_time = parseATTime(time_string)
         self.assertEqual(actual_time, expected_time)
@@ -37,27 +36,27 @@ class ATTimeTimezoneTests(TestCase):
 
     def test_absolute_time_YYMMDD(self):
         time_string = '20150110'
-        expected_time = self.specified_tz.localize(datetime.strptime(time_string, '%Y%m%d'))
+        expected_time = self.default_tz.localize(datetime.strptime(time_string, '%Y%m%d'))
         actual_time = parseATTime(time_string, self.specified_tz)
-        self.assertEqual(actual_time, expected_time)
+        self.assertEqual(actual_time, expected_time.astimezone(self.specified_tz))
 
     def test_midnight(self):
-        expected_time = self.specified_tz.localize(datetime.strptime("0:00_20150308", '%H:%M_%Y%m%d'))
+        expected_time = self.default_tz.localize(datetime.strptime("0:00_20150308", '%H:%M_%Y%m%d'))
         actual_time = parseATTime("midnight", self.specified_tz)
-        self.assertEqual(actual_time, expected_time)
+        self.assertEqual(actual_time, expected_time.astimezone(self.specified_tz))
 
     def test_offset_with_tz(self):
-        expected_time = self.specified_tz.localize(datetime.strptime("5:00_20150308", '%H:%M_%Y%m%d'))
+        expected_time = self.default_tz.localize(datetime.strptime("5:00_20150308", '%H:%M_%Y%m%d'))
         actual_time = parseATTime("midnight+5h", self.specified_tz)
-        self.assertEqual(actual_time, expected_time)
+        self.assertEqual(actual_time, expected_time.astimezone(self.specified_tz))
 
     def test_relative_day_with_tz(self):
-        expected_time = self.specified_tz.localize(datetime.strptime("0:00_20150309", '%H:%M_%Y%m%d'))
+        expected_time = self.default_tz.localize(datetime.strptime("0:00_20150309", '%H:%M_%Y%m%d'))
         actual_time = parseATTime("midnight_tomorrow", self.specified_tz)
         self.assertEqual(actual_time, expected_time)
 
     def test_relative_day_and_offset_with_tz(self):
-        expected_time = self.specified_tz.localize(datetime.strptime("3:00_20150309", '%H:%M_%Y%m%d'))
+        expected_time = self.default_tz.localize(datetime.strptime("3:00_20150309", '%H:%M_%Y%m%d'))
         actual_time = parseATTime("midnight_tomorrow+3h", self.specified_tz)
         self.assertEqual(actual_time, expected_time)
 
@@ -67,35 +66,41 @@ class ATTimeTimezoneTests(TestCase):
         self.assertEqual(actual_time, expected_time)
 
     def test_now_should_respect_tz(self):
-        expected_time = self.specified_tz.localize(datetime.strptime("12:00_20150308", '%H:%M_%Y%m%d'))
+        expected_time = self.default_tz.localize(datetime.strptime("12:00_20150308", '%H:%M_%Y%m%d'))
         actual_time = parseATTime("now", self.specified_tz)
         self.assertEqual(actual_time, expected_time)
 
+    def test_relative_time_in_alternate_zone(self):
+        expected_time = self.specified_tz.localize(datetime.strptime("04:00_20150308", '%H:%M_%Y%m%d'))
+        actual_time = parseATTime("-1h", self.specified_tz)
+        self.assertEqual(actual_time.hour, expected_time.hour)
+
     def test_should_handle_dst_boundary(self):
-        expected_time = self.specified_tz.localize(datetime.strptime("03:00_20150308", '%H:%M_%Y%m%d'))
+        expected_time = self.default_tz.localize(datetime.strptime("02:00_20150308", '%H:%M_%Y%m%d'))
         actual_time = parseATTime("midnight+2h", self.specified_tz)
         self.assertEqual(actual_time, expected_time)
-
-MOCK_DATE = datetime(2015, 1, 1, 11, 00)
 
 class AnotherMockedDateTime(datetime):
     def __new__(cls, *args, **kwargs):
         return datetime.__new__(datetime, *args, **kwargs)
     @classmethod
-    def now(cls):
-        return cls(2015, 1, 1, 11, 0, 0)
+    def now(cls, tzinfo=None):
+        return cls(2015, 1, 1, 11, 0, 0, tzinfo=tzinfo)
 
 
 @mock.patch('graphite.render.attime.datetime', AnotherMockedDateTime)
 class parseTimeReferenceTest(TestCase):
 
+    zone = pytz.utc
+    MOCK_DATE = zone.localize(datetime(2015, 1, 1, 11, 00))
+
     def test_parse_empty_return_now(self):
         time_ref = parseTimeReference('')
-        self.assertEquals(time_ref, MOCK_DATE)
+        self.assertEquals(time_ref, self.MOCK_DATE)
 
     def test_parse_None_return_now(self):
         time_ref = parseTimeReference(None)
-        self.assertEquals(time_ref, MOCK_DATE)
+        self.assertEquals(time_ref, self.MOCK_DATE)
 
     def test_parse_random_string_raise_Exception(self):
         with self.assertRaises(Exception):
@@ -103,7 +108,7 @@ class parseTimeReferenceTest(TestCase):
 
     def test_parse_now_return_now(self):
         time_ref = parseTimeReference("now")
-        self.assertEquals(time_ref, MOCK_DATE)
+        self.assertEquals(time_ref, self.MOCK_DATE)
 
     def test_parse_colon_raises_ValueError(self):
         with self.assertRaises(ValueError):
@@ -111,67 +116,67 @@ class parseTimeReferenceTest(TestCase):
 
     def test_parse_hour_return_hour_of_today(self):
         time_ref = parseTimeReference("8:50")
-        expected = datetime(MOCK_DATE.year, MOCK_DATE.month, MOCK_DATE.day, 8, 50)
+        expected = self.zone.localize(datetime(self.MOCK_DATE.year, self.MOCK_DATE.month, self.MOCK_DATE.day, 8, 50))
         self.assertEquals(time_ref, expected)
 
     def test_parse_hour_am(self):
         time_ref = parseTimeReference("8:50am")
-        expected = datetime(MOCK_DATE.year, MOCK_DATE.month, MOCK_DATE.day, 8, 50)
+        expected = self.zone.localize(datetime(self.MOCK_DATE.year, self.MOCK_DATE.month, self.MOCK_DATE.day, 8, 50))
         self.assertEquals(time_ref, expected)
 
     def test_parse_hour_pm(self):
         time_ref = parseTimeReference("8:50pm")
-        expected = datetime(MOCK_DATE.year, MOCK_DATE.month, MOCK_DATE.day, 20, 50)
+        expected = self.zone.localize(datetime(self.MOCK_DATE.year, self.MOCK_DATE.month, self.MOCK_DATE.day, 20, 50))
         self.assertEquals(time_ref, expected)
 
     def test_parse_noon(self):
         time_ref = parseTimeReference("noon")
-        expected = datetime(MOCK_DATE.year, MOCK_DATE.month, MOCK_DATE.day, 12, 0)
+        expected = self.zone.localize(datetime(self.MOCK_DATE.year, self.MOCK_DATE.month, self.MOCK_DATE.day, 12, 0))
         self.assertEquals(time_ref, expected)
 
     def test_parse_midnight(self):
         time_ref = parseTimeReference("midnight")
-        expected = datetime(MOCK_DATE.year, MOCK_DATE.month, MOCK_DATE.day, 0, 0)
+        expected = self.zone.localize(datetime(self.MOCK_DATE.year, self.MOCK_DATE.month, self.MOCK_DATE.day, 0, 0))
         self.assertEquals(time_ref, expected)
 
     def test_parse_teatime(self):
         time_ref = parseTimeReference("teatime")
-        expected = datetime(MOCK_DATE.year, MOCK_DATE.month, MOCK_DATE.day, 16, 0)
+        expected = self.zone.localize(datetime(self.MOCK_DATE.year, self.MOCK_DATE.month, self.MOCK_DATE.day, 16, 0))
         self.assertEquals(time_ref, expected)
 
     def test_parse_yesterday(self):
         time_ref = parseTimeReference("yesterday")
-        expected = datetime(2014, 12, 31, 0, 0)
+        expected = self.zone.localize(datetime(2014, 12, 31, 0, 0))
         self.assertEquals(time_ref, expected)
 
     def test_parse_tomorrow(self):
         time_ref = parseTimeReference("tomorrow")
-        expected = datetime(2015, 1, 2, 0, 0)
+        expected = self.zone.localize(datetime(2015, 1, 2, 0, 0))
         self.assertEquals(time_ref, expected)
 
     def test_parse_MM_slash_DD_slash_YY(self):
         time_ref = parseTimeReference("02/25/15")
-        expected = datetime(2015, 2, 25, 0, 0)
+        expected = self.zone.localize(datetime(2015, 2, 25, 0, 0))
         self.assertEquals(time_ref, expected)
 
     def test_parse_MM_slash_DD_slash_YYYY(self):
         time_ref = parseTimeReference("02/25/2015")
-        expected = datetime(2015, 2, 25, 0, 0)
+        expected = self.zone.localize(datetime(2015, 2, 25, 0, 0))
         self.assertEquals(time_ref, expected)
 
     def test_parse_YYYYMMDD(self):
         time_ref = parseTimeReference("20140606")
-        expected = datetime(2014, 6, 6, 0, 0)
+        expected = self.zone.localize(datetime(2014, 6, 6, 0, 0))
         self.assertEquals(time_ref, expected)
 
     def test_parse_MonthName_DayOfMonth_onedigits(self):
         time_ref = parseTimeReference("january8")
-        expected = datetime(2015, 1, 8, 0, 0)
+        expected = self.zone.localize(datetime(2015, 1, 8, 0, 0))
         self.assertEquals(time_ref, expected)
 
     def test_parse_MonthName_DayOfMonth_twodigits(self):
         time_ref = parseTimeReference("january10")
-        expected = datetime(2015, 1, 10, 0, 0)
+        expected = self.zone.localize(datetime(2015, 1, 10, 0, 0))
         self.assertEquals(time_ref, expected)
 
     def test_parse_MonthName_DayOfMonth_threedigits_raise_ValueError(self):
@@ -184,29 +189,28 @@ class parseTimeReferenceTest(TestCase):
 
     def test_parse_monday_return_monday_before_now(self):
         time_ref = parseTimeReference("monday")
-        expected = datetime(2014, 12, 29, 0, 0)
+        expected = self.zone.localize(datetime(2014, 12, 29, 0, 0))
         self.assertEquals(time_ref, expected)
-
-BUG_551771_MOCK_DATE = datetime(2010, 3, 30, 00, 00)
 
 class Bug551771MockedDateTime(datetime):
     def __new__(cls, *args, **kwargs):
         return datetime.__new__(datetime, *args, **kwargs)
     @classmethod
-    def now(cls):
-        return cls(2010, 3, 30, 00, 0, 0)
-
+    def now(cls, tzinfo=None):
+        return cls(2010, 3, 30, 00, 0, 0, tzinfo=tzinfo)
 
 @mock.patch('graphite.render.attime.datetime', Bug551771MockedDateTime)
 class parseTimeReferenceTestBug551771(TestCase):
+    zone = pytz.utc
+
     def test_parse_MM_slash_DD_slash_YY(self):
         time_ref = parseTimeReference("02/23/10")
-        expected = datetime(2010, 2, 23, 0, 0)
+        expected = self.zone.localize(datetime(2010, 2, 23, 0, 0))
         self.assertEquals(time_ref, expected)
 
     def test_parse_YYYYMMDD(self):
         time_ref = parseTimeReference("20100223")
-        expected = datetime(2010, 2, 23, 0, 0)
+        expected = self.zone.localize(datetime(2010, 2, 23, 0, 0))
         self.assertEquals(time_ref, expected)
 
 class parseTimeOffsetTest(TestCase):

--- a/webapp/tests/test_attime.py
+++ b/webapp/tests/test_attime.py
@@ -365,9 +365,11 @@ class getUnitStringTest(TestCase):
 
 
 class parseATTimeTest(TestCase):
+    zone = pytz.utc
+    MOCK_DATE = zone.localize(datetime(2015, 1, 1, 11, 00))
 
     @unittest.expectedFailure
     def test_parse_noon_plus_yesterday(self):
         time_ref = parseATTime("noon+yesterday")
-        expected = datetime(MOCK_DATE.year, MOCK_DATE.month, MOCK_DATE.day - 1, 12, 00)
+        expected = datetime(self.MOCK_DATE.year, self.MOCK_DATE.month, self.MOCK_DATE.day - 1, 12, 00)
         self.assertEquals(time_ref, expected)


### PR DESCRIPTION
This is cherry picked from the 0.9.x branch with changes made to the tests to accommodate the changes to graphite/render/attime.py
