### PR TITLE
Option to filter null datapoints from json results

### DIFF
--- a/docs/dashboard.rst
+++ b/docs/dashboard.rst
@@ -229,7 +229,7 @@ The functions are grouped as follows:
   - the number of minor lines to draw (see :ref:`param-minorY`)
   - drawing on a logarithmic scale of the specified base (see :ref:`param-logBase`)
   - step between the Y-axis labels and gridlines (see :ref:`param-yStep`)
-  - divisor for the axis (see :ref:`param-yDivisor`)
+  - divisor for the axis (see :ref:`param-yDivisors`)
   - unit system (SI, binary, or none - see :ref:`param-yUnitSystem`)
   - side the axis appears (see :ref:`param-yAxisSide`).
 

--- a/docs/render_api.rst
+++ b/docs/render_api.rst
@@ -476,7 +476,6 @@ Takes one of the following parameters which determines the fill mode to use:
   Creates a graph where the filled area of each target is stacked on one another.
   Each target line is displayed as the sum of all previous lines plus the value of the current line.
 
-
 .. _param-bgcolor:
   
 bgcolor
@@ -520,6 +519,8 @@ Examples:
   &bgcolor=blue
   &bgcolor=2222FF
   &bgcolor=5522FF60
+
+.. _param-cacheTimeout:
 
 cacheTimeout
 ------------
@@ -624,9 +625,13 @@ Example:
 
   &fontSize=8
 
+.. _param-format:
+
 format
 ------
 See: `Data Display Formats`_
+
+.. _param-from:
 
 from
 ----
@@ -639,6 +644,8 @@ graphOnly
 *Default: False*
 
 Display only the graph area with no grid lines, axes, or legend
+
+.. _param-graphType:
 
 graphType
 ---------
@@ -715,6 +722,8 @@ Example:
 
   &hideGrid=true
 
+.. _param-height:
+
 height
 ------
 *Default: 250*
@@ -729,6 +738,8 @@ Example:
 
   &width=650&height=250
 
+.. _param-jsonp:
+
 jsonp
 -----
 *Default: <unset>*
@@ -736,17 +747,23 @@ jsonp
 If set and combined with ``format=json``, wraps the JSON response in a function call
 named by the parameter specified.
 
+.. _param-leftColor:
+
 leftColor
 ---------
 *Default: color chosen from* colorList_
 
 In dual Y-axis mode, sets the color of all metrics associated with the left Y-axis.
 
+.. _param-leftDashed:
+
 leftDashed
 ----------
 *Default: False*
 
 In dual Y-axis mode, draws all metrics associated with the left Y-axis using dashed lines
+
+.. _param-leftWidth:
 
 leftWidth
 ---------
@@ -798,6 +815,8 @@ logBase
 
 If set, draws the graph with a logarithmic scale of the specified base (e.g. 10 for common logarithm)
 
+.. _param-localOnly:
+
 localOnly
 ---------
 *Default: False*
@@ -821,6 +840,8 @@ Example:
 
   &majorGridLineColor=FF22FF
 
+.. _param-margin:
+
 margin
 ------
 *Default: 10*
@@ -832,10 +853,14 @@ Example:
 
   &margin=20
 
+.. _param-max:
+
 max
 ---
 .. deprecated:: 0.9.0
    See yMax_
+
+.. _param-maxDataPoints:
 
 maxDataPoints
 -------------
@@ -871,6 +896,8 @@ Example:
 
   &minorY=3
 
+.. _param-min:
+
 min
 ---
 .. deprecated:: 0.9.0
