### PR TITLE
Interpolate across Nones in perSecond()

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1146,14 +1146,15 @@ def perSecond(requestContext, seriesList, maxValue=None):
   for series in seriesList:
     newValues = []
     prev = None
+    step = series.step
     for val in series:
-      step = series.step
-      if prev == None:
+      if prev is None:
         newValues.append(None)
         prev = val
         continue
-      if val == None:
+      if val is None:
         newValues.append(None)
+        step = step * 2
         continue
 
       diff = val - prev
@@ -1164,6 +1165,7 @@ def perSecond(requestContext, seriesList, maxValue=None):
       else:
         newValues.append(None)
 
+      step = series.step
       prev = val
     newName = "perSecond(%s)" % series.name
     newSeries = TimeSeries(newName, series.start, series.end, series.step, newValues)

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -977,6 +977,12 @@ class FunctionsTest(TestCase):
         result = functions.perSecond({}, seriesList)
         self.assertEqual(expected, result, 'perSecond result incorrect')
 
+    def test_perSecond_nones(self):
+        seriesList = [TimeSeries('test', 0, 600, 60, [0, 60, None, 180, None, 300, None, 420, None, 540])]
+        expected = [TimeSeries('perSecond(test)', 0, 600, 60, [None, 1, None, 1, None, 1, None, 1, None, 1])]
+        result = functions.perSecond({}, seriesList)
+        self.assertEqual(expected, result, 'perSecond result incorrect')
+
     def test_perSecond_max(self):
         seriesList = [TimeSeries('test', 0, 600, 60, [0, 120, 240, 480, 960, 900, 120, 240, 120, 0])]
         expected = [TimeSeries('perSecond(test)', 0, 600, 60, [None, 2, 2, 4, 8, None, -5, 2, 6, 6])]


### PR DESCRIPTION
Expanding upon pull request #717 from @bruce-lyft 

* Add tracking of the step to reflect when we're skipping over a None value.
* Add test case.