### PR TITLE
Expose django-tagging MAX_TAG_LENGTH setting

### DIFF
--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -69,6 +69,9 @@
 # Set URL_PREFIX when deploying graphite-web to a non-root location
 #URL_PREFIX = '/graphite'
 
+# Graphite uses Django Tagging to support tags in Events. By default each
+# tag is limited to 50 characters in length.
+#MAX_TAG_LENGTH = 50
 
 #####################################
 # Filesystem Paths #

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -92,6 +92,7 @@ STORAGE_FINDERS = (
     'graphite.finders.standard.StandardFinder',
 )
 MIDDLEWARE_CLASSES=''
+MAX_TAG_LENGTH = 50
 
 #Authentication settings
 USE_LDAP_AUTH = False


### PR DESCRIPTION
fixes #1635 