### PR TITLE
Add verticalLine function

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2864,11 +2864,6 @@ def verticalLine(requestContext, ts, label=None, color=None):
   return [series]
 
 
-def horizontalLine(**kwargs):
-  # suggest deprecating constantLine
-  threshold(**kwargs)
-
-
 def threshold(requestContext, value, label=None, color=None):
   """
   Takes a float F, followed by a label (in double quotes) and a color.

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -3790,7 +3790,6 @@ SeriesFunctions = {
   'threshold': threshold,
   'transformNull': transformNull,
   'isNonNull': isNonNull,
-  'horizontalLine' : horizontalLine,
   'threshold' : threshold,
   'verticalLine' : verticalLine,
   'identity': identity,

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2828,7 +2828,7 @@ def aggregateLine(requestContext, seriesList, func='avg'):
 
 def verticalLine(requestContext, ts, label=None, color=None):
   """
-  Takes a timestamp string.
+  Takes a timestamp string ts.
 
   Draws a vertical line at the designated timestamp with optional
   'label' and 'color'. Supported timestamp formats include both
@@ -2852,9 +2852,9 @@ def verticalLine(requestContext, ts, label=None, color=None):
   start = timestamp( requestContext['startTime'] )
   end = timestamp( requestContext['endTime'] )
   if ts < start:
-    raise ValueError('verticalLine(): ts is < start')
+    raise ValueError("verticalLine(): timestamp %s exists before start of range" % ts)
   elif ts > end:
