### PR TITLE
Fixed jsonp support for metrics view

### DIFF
--- a/webapp/tests/test_metrics.py
+++ b/webapp/tests/test_metrics.py
@@ -17,7 +17,7 @@ class MetricsTester(TestCase):
     db = os.path.join(settings.WHISPER_DIR, 'test.wsp')
     hostcpu = os.path.join(settings.WHISPER_DIR, 'hosts/hostname/cpu.wsp')
 
-    settings.CLUSTER_SERVERS = ['127.0.0.1', '127.1.1.1']
+    settings.CLUSTER_SERVERS = ['127.1.1.1', '127.1.1.2']
 
     def wipe_whisper(self):
         try:

--- a/webapp/tests/test_metrics.py
+++ b/webapp/tests/test_metrics.py
@@ -63,14 +63,12 @@ class MetricsTester(TestCase):
         self.assertEqual(data[0], 'hosts.worker1.cpu')
         self.assertEqual(data[1], 'hosts.worker2.cpu')
 
-# This currently fails because there's no error checking on the urlopen()
-#        # cluster
-#        request = {'cluster': 1}
-#        response = self.client.post(url, request)
-#        self.assertEqual(response.status_code, 200)
-#        data = json.loads(response.content)
-#        self.assertEqual(data[0], 'hosts.worker1.cpu')
-#        self.assertEqual(data[1], 'hosts.worker2.cpu')
+        # cluster failure
+        request = {'cluster': 1}
+        response = self.client.post(url, request)
+        self.assertEqual(response.status_code, 500)
+        data = json.loads(response.content)
+        self.assertEqual(data, [])
 
         # jsonp
         request = {'jsonp': 'callback'}


### PR DESCRIPTION
This PR supersedes #733. Aside from rebasing, I've also added a handful more jsonp responses, fixed a potential minor bug with not allowing a single `CLUSTER_SERVERS`, and a test for cluster failures.

@cbowman0 Any ideas on how we could add a positive cluster query in our tests?