### PR TITLE
Prefer cairocffi, fall back to pycairo

### DIFF
--- a/check-dependencies.py
+++ b/check-dependencies.py
@@ -28,12 +28,13 @@ except ImportError:
     required += 1
 
 
-# Test for pycairo or cairocffi
+# Test for cairocffi or pycairo
 try:
-  import cairo
+  import cairocffi as cairo
 except ImportError:
+  sys.stderr.write("[REQUIRED] Unable to import the 'cairocffi' module, attempting to fall back to pycairo\n")
   try:
-    import cairocffi as cairo
+    import cairo
   except ImportError:
     sys.stderr.write("[REQUIRED] Unable to import the 'cairo' module, do you have pycairo installed for python %s?\n" % py_version)
     cairo = None
@@ -48,6 +49,7 @@ try:
 except Exception:
   sys.stderr.write("[REQUIRED] Failed to create an ImageSurface with cairo, you probably need to recompile cairo with PNG support\n")
   required += 1
+
 
 # Test that cairo can find fonts
 try:

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -14,9 +14,9 @@ limitations under the License."""
 
 import math, itertools, re
 try:
-    import cairo
-except ImportError:
     import cairocffi as cairo
+except ImportError:
+    import cairo
 
 import StringIO
 from datetime import datetime, timedelta
@@ -25,7 +25,6 @@ from ConfigParser import SafeConfigParser
 from django.conf import settings
 from graphite.render.datalib import TimeSeries
 from graphite.util import json
-
 
 import pytz
 


### PR DESCRIPTION
Earlier commits led us to prefer installing cairocffi over pycairo, but `glyph.py` would still use pycairo first if it was available. Let's fix this oversight.

/cc @SEJeff @anotherthomas (via #341) and @brutasse who were involved in the earlier Cairo discussions.