### PR TITLE
Lower the default REMOTE_FETCH_TIMEOUT

### DIFF
--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -222,7 +222,7 @@
 #INTRACLUSTER_HTTPS = False
 ## These are timeout values (in seconds) for requests to remote webapps
 #REMOTE_FIND_TIMEOUT = 3.0             # Timeout for metric find requests
-#REMOTE_FETCH_TIMEOUT = 6.0            # Timeout to fetch series data
+#REMOTE_FETCH_TIMEOUT = 3.0            # Timeout to fetch series data
 #REMOTE_RETRY_DELAY = 60.0             # Time before retrying a failed remote webapp
 #REMOTE_EXCLUDE_LOCAL = False          # Try to detect when a cluster server is localhost and don't forward queries
 #FIND_CACHE_DURATION = 300             # Time to cache remote metric find results

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -52,7 +52,7 @@ CLUSTER_SERVERS = []
 # This settings control wether https is used to communicate between cluster members
 INTRACLUSTER_HTTPS = False
 REMOTE_FIND_TIMEOUT = 3.0
-REMOTE_FETCH_TIMEOUT = 6.0
+REMOTE_FETCH_TIMEOUT = 3.0
 REMOTE_RETRY_DELAY = 60.0
 REMOTE_EXCLUDE_LOCAL = False
 CARBON_METRIC_PREFIX='carbon'


### PR DESCRIPTION
While testing #1588 I noticed that rendering took a "long" time when `CLUSTER_SERVERS` was broken, even though the metrics were local. Our default `REMOTE_FETCH_TIMEOUT` value was set to **6.0**, an excessively high setting for most environments. Lowering this to a more sane default value of **3.0**.

@bmhatfield @drawks You guys see any reason this shouldn't go in?