### PR TITLE
Make Timeseries equality test check for color

### DIFF
--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -34,8 +34,17 @@ class TimeSeries(list):
 
   def __eq__(self, other):
     if isinstance(other, TimeSeries):
+      color_check = True
+      if hasattr(self, 'color'):
+        if hasattr(other, 'color'):
+          color_check = (self.color == other.color)
+        else:
+          color_check = False
+      elif hasattr(other, 'color'):
+        color_check = False
+
       return ((self.name, self.start, self.end, self.step, self.consolidationFunc, self.valuesPerPoint, self.options) ==
-              (other.name, other.start, other.end, other.step, other.consolidationFunc, other.valuesPerPoint, other.options)) and list.__eq__(self, other)
+              (other.name, other.start, other.end, other.step, other.consolidationFunc, other.valuesPerPoint, other.options)) and list.__eq__(self, other) and color_check
     return False
 
 

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -2307,6 +2307,7 @@ class FunctionsTest(TestCase):
         expectedResult = [
             TimeSeries('MyLine', 3600, 3600, 0, [7.0, 7.0, 7.0]),
         ]
+        expectedResult[0].color='blue'
         requestContext = {
                           'startTime': datetime(1970,1,1,1,0,0,0,pytz.timezone(settings.TIME_ZONE)),
                           'endTime':datetime(1970,1,1,1,0,0,0,pytz.timezone(settings.TIME_ZONE))

--- a/webapp/tests/test_render_datalib.py
+++ b/webapp/tests/test_render_datalib.py
@@ -19,6 +19,30 @@ class TimeSeriesTest(TestCase):
       with self.assertRaises(AssertionError):
         self.assertEqual(values, series)
 
+    def test_TimeSeries_equal_list_color(self):
+      values = range(0,100)
+      series1 = TimeSeries("collectd.test-db.load.value", 0, len(values), 1, values)
+      series1.color = 'white'
+      series2 = TimeSeries("collectd.test-db.load.value", 0, len(values), 1, values)
+      series2.color = 'white'
+      self.assertEqual(series1, series2)
+
+    def test_TimeSeries_equal_list_color_bad(self):
+      values = range(0,100)
+      series1 = TimeSeries("collectd.test-db.load.value", 0, len(values), 1, values)
+      series2 = TimeSeries("collectd.test-db.load.value", 0, len(values), 1, values)
+      series2.color = 'white'
+      with self.assertRaises(AssertionError):
+        self.assertEqual(series1, series2)
+
+    def test_TimeSeries_equal_list_color_bad2(self):
+      values = range(0,100)
+      series1 = TimeSeries("collectd.test-db.load.value", 0, len(values), 1, values)
+      series2 = TimeSeries("collectd.test-db.load.value", 0, len(values), 1, values)
+      series1.color = 'white'
+      with self.assertRaises(AssertionError):
+        self.assertEqual(series1, series2)
+
     def test_TimeSeries_getInfo(self):
       values = range(0,100)
       series = TimeSeries("collectd.test-db.load.value", 0, len(values), 1, values)


### PR DESCRIPTION
The color attribute is not expected to always be there.  If it does exist, then check for equality.

I'm not 100% satisfied on the pythonic way of doing this sort of logic, so code cleanup suggestions is welcome.