### PR TITLE
Tagging mixin to support set return types

### DIFF
--- a/docs/events.rst
+++ b/docs/events.rst
@@ -23,7 +23,7 @@ Events can be submitted via HTTP POST using command-line tools such as ``curl`` 
 .. code-block:: none
 
     $ curl -X POST "http://graphite/events/" 
-        -d '{ "what": "Event - deploy", "tags": "deploy", 
+        -d '{ "what": "Event - deploy", "tags": ["deploy"], 
         "data": "deploy of master branch happened at Wed Jul  6 22:34:41 UTC 2016" }'
 
 
@@ -60,7 +60,7 @@ It's also possible to dump the raw events using the API.
     [
        {
           "when" : 1392046352,
-          "tags" : "deploy",
+          "tags" : ["deploy"],
           "data" : "deploy of master branch happened at Fri Jan 3 22:34:41 UTC 2014",
           "id" : 2,
           "what" : "Event - deploy"
@@ -69,10 +69,12 @@ It's also possible to dump the raw events using the API.
           "id" : 3,
           "what" : "Event - deploy",
           "when" : 1392046661,
-          "tags" : "deploy",
+          "tags" : ["deploy"],
           "data" : "deploy of master branch happened at Fri Jan 3 22:34:41 UTC 2014"
        }
     ]
+
+The ``set`` parameter accepts an optional ``union`` or ``intersection`` argument to determine the behavior for filtering sets of tags (i.e. inclusive or exclusive). By default, Graphite uses a "lazy union" that will return any matching events for a given tag in a list of tags. This behavior is not intuitive and will therefore be deprecated in a future release.
 
 
 Managing Events in the Admin UI

--- a/webapp/graphite/events/compat.py
+++ b/webapp/graphite/events/compat.py
@@ -1,0 +1,13 @@
+
+from tagging.managers import (ModelTaggedItemManager as BaseModelTaggedItemManager,
+                            TaggedItem)
+
+class ContentTypeMixin(object):
+    def with_intersection(self, tags, queryset=None):
+        if queryset is None:
+            return TaggedItem.objects.get_intersection_by_model(self.model, tags)
+        else:
+            return TaggedItem.objects.get_intersection_by_model(queryset, tags)
+
+class ModelTaggedItemManager(ContentTypeMixin, BaseModelTaggedItemManager):
+    pass

--- a/webapp/graphite/events/models.py
+++ b/webapp/graphite/events/models.py
@@ -23,12 +23,12 @@ class Event(models.Model):
         return "%s: %s" % (self.when, self.what)
 
     @staticmethod
-    def find_events(time_from=None, time_until=None, tags=None, set=None):
+    def find_events(time_from=None, time_until=None, tags=None, set_operation=None):
 
         if tags is not None:
-            if set == 'union':
+            if set_operation == 'union':
                 query = Event.tagged.with_any(tags)
-            elif set == 'intersection':
+            elif set_operation == 'intersection':
                 query = Event.tagged.with_intersection(tags)
             else:
                 query = Event.tagged.with_all(tags)

--- a/webapp/graphite/events/models.py
+++ b/webapp/graphite/events/models.py
@@ -1,8 +1,9 @@
 import os
 
 from django.db import models
-from tagging.managers import ModelTaggedItemManager
 from tagging.models import Tag
+
+from graphite.events.compat import ModelTaggedItemManager
 
 if os.environ.get('READTHEDOCS'):
     TagField = lambda *args, **kwargs: None
@@ -22,10 +23,15 @@ class Event(models.Model):
         return "%s: %s" % (self.when, self.what)
 
     @staticmethod
-    def find_events(time_from=None, time_until=None, tags=None):
+    def find_events(time_from=None, time_until=None, tags=None, set=None):
 
         if tags is not None:
-            query = Event.tagged.with_all(tags)
+            if set == 'union':
+                query = Event.tagged.with_any(tags)
+            elif set == 'intersection':
+                query = Event.tagged.with_intersection(tags)
+            else:
+                query = Event.tagged.with_all(tags)
         else:
             query = Event.objects.all()
 

