### PR TITLE
Add nodelist format to metrics find view

### DIFF
--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -80,6 +80,7 @@ def find_view(request):
   wildcards = int( queryParams.get('wildcards', 0) )
   fromTime = int( queryParams.get('from', -1) )
   untilTime = int( queryParams.get('until', -1) )
+  nodePosition = int( queryParams.get('position', -1) )
   jsonp = queryParams.get('jsonp', False)
 
   if fromTime == -1:
@@ -124,6 +125,10 @@ def find_view(request):
 
   if format == 'treejson':
     content = tree_json(matches, base_path, wildcards=profile.advancedUI or wildcards)
+    response = json_response_for(request, content)
+
+  elif format == 'nodelist':
+    content = nodes_by_position(matches, nodePosition)
     response = json_response_for(request, content)
 
   elif format == 'pickle':
@@ -287,6 +292,16 @@ def tree_json(nodes, base_path, wildcards=False):
 
   results.extend(results_branch)
   results.extend(results_leaf)
+  return results
+
+
+def nodes_by_position(matches, position):
+  found = set()
+
+  for metric in matches:
+    nodes = metric.path.split('.')
+    found.add(nodes[position])
+  results = { 'nodes' : sorted(found) }
   return results
 
 

--- a/webapp/tests/test_metrics.py
+++ b/webapp/tests/test_metrics.py
@@ -253,6 +253,39 @@ class MetricsTester(TestCase):
         data = json.loads(content.split("(")[1].strip(")"))
         self.assertEqual(data['metrics'], [])
 
+        #
+        # format=nodelist
+        #
+        request=copy.deepcopy(request_default)
+        request['format']='nodelist'
+        request['query']='*'
+        content = test_find_view_basics(request)
+        data = json.loads(content)
+        self.assertEqual(data, {u'nodes': [u'hosts']})
+
+        request=copy.deepcopy(request_default)
+        request['format']='nodelist'
+        request['query']='*.*'
+        content = test_find_view_basics(request)
+        data = json.loads(content)
+        self.assertEqual(data, {u'nodes': [u'worker1', u'worker2']})
+
+        request=copy.deepcopy(request_default)
+        request['format']='nodelist'
+        request['query']='*.*.*'
+        content = test_find_view_basics(request)
+        data = json.loads(content)
+        self.assertEqual(data, {u'nodes': [u'cpu']})
+
+        # override node position
+        request=copy.deepcopy(request_default)
+        request['format']='nodelist'
+        request['query']='*.*.*'
+        request['position']='0'
+        content = test_find_view_basics(request)
+        data = json.loads(content)
+        self.assertEqual(data, {u'nodes': [u'hosts']})
+
 
     def test_expand_view(self):
         self.create_whisper_hosts()


### PR DESCRIPTION
This is a new implementation of @toni-moreno's proposed change in https://github.com/graphite-project/graphite-web/pull/718. I believe this is a cleaner approach, extending `/metrics/find/` with a new `format=nodelist` parameter. The optional `position` parameter allows the user to override the default (`-1`) node index.

/cc @brutasse @cbowman0 

```
$ curl -k "https://127.0.0.1:443/metrics/find/?query=carbon.*.*.*&format=nodelist&position=2"
"{'nodes': ['vagrant-1']}"

$ curl -k "https://127.0.0.1:443/metrics/find/?query=carbon.*.*.*&format=nodelist"
"{'nodes': ['activeConnections', 'avgUpdateTime', 'blacklistMatches', 'cache', 'committedPoints', 'cpuUsage', 'creates', 'droppedCreates', 'errors', 'memUsage', 'metricsReceived', 'pointsPerUpdate', 'updateOperations', 'whitelistRejects']}"
```