### PR TITLE
Missing PYTHONPATH in docs example

### DIFF
--- a/docs/config-local-settings.rst
+++ b/docs/config-local-settings.rst
@@ -86,7 +86,7 @@ STATIC_ROOT
 
   This directory doesn't even exist once you've installed graphite. It needs to be populated with the following command::
 
-      django-admin.py collectstatic --noinput --settings=graphite.settings
+      PYTHONPATH=$GRAPHITE_ROOT/webapp django-admin.py collectstatic --noinput --settings=graphite.settings
 
   This collects static files for graphite-web and external apps (namely, the Django admin app) and puts them in a directory that needs to be available under the ``/static/`` URL of your web server. To configure Apache::
 


### PR DESCRIPTION
@mauron85 pointed out in #890 that we need to specify the `PYTHONPATH` when running `django-admin.py`. His PR had some issues that have not been addressed so I'm fixing it here.