### PR TITLE
Floating point values are valid when unit=DAY

### DIFF
--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1968,7 +1968,8 @@ def find_x_times(start_dt, unit, step):
   if not isinstance(start_dt, datetime):
     raise ValueError("Invalid start_dt: %s" % start_dt)
   if not isinstance(step, int) or not step > 0:
-    raise ValueError("Invalid step value: %s" % step)
+    if not isinstance(step, float) or unit != DAY or not step > 0.0:
+      raise ValueError("Invalid step value: %s" % step)
 
   if unit == SEC:
     dt = start_dt.replace(second=start_dt.second - (start_dt.second % step))

--- a/webapp/tests/test_render_glyph.py
+++ b/webapp/tests/test_render_glyph.py
@@ -319,6 +319,12 @@ class glyphStandaloneFunctionTest(TestCase):
       self.assertEquals(dt_out, expected_dt)
       self.assertEquals(delta_out, expected_delta)
 
+    def test_find_x_times_xconfigs(self):
+      for xconf in glyph.xAxisConfigs:
+        glyph.find_x_times(self.dt, xconf['labelUnit'], xconf['labelStep'])
+        glyph.find_x_times(self.dt, xconf['majorGridUnit'], xconf['majorGridStep'])
+        glyph.find_x_times(self.dt, xconf['minorGridUnit'], xconf['minorGridStep'])
+
     def test_find_x_times_invalid_input(self):
       with self.assertRaises(ValueError):
           glyph.find_x_times(None, glyph.SEC, 1.0)
@@ -346,6 +352,9 @@ class glyphStandaloneFunctionTest(TestCase):
 
       with self.assertRaises(ValueError):
           glyph.find_x_times(self.dt, glyph.SEC, 1.0)
+
+      with self.assertRaises(ValueError):
+          glyph.find_x_times(self.dt, glyph.DAY, -1.0)
 
 
 class AxisTicsTest(TestCase):


### PR DESCRIPTION
FYI @cbowman0 - I noticed this regression when I triggered a render that chose the following xAxisConfig:

```
dict(seconds=8000,        
     minorGridUnit=DAY,   
     minorGridStep=3.5,   # <--- float here
     majorGridUnit=DAY,   
     majorGridStep=7,     
     labelUnit=DAY,       
     labelStep=7,         
     format="%m/%d",      
     maxInterval=365*DAY),
```