### PR TITLE
Allow setColor to recognize unquoted integers as hex values (master)

### DIFF
--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -602,6 +602,9 @@ class Graph:
       r,g,b = ( int(s[0:2],base=16), int(s[2:4],base=16), int(s[4:6],base=16) )
       if len(s) == 8 and not forceAlpha:
         alpha = float( int(s[6:8],base=16) ) / 255.0
+    elif isinstance(value, int) and len(str(value)) == 6:
+        s = str(value)
+        r,g,b = ( int(s[0:2],base=16), int(s[2:4],base=16), int(s[4:6],base=16) )
     else:
       raise ValueError("Must specify an RGB 3-tuple, an html color string, or a known color alias!")
     r,g,b = [float(c) / 255.0 for c in (r,g,b)]

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -603,8 +603,8 @@ class Graph:
       if len(s) == 8 and not forceAlpha:
         alpha = float( int(s[6:8],base=16) ) / 255.0
     elif isinstance(value, int) and len(str(value)) == 6:
-        s = str(value)
-        r,g,b = ( int(s[0:2],base=16), int(s[2:4],base=16), int(s[4:6],base=16) )
+      s = str(value)
+      r,g,b = ( int(s[0:2],base=16), int(s[2:4],base=16), int(s[4:6],base=16) )
     else:
       raise ValueError("Must specify an RGB 3-tuple, an html color string, or a known color alias!")
     r,g,b = [float(c) / 255.0 for c in (r,g,b)]


### PR DESCRIPTION
This is a port of #1596 (based on #1053) to the master branch. Please see the aforementioned for a full explanation.

P.S. It was cute of me to think I was clever enough to write any tests for `setColor` in glyph.py. /cc @cbowman0 in case he's feeling up to the challenge.