### PR TITLE
Allow setColor to recognize unquoted integers as hex values (0.9.x)

### DIFF
--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -224,8 +224,8 @@ class Graph:
       if len(s) == 8 and not forceAlpha:
         alpha = float( int(s[6:8],base=16) ) / 255.0
     elif isinstance(value, int) and len(str(value)) == 6:
-        s = str(value)
-        r,g,b = ( int(s[0:2],base=16), int(s[2:4],base=16), int(s[4:6],base=16) )
+      s = str(value)
+      r,g,b = ( int(s[0:2],base=16), int(s[2:4],base=16), int(s[4:6],base=16) )
     else:
       raise ValueError, "Must specify an RGB 3-tuple, an html color string, or a known color alias!"
     r,g,b = [float(c) / 255.0 for c in (r,g,b)]

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -223,6 +223,9 @@ class Graph:
       r,g,b = ( int(s[0:2],base=16), int(s[2:4],base=16), int(s[4:6],base=16) )
       if len(s) == 8 and not forceAlpha:
         alpha = float( int(s[6:8],base=16) ) / 255.0
+    elif isinstance(value, int) and len(str(value)) == 6:
+        s = str(value)
+        r,g,b = ( int(s[0:2],base=16), int(s[2:4],base=16), int(s[4:6],base=16) )
     else:
       raise ValueError, "Must specify an RGB 3-tuple, an html color string, or a known color alias!"
     r,g,b = [float(c) / 255.0 for c in (r,g,b)]
@@ -957,7 +960,7 @@ class LineGraph(Graph):
 
       if 'stacked' in series.options:
         if self.lineMode == 'staircase':
-          xPos = x 
+          xPos = x
         else:
           xPos = x-series.xStep
         if self.secondYAxis:


### PR DESCRIPTION
This PR is based on #1053 with minor whitespace fixes by me. The gist is that it's possible for a user to manually pass an unquoted hex value (e.g. `808080`) which will be interpreted as an integer. Note that this only works for all-numeric values. Any unquoted alphanumeric values (e.g. `ff0000`) will still raise an exception.