--- a/webapp/graphite/events/views.py
+++ b/webapp/graphite/events/views.py
@@ -25,11 +25,11 @@ class EventEncoder(json.JSONEncoder):
 
 
 def view_events(request):
-    if request.method == "GET":
+    if request.method == 'GET':
         context = {'events': fetch(request),
                    'site': RequestSite(request),
                    'protocol': 'https' if request.is_secure() else 'http'}
-        return render_to_response("events.html", context)
+        return render_to_response('events.html', context)
     else:
         return post_event(request)
 
@@ -48,7 +48,7 @@ def detail(request, event_id):
     else:
         e = get_object_or_404(Event, pk=event_id)
         context = {'event': e}
-        return render_to_response("event.html", context)
+        return render_to_response('event.html', context)
 
 
 def post_event(request):
@@ -91,24 +91,26 @@ def get_data(request):
     else:
         response = HttpResponse(
             json.dumps(fetch(request), cls=EventEncoder),
-            content_type="application/json")
+            content_type='application/json')
     return response
 
 
 def fetch(request):
-    if request.GET.get("from") is not None:
-        time_from = parseATTime(request.GET["from"])
+    if request.GET.get('from') is not None:
+        time_from = parseATTime(request.GET['from'])
     else:
         time_from = datetime.datetime.fromtimestamp(0)
 
-    if request.GET.get("until") is not None:
-        time_until = parseATTime(request.GET["until"])
+    if request.GET.get('until') is not None:
+        time_until = parseATTime(request.GET['until'])
     else:
         time_until = now()
 
-    tags = request.GET.get("tags")
+    set = request.GET.get('set')
+
+    tags = request.GET.get('tags')
     if tags is not None:
-        tags = request.GET.get("tags").split(" ")
+        tags = request.GET.get('tags').split(' ')
 
     return [x.as_dict() for x in
-            Event.find_events(time_from, time_until, tags=tags)]
+            Event.find_events(time_from, time_until, tags=tags, set=set)]

--- a/webapp/graphite/events/views.py
+++ b/webapp/graphite/events/views.py
@@ -106,11 +106,17 @@ def fetch(request):
     else:
         time_until = now()
 
-    set = request.GET.get('set')
+    set_operation = request.GET.get('set')
 
     tags = request.GET.get('tags')
     if tags is not None:
         tags = request.GET.get('tags').split(' ')
 
-    return [x.as_dict() for x in
-            Event.find_events(time_from, time_until, tags=tags, set=set)]
+    result = []
+    for x in Event.find_events(time_from, time_until, tags=tags, set_operation=set_operation):
+        if set_operation == 'intersection':
+            if len(set(tags) & set(x.as_dict()['tags'])) == len(tags):
+                result.append(x.as_dict())
+        else:
+            result.append(x.as_dict())
+    return result

--- a/webapp/graphite/events/views.py
+++ b/webapp/graphite/events/views.py
@@ -114,6 +114,9 @@ def fetch(request):
 
     result = []
     for x in Event.find_events(time_from, time_until, tags=tags, set_operation=set_operation):
+
+        # django-tagging's with_intersection() returns matches with unknown tags
+        # this is a workaround to ensure we only return positive matches
         if set_operation == 'intersection':
             if len(set(tags) & set(x.as_dict()['tags'])) == len(tags):
                 result.append(x.as_dict())


### PR DESCRIPTION
This introduces two new filtering options for searching events+tags. Turns out that graphite-web has used django-tagging's `with_all()`, returning a "lazy union" that is surprisingly unintuitive (see #1210).

With this change we're adding a mixin to expose django-tagging's `get_intersection_by_model`, and extending our Events model to accept a `set` param that lets the user select among the different set types:

* union
* intersection
* "lazy union" (legacy, default)

Fixes #1210.