-    raise ValueError('verticalLine(): ts is > end')
+    raise ValueError("verticalLine(): timestamp %s exists after end of range" % ts)
   start = end = ts
   step = 1.0
   series = TimeSeries(label, start, end, step, [1.0, 1.0])

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2848,9 +2848,9 @@ def verticalLine(requestContext, ts, label=None, color=None):
     &target=verticalLine("-5mins")
 
   """
-  ts = timestamp( parseATTime(ts, requestContext['tzinfo']) )
-  start = timestamp( requestContext['startTime'] )
-  end = timestamp( requestContext['endTime'] )
+  ts = int(timestamp( parseATTime(ts, requestContext['tzinfo']) ))
+  start = int(timestamp( requestContext['startTime'] ))
+  end = int(timestamp( requestContext['endTime'] ))
   if ts < start:
     raise ValueError("verticalLine(): timestamp %s exists before start of range" % ts)
   elif ts > end:

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -55,6 +55,7 @@ def renderView(request):
     'endTime' : requestOptions['endTime'],
     'localOnly' : requestOptions['localOnly'],
     'template' : requestOptions['template'],
+    'tzinfo' : requestOptions['tzinfo'],
     'data' : []
   }
   data = requestContext['data']

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -1484,7 +1484,7 @@ class FunctionsTest(TestCase):
                           'tzinfo':pytz.utc,
                          }
         result = functions.verticalLine(requestContext, "01:0019700101", "foo")
-        expectedResult = [ TimeSeries('foo',3600.0,3600.0,1.0,[1.0, 1.0]), ]
+        expectedResult = [ TimeSeries('foo',3600,3600,1.0,[1.0, 1.0]), ]
         expectedResult[0].options = {'drawAsInfinite': True}
         self.assertEqual(result, expectedResult)
 
@@ -1495,7 +1495,7 @@ class FunctionsTest(TestCase):
                           'tzinfo':pytz.utc,
                          }
         result = functions.verticalLine(requestContext, "01:0019700101", "foo", "white")
-        expectedResult = [ TimeSeries('foo',3600.0,3600.0,1.0,[1.0, 1.0]), ]
+        expectedResult = [ TimeSeries('foo',3600,3600,1.0,[1.0, 1.0]), ]
         expectedResult[0].options = {'drawAsInfinite': True}
         expectedResult[0].color = "white"
         self.assertEqual(result, expectedResult)
@@ -1506,7 +1506,7 @@ class FunctionsTest(TestCase):
                           'endTime':datetime(1971,1,1,1,2,0,0,pytz.timezone(settings.TIME_ZONE)),
                           'tzinfo':pytz.utc,
                          }
-        with self.assertRaisesRegexp(ValueError, "verticalLine\(\): timestamp 3600.0 exists before start of range"):
+        with self.assertRaisesRegexp(ValueError, "verticalLine\(\): timestamp 3600 exists before start of range"):
             result = functions.verticalLine(requestContext, "01:0019700101", "foo")
 
     def test_vertical_line_after_end(self):
@@ -1515,7 +1515,7 @@ class FunctionsTest(TestCase):
                           'endTime':datetime(1970,1,1,1,2,0,0,pytz.timezone(settings.TIME_ZONE)),
                           'tzinfo':pytz.utc,
                          }
-        with self.assertRaisesRegexp(ValueError, "verticalLine\(\): timestamp 31539600.0 exists after end of range"):
+        with self.assertRaisesRegexp(ValueError, "verticalLine\(\): timestamp 31539600 exists after end of range"):
             result = functions.verticalLine(requestContext, "01:0019710101", "foo")
 
     def test_line_width(self):

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -1478,10 +1478,45 @@ class FunctionsTest(TestCase):
         self._verify_series_options(results, "drawAsInfinite", True)
 
     def test_vertical_line(self):
-        seriesList = self._generate_series_list()
-        result = functions.verticalLine({'tzinfo' : '1470080529'}, "foo")
-        expectedResult = [ TimeSeries('foo',0,1,1,[1.0]), ]
+        requestContext = {
+                          'startTime': datetime(1970,1,1,1,0,0,0,pytz.timezone(settings.TIME_ZONE)),
+                          'endTime':datetime(1970,1,1,1,2,0,0,pytz.timezone(settings.TIME_ZONE)),
+                          'tzinfo':pytz.utc,
+                         }
+        result = functions.verticalLine(requestContext, "01:0019700101", "foo")
+        expectedResult = [ TimeSeries('foo',3600.0,3600.0,1.0,[1.0, 1.0]), ]
+        expectedResult[0].options = {'drawAsInfinite': True}
         self.assertEqual(result, expectedResult)
+
+    def test_vertical_line_color(self):
+        requestContext = {
+                          'startTime': datetime(1970,1,1,1,0,0,0,pytz.timezone(settings.TIME_ZONE)),
+                          'endTime':datetime(1970,1,1,1,2,0,0,pytz.timezone(settings.TIME_ZONE)),
+                          'tzinfo':pytz.utc,
+                         }
+        result = functions.verticalLine(requestContext, "01:0019700101", "foo", "white")
+        expectedResult = [ TimeSeries('foo',3600.0,3600.0,1.0,[1.0, 1.0]), ]
+        expectedResult[0].options = {'drawAsInfinite': True}
+        expectedResult[0].color = "white"
+        self.assertEqual(result, expectedResult)
+
+    def test_vertical_line_before_start(self):
+        requestContext = {
+                          'startTime': datetime(1971,1,1,1,0,0,0,pytz.timezone(settings.TIME_ZONE)),
+                          'endTime':datetime(1971,1,1,1,2,0,0,pytz.timezone(settings.TIME_ZONE)),
+                          'tzinfo':pytz.utc,
+                         }
+        with self.assertRaisesRegexp(ValueError, "verticalLine\(\): timestamp 3600.0 exists before start of range"):
+            result = functions.verticalLine(requestContext, "01:0019700101", "foo")
+
+    def test_vertical_line_after_end(self):
+        requestContext = {
+                          'startTime': datetime(1970,1,1,1,0,0,0,pytz.timezone(settings.TIME_ZONE)),
+                          'endTime':datetime(1970,1,1,1,2,0,0,pytz.timezone(settings.TIME_ZONE)),
+                          'tzinfo':pytz.utc,
+                         }
+        with self.assertRaisesRegexp(ValueError, "verticalLine\(\): timestamp 31539600.0 exists after end of range"):
+            result = functions.verticalLine(requestContext, "01:0019710101", "foo")
 
     def test_line_width(self):
         seriesList = self._generate_series_list()

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -1477,6 +1477,12 @@ class FunctionsTest(TestCase):
         results = functions.drawAsInfinite({}, seriesList)
         self._verify_series_options(results, "drawAsInfinite", True)
 
+    def test_vertical_line(self):
+        seriesList = self._generate_series_list()
+        result = functions.verticalLine({'tzinfo' : '1470080529'}, "foo")
+        expectedResult = [ TimeSeries('foo',0,1,1,[1.0]), ]
+        self.assertEqual(result, expectedResult)
+
     def test_line_width(self):
         seriesList = self._generate_series_list()
         width = 10


### PR DESCRIPTION
This PR supersedes #493, introducing the `verticalLine` function by @nharkins. I've resolved merge conflicts and enhanced the function documentation a bit. Took a stab at a unit test but I'm hitting problems with the attime stuff.

/cc @cbowman0 for his usual testing brilliance