@@ -890,16 +917,30 @@ than there are pixels in the graph area (e.g. a few month's worth of per-minute 
 'smooshed' as there will be a good deal of line overlap. In response, one may use lineWidth_ to compensate
 for this.
 
+.. _param-noCache:
+
 noCache
 -------
 *Default: False*
 
 Set to disable caching of rendered images
 
+.. _param-noNullPoints:
+
+noNullPoints
+------------
+*Default: False*
+
+If set and combined with ``format=json``, removes all null datapoints from the series returned.
+
+.. _param-pickle:
+
 pickle
 ------
 .. deprecated:: 0.9.10
   See `Data Display Formats`_
+
+.. _param-pieLabels:
 
 pieLabels
 ---------
@@ -911,6 +952,8 @@ Orientation to use for slice labels inside of a pie chart.
   Labels are oriented horizontally within each slice
 ``rotated``
   Labels are oriented radially within each slice
+
+.. _param-pieMode:
 
 pieMode
 -------
@@ -926,17 +969,23 @@ One of:
 ``minimum``
   THe minimum of non-null points in the series
 
+.. _param-rightColor:
+
 rightColor
 ----------
 *Default: color chosen from* colorList_
 
 In dual Y-axis mode, sets the color of all metrics associated with the right Y-axis.
 
+.. _param-rightDashed:
+
 rightDashed
 -----------
 *Default: False*
 
 In dual Y-axis mode, draws all metrics associated with the right Y-axis using dashed lines
+
+.. _param-rightWidth:
 
 rightWidth
 ----------
@@ -958,6 +1007,8 @@ Example:
 .. code-block:: none
 
   &template=plain
+
+.. _param-thickness:
 
 thickness
 ---------
@@ -1006,11 +1057,13 @@ uniqueLegend
 
 Display only unique legend items, removing any duplicates
 
+.. _param-until:
+
 until
 -----
 See: `from / until`_
 
-.. _param-vtitle:
+.. _param-valueLabels:
 
 valueLabels
 -----------
@@ -1025,17 +1078,23 @@ Determines how slice labels are rendered within a pie chart.
 ``percent``
   Slice labels are reported as a percent of the whole
 
+.. _param-valueLabelsColor:
+
 valueLabelsColor
 ----------------
 *Default: black*
 
 Color used to draw slice labels within a pie chart.
 
+.. _param-valueLabelsMin:
+
 valueLabelsMin
 --------------
 *Default: 5*
 
 Slice values below this minimum will not have their labels rendered.
+
+.. _param-vtitle:
 
 vtitle
 ------
@@ -1050,11 +1109,15 @@ Example:
 
   &vtitle=Threads
 
+.. _param-vtitleRight:
+
 vtitleRight
 -----------
 *Default: <unset>*
 
 In dual Y-axis mode, sets the title of the right Y-Axis (See: `vtitle`_)
+
+.. _param-width:
 
 width
 -----
@@ -1088,7 +1151,7 @@ yAxisSide
 
 Sets the side of the graph on which to render the Y-axis. Accepts values of ``left`` or ``right``
 
-.. _param-yDivisor:
+.. _param-yDivisors:
   
 yDivisors
 ---------
@@ -1100,15 +1163,21 @@ display based on a 'pretty' factor, which tries to maintain a sensible scale (e.
 intermediary values like 25%,50%,75% over 33.3%,66.6%).  To explicitly set the Y-axis values, 
 see `yStep`_
 
+.. _param-yLimit:
+
 yLimit
 ------
 *Reserved for future use*
 See: yMax_
 
+.. _param-yLimitLeft:
+
 yLimitLeft
 ----------
 *Reserved for future use*
 See: yMaxLeft_
+
+.. _param-yLimitRight:
 
 yLimitRight
 -----------
@@ -1143,17 +1212,25 @@ Example:
 
   &yMax=0.2345
 
+.. _param-yMaxLeft:
+
 yMaxLeft
 --------
 In dual Y-axis mode, sets the upper bound of the left Y-Axis (See: `yMax`_)
+
+.. _param-yMaxRight:
 
 yMaxRight
 ---------
 In dual Y-axis mode, sets the upper bound of the right Y-Axis (See: `yMax`_)
 
+.. _param-yMinLeft:
+
 yMinLeft
 --------
 In dual Y-axis mode, sets the lower bound of the left Y-Axis (See: `yMin`_)
+
+.. _param-yMinRight:
 
 yMinRight
 ---------
@@ -1167,9 +1244,13 @@ yStep
 
 Manually set the value step between Y-axis labels and grid lines
 
+.. _param-yStepLeft:
+
 yStepLeft
 ---------
 In dual Y-axis mode, Manually set the value step between the left Y-axis labels and grid lines (See: `yStep`_)
+
+.. _param-yStepRight:
 
 yStepRight
 ----------

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -154,7 +154,7 @@ def renderView(request):
             timestamps = range(int(series.start), int(series.end) + 1, int(series.step))
           datapoints = zip(series, timestamps)
           series_data.append(dict(target=series.name, datapoints=datapoints))
-      elif 'NoNullPoints' in requestOptions and any(data):
+      elif 'noNullPoints' in requestOptions and any(data):
         for series in data:
           values = []
           for (index,v) in enumerate(series):
@@ -328,8 +328,8 @@ def parseOptions(request):
     requestOptions['noCache'] = True
   if 'maxDataPoints' in queryParams and queryParams['maxDataPoints'].isdigit():
     requestOptions['maxDataPoints'] = int(queryParams['maxDataPoints'])
-  if 'NoNullPoints' in queryParams:
-    requestOptions['NoNullPoints'] = True
+  if 'noNullPoints' in queryParams:
+    requestOptions['noNullPoints'] = True
 
   requestOptions['localOnly'] = queryParams.get('local') == '1'
 


### PR DESCRIPTION
This supersedes #1172, introducing the `noNullPoints` param for removing null results in `format=json` output. The original work was submitted by @kokje. I've made a small change to the parameter name and documented the feature.