### PR TITLE
Sort dashboards by name in Finder

### DIFF
--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -2826,7 +2826,7 @@ function showDashboardFinder() {
     root: 'dashboards',
     sortInfo: {
       field: 'name',
-      direction: 'DESC'
+      direction: 'ASC'
     },
     listeners: {
       beforeload: function (store) {

--- a/webapp/graphite/dashboard/views.py
+++ b/webapp/graphite/dashboard/views.py
@@ -310,7 +310,7 @@ def find(request):
   results = []
 
   # Find all dashboard names that contain each of our query terms as a substring
-  for dashboard in Dashboard.objects.all():
+  for dashboard in Dashboard.objects.order_by('name'):
     name = dashboard.name.lower()
     if name.startswith('temporary-'):
       continue


### PR DESCRIPTION
Adapt the proposed fix by @kaarelk in #434, adding another fix to the UI sorting.