### PR TITLE
Fix metric index build scripts

### DIFF
--- a/bin/build-index
+++ b/bin/build-index
@@ -2,8 +2,11 @@
 from graphite import settings
 from optparse import OptionParser
 import os
+import django
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "graphite.settings")
+django.setup()
+
 from graphite.util import write_index
 
 

--- a/bin/build-index.sh
+++ b/bin/build-index.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 export PYTHONPATH="/opt/graphite/webapp/:$PYTHONPATH"
-./build-index
+BINDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+${BINDIR}/build-index


### PR DESCRIPTION
The "build-index" scripts have been broken in master for a while. This includes a fix for modern Django as well as a path fix for the wrapper script.