### PR TITLE
Ability to GET single event in json

### DIFF
--- a/webapp/graphite/compat.py
+++ b/webapp/graphite/compat.py
@@ -1,4 +1,7 @@
+import json
+
 from django import VERSION
+from django.core.serializers.json import DjangoJSONEncoder
 from django.http import (HttpResponse as BaseHttpResponse,
                          HttpResponseBadRequest as Base400)
 
@@ -16,3 +19,21 @@ class HttpResponse(ContentTypeMixin, BaseHttpResponse):
 
 class HttpResponseBadRequest(ContentTypeMixin, Base400):
     pass
+
+
+class JsonResponse(HttpResponse):
+    # Django < 1.7 does not have JsonResponse
+    # https://github.com/django/django/commit/024213
+    # https://github.com/django/django/blob/master/LICENSE
+    def __init__(self, data, encoder=DjangoJSONEncoder, safe=True,
+                 json_dumps_params=None, **kwargs):
+        if safe and not isinstance(data, dict):
+            raise TypeError(
+                'In order to allow non-dict objects to be serialized set the '
+                'safe parameter to False.'
+            )
+        if json_dumps_params is None:
+            json_dumps_params = {}
+        kwargs.setdefault('content_type', 'application/json')
+        data = json.dumps(data, cls=encoder, **json_dumps_params)
+        super(JsonResponse, self).__init__(content=data, **kwargs)

--- a/webapp/graphite/events/views.py
+++ b/webapp/graphite/events/views.py
@@ -8,7 +8,7 @@ except ImportError:  # Django < 1.9
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.forms.models import model_to_dict
-from django.http import HttpResponseNotFound, JsonResponse
+from django.http import JsonResponse
 from django.shortcuts import render_to_response, get_object_or_404
 from django.utils.timezone import now, make_aware
 

--- a/webapp/graphite/events/views.py
+++ b/webapp/graphite/events/views.py
@@ -8,7 +8,7 @@ except ImportError:  # Django < 1.9
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.forms.models import model_to_dict
-from django.http import HttpResponseNotFound
+from django.http import HttpResponseNotFound, JsonResponse
 from django.shortcuts import render_to_response, get_object_or_404
 from django.utils.timezone import now, make_aware
 
@@ -40,15 +40,11 @@ def detail(request, event_id):
         try:
            e = Event.objects.get(id=event_id)
            e.tags = e.tags.split()
-           response = HttpResponse(
-               json.dumps(model_to_dict(e), cls=EventEncoder),
-               content_type='application/json')
+           response = JsonResponse(model_to_dict(e))
            return response
         except ObjectDoesNotExist:
            error = {'error': 'Event matching query does not exist'}
-           response = HttpResponseNotFound(
-               json.dumps(error, cls=EventEncoder),
-               content_type='application/json')
+           response = JsonResponse(error, status=404)
            return response
     else:
         e = get_object_or_404(Event, pk=event_id)

--- a/webapp/graphite/events/views.py
+++ b/webapp/graphite/events/views.py
@@ -8,11 +8,10 @@ except ImportError:  # Django < 1.9
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.forms.models import model_to_dict
-from django.http import JsonResponse
 from django.shortcuts import render_to_response, get_object_or_404
 from django.utils.timezone import now, make_aware
 
-from graphite.compat import HttpResponse
+from graphite.compat import HttpResponse, JsonResponse
 from graphite.util import json, epoch
 from graphite.events.models import Event
 from graphite.render.attime import parseATTime

--- a/webapp/tests/test_events.py
+++ b/webapp/tests/test_events.py
@@ -104,3 +104,10 @@ class EventTest(TestCase):
         event = json.loads(response.content)
         self.assertEqual(event['what'], 'Something happened')
         self.assertEqual(event['tags'], ['foo', 'bar'])
+
+    def test_get_detail_json_object_does_not_exist(self):
+        url = reverse('events_detail', args=[1])
+        response = self.client.get(url, {}, HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 404)
+        event = json.loads(response.content)
+        self.assertEqual(event['error'], 'Event matching query does not exist')

--- a/webapp/tests/test_events.py
+++ b/webapp/tests/test_events.py
@@ -86,3 +86,21 @@ class EventTest(TestCase):
         error = json.loads(response.content)
         self.assertEqual(error, {'error': '"tags" must be an array'})
         self.assertEqual(Event.objects.count(), 0)
+
+    def test_get_detail_json(self):
+        creation_url = reverse('graphite.events.views.view_events')
+        event = {
+            'what': 'Something happened',
+            'data': 'more info',
+            'tags': ['foo', 'bar'],
+        }
+        response = self.client.post(creation_url, json.dumps(event),
+                                    content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+
+        url = reverse('events_detail', args=[1])
+        response = self.client.get(url, {}, HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 200)
+        event = json.loads(response.content)
+        self.assertEqual(event['what'], 'Something happened')
+        self.assertEqual(event['tags'], ['foo', 'bar'])


### PR DESCRIPTION
First small step towards REST-ifying our Events support. There are no native consumers for this but it drives me nuts that you'd have to dump all events (`/events/get_data`) to inspect a single event from the command-line.

```
$ curl -s -k -H "Accept: application/json" "https://127.0.0.1/events/4/" | json_pp
{
   "id" : 4,
   "tags" : [
      "deploy",
      "stupid"
   ],
   "what" : "Event - deploy",
   "data" : "",
   "when" : 1469714975
}
```

Need to add a test for this before we merge. Will try to get this done soonish unless @cbowman0 beats me to it.