### PR TITLE
Delay function (rebased)

### DIFF
--- a/webapp/content/js/composer_widgets.js
+++ b/webapp/content/js/composer_widgets.js
@@ -1089,6 +1089,7 @@ function createFunctionsMenu() {
         {text: 'Power', handler: applyFuncToEachWithInput('pow', 'Please enter a power factor')},
         {text: 'Square Root', handler: applyFuncToEach('squareRoot')},
         {text: 'Time-adjusted Derivative', handler: applyFuncToEachWithInput('perSecond', "Please enter a maximum value if this metric is a wrapping counter (or just leave this blank)", {allowBlank: true})},
+	{text: 'Delay', handler: applyFuncToEachWithInput('delay', 'Please enter the number of steps to delay')},
         {text: 'Integral', handler: applyFuncToEach('integral')},
 	{text: 'Integral by Interval', handler: applyFuncToEachWithInput('integralByInterval', 'Integral this metric with a reset every ___ (examples: 1d, 1h, 10min)', {quote: true})},
         {text: 'Percentile Values', handler: applyFuncToEachWithInput('percentileOfSeries', "Please enter the percentile to use")},

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1180,6 +1180,42 @@ def perSecond(requestContext, seriesList, maxValue=None):
     results.append(newSeries)
   return results
 
+def delay(requestContext, seriesList, steps):
+  """
+  This shifts all samples later by an integer number of steps. This can be
+  used for custom derivative calculations, among other things. Note: this
+  will pad the early end of the data with None for every step shifted.
+
+  This complements other time-displacement functions such as timeShift and
+  timeSlice, in that this function is indifferent about the step intervals
+  being shifted.
+
+  Example:
+
+  .. code-block:: none
+
+    &target=divideSeries(server.FreeSpace,delay(server.FreeSpace,1))
+
+  This computes the change in server free space as a percentage of the previous
+  free space.
+  """
+  results = []
+  for series in seriesList:
+    newValues = []
+    prev = []
+    for val in series:
+      if len(prev) < steps:
+        newValues.append(None)
+        prev.append(val)
+        continue
+      newValues.append(prev.pop(0))
+      prev.append(val)
+    newName = "delay(%s,%d)" % (series.name, steps)
+    newSeries = TimeSeries(newName, series.start, series.end, series.step, newValues)
+    newSeries.pathExpression = newName
+    results.append(newSeries)
+  return results
+
 def integral(requestContext, seriesList):
   """
   This will show the sum over time, sort of like a continuous addition function.
@@ -3699,6 +3735,7 @@ SeriesFunctions = {
   'offset': offset,
   'offsetToZero': offsetToZero,
   'derivative': derivative,
+  'delay': delay,
   'squareRoot': squareRoot,
   'pow': pow,
   'perSecond': perSecond,

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -638,6 +638,19 @@ class FunctionsTest(TestCase):
             result = functions.changed({}, series)
             self.assertEqual(result, expected)
 
+    def test_delay(self):
+        source = [
+            TimeSeries('collectd.test-db1.load.value',0,1,1,[range(18)] + [None, None]),
+        ]
+        delay = 2
+        expectedList = [
+            TimeSeries('delay(collectd.test-db1.load.value,2)',0,1,1,[None, None] + [range(18)]),
+        ]
+        gotList = functions.delay({}, source, delay)
+        self.assertEqual(len(gotList), len(expectedList))
+        for got, expected in zip(gotList, expectedList):
+            self.assertListEqual(got, expected)
+
     def test_asPercent_error(self):
         seriesList = [
             TimeSeries('collectd.test-db1.load.value',0,1,1,[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]),


### PR DESCRIPTION
This PR supersedes #984, adding a `delay()` function by @andrewbaxter. From his original description:

"This delays a series by a number of time steps. The delay method is the same as in derivative (Nones appended to the beginning).

Our immediate use case is computing a derivative using divideSeries, to find the percent difference from the previous data point."

The original feature branch has been deleted, making `git am` a painful affair. I've had to re-commit his original work with a couple fixes along the way. 