### PR TITLE
Support for cactiStyle unit suffix

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1407,11 +1407,12 @@ def cactiStyle(requestContext, seriesList, system=None, units=None):
   Takes a series list and modifies the aliases to provide column aligned
   output with Current, Max, and Min values in the style of cacti. Optionally
   takes a "system" value to apply unit formatting in the same style as the
-  Y-axis.
+  Y-axis, or a "unit" string to append an arbitrary unit suffix.
 
   .. code-block:: none
 
     &target=cactiStyle(ganglia.*.net.bytes_out,"si")
+    &target=cactiStyle(ganglia.*.net.bytes_out,"si","b")
 
   A possible value for ``system`` is ``si``, which would express your values in
   multiples of a thousand. A second option is to use ``binary`` which will

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1402,7 +1402,7 @@ def alias(requestContext, seriesList, newName):
       series.name = newName
   return seriesList
 
-def cactiStyle(requestContext, seriesList, system=None):
+def cactiStyle(requestContext, seriesList, system=None, units=None):
   """
   Takes a series list and modifies the aliases to provide column aligned
   output with Current, Max, and Min values in the style of cacti. Optionally
@@ -1431,9 +1431,15 @@ def cactiStyle(requestContext, seriesList, system=None):
   if 0 == len(seriesList):
       return seriesList
   if system:
-      fmt = lambda x:"%.2f%s" % format_units(x,system=system)
+      if units:
+          fmt = lambda x:"%.2f %s" % format_units(x,system=system,units=units)
+      else:
+          fmt = lambda x:"%.2f%s" % format_units(x,system=system)
   else:
-      fmt = lambda x:"%.2f"%x
+      if units:
+          fmt = lambda x:"%.2f %s"%(x,units)
+      else:
+          fmt = lambda x:"%.2f"%x
   nameLen = max([0] + [len(getattr(series,"name")) for series in seriesList])
   lastLen = max([0] + [len(fmt(int(safeLast(series) or 3))) for series in seriesList]) + 3
   maxLen = max([0] + [len(fmt(int(safeMax(series) or 3))) for series in seriesList]) + 3

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1965,7 +1965,7 @@ def format_units(v, step=None, system='si', units=None):
   if units:
     prefix = units
   else:
-    prefix=''
+    prefix = ''
   return v, prefix
 
 

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1933,7 +1933,7 @@ def sort_stacked(series_list):
   return stacked + not_stacked
 
 
-def format_units(v, step=None, system="si"):
+def format_units(v, step=None, system='si', units=None):
   """Format the given value in standardized units.
 
   ``system`` is either 'binary' or 'si'
