### PR TITLE
Handle missing divisor series in divideSeries gracefully

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -627,7 +627,14 @@ def divideSeries(requestContext, dividendSeriesList, divisorSeries):
 
 
   """
-  if len(divisorSeries) != 1:
+  if len(divisorSeries) == 0:
+    for series in dividendSeriesList:
+      series.name = "divideSeries(%s,MISSING)" % series.name
+      series.pathExpression = series.name
+      for i in range(len(series)):
+        series[i] = None
+    return dividendSeriesList
+  if len(divisorSeries) > 1:
     raise ValueError("divideSeries second argument must reference exactly 1 series (got {0})".format(len(divisorSeries)))
 
   divisorSeries = divisorSeries[0]


### PR DESCRIPTION
This PR supersedes #982, resolving conflicts. Thanks to @andrewbaxter for this change to pad the `dividendSeriesList` with nulls when a series goes out of scope.