@@ -1944,7 +1944,7 @@ def format_units(v, step=None, system="si"):
   """
 
   if v is None:
-    return v, ""
+    return v, ''
 
   if step is None:
     condition = lambda size: abs(v) >= size
@@ -1956,11 +1956,17 @@ def format_units(v, step=None, system="si"):
       v2 = v / size
       if (v2 - math.floor(v2)) < 0.00000000001 and v > 1:
         v2 = math.floor(v2)
+      if units:
+        prefix = "%s%s" % (prefix, units)
       return v2, prefix
 
   if (v - math.floor(v)) < 0.00000000001 and v > 1 :
     v = math.floor(v)
-  return v, ""
+  if units:
+    prefix = units
+  else:
+    prefix=''
+  return v, prefix
 
 
 def find_x_times(start_dt, unit, step):

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -1084,6 +1084,29 @@ class FunctionsTest(TestCase):
         result = functions.cactiStyle(request_context, seriesList)
         self.assertEqual(result, expectedResult)
 
+    def test_cactiStyle_units(self):
+        seriesList = [
+            TimeSeries('collectd.test-db1.load.value',0,600,60,[1,2,3,4,5,6,7,8,9,10]),
+            TimeSeries('collectd.test-db2.load.value',0,600,60,[None,None,None,None,None,None,None,None,None,None]),
+            TimeSeries('collectd.test-db3.load.value',0,600,60,[1,2,None,None,None,6,7,8,9,10]),
+            TimeSeries('collectd.test-db4.load.value',0,600,60,[1,2,3,4,5,6,7,8,9,None]),
+        ]
+        for series in seriesList:
+            series.pathExpression = series.name
+        expectedResult = [
+            TimeSeries('collectd.test-db1.load.value Current:10.00 b    Max:10.00 b    Min:1.00 b    ',0,600,60,[1,2,3,4,5,6,7,8,9,10]),
+            TimeSeries('collectd.test-db2.load.value Current:nan        Max:nan        Min:nan       ',0,600,60,[None,None,None,None,None,None,None,None,None,None]),
+            TimeSeries('collectd.test-db3.load.value Current:10.00 b    Max:10.00 b    Min:1.00 b    ',0,600,60,[1,2,None,None,None,6,7,8,9,10]),
+            TimeSeries('collectd.test-db4.load.value Current:9.00 b     Max:9.00 b     Min:1.00 b    ',0,600,60,[1,2,3,4,5,6,7,8,9,None]),
+        ]
+        for series in expectedResult:
+            series.options = {}
+
+        request_context = {}
+        result = functions.cactiStyle(request_context, seriesList, units="b")
+        self.assertEqual(result, expectedResult)
+
+
     def test_cactiStyle_emptyList(self):
         result = functions.cactiStyle({}, [])
         self.assertEqual(result, [])
@@ -1109,6 +1132,29 @@ class FunctionsTest(TestCase):
         request_context = {}
         result = functions.cactiStyle(request_context, seriesList, "binary")
         self.assertEqual(result, expectedResult)
+
+    def test_cactiStyle_binary_units(self):
+        seriesList = [
+            TimeSeries('collectd.test-db1.load.value',0,600,60,[1,2,3,4,5,6,7,8,9,10]),
+            TimeSeries('collectd.test-db2.load.value',0,600,60,[None,None,None,None,None,None,None,None,None,None]),
+            TimeSeries('collectd.test-db3.load.value',0,600,60,[1,2,None,None,None,6,7,8,9,10]),
+            TimeSeries('collectd.test-db4.load.value',0,600,60,[1,2,3,4,5,6,7,8,9,None]),
+        ]
+        for series in seriesList:
+            series.pathExpression = series.name
+        expectedResult = [
+            TimeSeries('collectd.test-db1.load.value Current:10.00 b    Max:10.00 b    Min:1.00 b    ',0,600,60,[1,2,3,4,5,6,7,8,9,10]),
+            TimeSeries('collectd.test-db2.load.value Current:nan        Max:nan        Min:nan       ',0,600,60,[None,None,None,None,None,None,None,None,None,None]),
+            TimeSeries('collectd.test-db3.load.value Current:10.00 b    Max:10.00 b    Min:1.00 b    ',0,600,60,[1,2,None,None,None,6,7,8,9,10]),
+            TimeSeries('collectd.test-db4.load.value Current:9.00 b     Max:9.00 b     Min:1.00 b    ',0,600,60,[1,2,3,4,5,6,7,8,9,None]),
+        ]
+        for series in expectedResult:
+            series.options = {}
+
+        request_context = {}
+        result = functions.cactiStyle(request_context, seriesList, "binary", "b")
+        self.assertEqual(result, expectedResult)
+
 
     def test_n_percentile(self):
         config = [

--- a/webapp/tests/test_render_glyph.py
+++ b/webapp/tests/test_render_glyph.py
@@ -249,44 +249,76 @@ class glyphStandaloneFunctionTest(TestCase):
     # Testing of format_units
     #
     def test_format_units_defaults(self):
-      # Tests (input, result, 'Error String')
+      # Tests (input, result, prefix, 'Error String')
       tests = [
-               (1, 1, 'format_units(1) != 1'),
-               (1.0, 1.0, 'format_units(1.0) != 1.0'),
-               (0.001, 0.001, 'format_units(0.001) != 0.001')
+               (1, 1, '', 'format_units(1) != 1'),
+               (1.0, 1.0, '', 'format_units(1.0) != 1.0'),
+               (0.001, 0.001, '', 'format_units(0.001) != 0.001'),
+               (1000, 1.0, 'k', 'format_units(1000) != 1.0 k'),
+               (1000000, 1.0, 'M', 'format_units(1000000) != 1.0 M'),
               ]
-      for (t,r,e) in tests:
-          self.assertEqual(glyph.format_units(t), (r, ''), e)
+      for (t,r,p,e) in tests:
+          self.assertEqual(glyph.format_units(t), (r, p), e)
 
     def test_format_units_val_None_defaults(self):
-      # Tests (input, result, 'Error String')
+      # Tests (input, result, prefix, 'Error String')
       tests = [
-               (1, 1, 'format_units(1, None) != 1'),
-               (1.0, 1.0, 'format_units(1.0, None) != 1.0'),
-               (0.001, 0.001, 'format_units(0.001, None) != 0.001')
+               (1, 1, '', 'format_units(1, None) != 1'),
+               (1.0, 1.0,'',  'format_units(1.0, None) != 1.0'),
+               (0.001, 0.001, '', 'format_units(0.001, None) != 0.001'),
+               (1000, 1.0, 'k', 'format_units(1000, None) != 1.0 k'),
+               (1000000, 1.0, 'M', 'format_units(1000000, None) != 1.0 M'),
               ]
-      for (t,r,e) in tests:
-          self.assertEqual(glyph.format_units(t, None), (r, ''), e)
+      for (t,r,p,e) in tests:
+          self.assertEqual(glyph.format_units(t, None), (r, p), e)
 
     def test_format_units_v_None_si(self):
-      # Tests (input, result, 'Error String')
+      # Tests (input, result, prefix, 'Error String')
       tests = [
-               (1, 1, 'format_units(1, None, \'si\') != 1'),
-               (1.0, 1.0, 'format_units(1.0, None, \'si\') != 1.0'),
-               (0.001, 0.001, 'format_units(0.001, None, \'si\') != 0.001')
+               (1, 1, '', 'format_units(1, None, \'si\') != 1'),
+               (1.0, 1.0, '', 'format_units(1.0, None, \'si\') != 1.0'),
+               (0.001, 0.001, '', 'format_units(0.001, None, \'si\') != 0.001'),
+               (1000, 1.0, 'k', 'format_units(1000, None, \'si\') != 1.0 k'),
+               (1000000, 1.0, 'M', 'format_units(1000000, None, \'si\') != 1.0 M'),
               ]
-      for (t,r,e) in tests:
-          self.assertEqual(glyph.format_units(t, None, 'si'), (r, ''), e)
+      for (t,r,p,e) in tests:
+          self.assertEqual(glyph.format_units(t, None, 'si'), (r, p), e)
+
+    def test_format_units_v_None_si_units(self):
+      # Tests (input, result, prefix, 'Error String')
+      tests = [
+               (1, 1, 'b', 'format_units(1, None, \'si\', \'b\') != 1'),
+               (1.0, 1.0, 'b', 'format_units(1.0, None, \'si\', \'b\') != 1.0'),
+               (0.001, 0.001, 'b', 'format_units(0.001, None, \'si\', \'b\') != 0.001'),
+               (1000, 1.0, 'kb', 'format_units(1000, None, \'si\', \'b\') != 1.0 kb'),
+               (1000000, 1.0, 'Mb', 'format_units(1000000, None, \'si\', \'b\') != 1.0 Mb'),
+              ]
+      for (t,r,p,e) in tests:
+          self.assertEqual(glyph.format_units(t, None, 'si', 'b'), (r, p), e)
 
     def test_format_units_v_step_si(self):
-      # Tests (input, step, result, 'Error String')
+      # Tests (input, step, result, prefix, 'Error String')
       tests = [
-               (1, 100, 1, 'format_units(1, 100, \'si\') != 1'),
-               (1.0, 100, 1.0, 'format_units(1.0, 100, \'si\') != 1.0'),
-               (0.001, 100, 0.001, 'format_units(0.001, 100, \'si\') != 0.001')
+               (1, 100, 1, '', 'format_units(1, 100, \'si\') != 1'),
+               (1.0, 100, 1.0, '', 'format_units(1.0, 100, \'si\') != 1.0'),
+               (0.001, 100, 0.001, '', 'format_units(0.001, 100, \'si\') != 0.001'),
+               (1000, 100, 1000.0, '', 'format_units(1000, 100, \'si\') != 1000.0'),
+               (1000000, 100, 1000000.0, '', 'format_units(1000000, 100, \'si\') != 1000000.0'),
               ]
-      for (t,s,r,e) in tests:
-          self.assertEqual(glyph.format_units(t, s, 'si'), (r, ''), e)
+      for (t,s,r,p,e) in tests:
+          self.assertEqual(glyph.format_units(t, s, 'si'), (r, p), e)
+
+    def test_format_units_v_step_si_units(self):
+      # Tests (input, step, result, prefix, 'Error String')
+      tests = [
+               (1, 100, 1, 'b', 'format_units(1, 100, \'si\', \'b\') != 1'),
+               (1.0, 100, 1.0, 'b', 'format_units(1.0, 100, \'si\', \'b\') != 1.0'),
+               (0.001, 100, 0.001, 'b', 'format_units(0.001, 100, \'si\', \'b\') != 0.001'),
+               (1000, 100, 1000.0, 'b', 'format_units(1000, 100, \'si\', \'b\') != 1000.0'),
+               (1000000, 100, 1000000.0, 'b', 'format_units(1000000, 100, \'si\', \'b\') != 1000000.0'),
+              ]
+      for (t,s,r,p,e) in tests:
+          self.assertEqual(glyph.format_units(t, s, 'si', 'b'), (r, p), e)
 
     #
     # Testing of find_x_times()


### PR DESCRIPTION
This PR supersedes #682, resolving a merge conflict and fixing the original change to pass tests. Fixes #671.

@toni-moreno I believe this accomplishes the same goal with less code. Please review and let me know if I left anything out.

Example:
```
target=cactiStyle(scale(collectd.graphite.filecount-whisper.files,20),"binary","b")
```

![127 0 0](https://cloud.githubusercontent.com/assets/494338/17225291/63db5ed0-54d2-11e6-8be6-7d34405eae17.png)
