### PR TITLE
Unquote metric/target names

### DIFF
--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License."""
 import fnmatch
 import os
-import urllib2
+import urllib
 
 from django.conf import settings
 from graphite.compat import HttpResponse, HttpResponseBadRequest
@@ -64,9 +64,9 @@ def index_json(request):
   if cluster and len(settings.CLUSTER_SERVERS) >= 1:
     try:
       matches = reduce( lambda x, y: list(set(x + y)), \
-        [json.loads(urllib2.urlopen('http://' + cluster_server + '/metrics/index.json').read()) \
+        [json.loads(urllib.urlopen('http://' + cluster_server + '/metrics/index.json').read()) \
         for cluster_server in settings.CLUSTER_SERVERS])
-    except urllib2.URLError:
+    except urllib.URLError:
       log.exception()
       return json_response_for(request, matches, jsonp=jsonp, status=500)
   else:
@@ -287,7 +287,7 @@ def tree_json(nodes, base_path, wildcards=False):
 
     found.add(node.name)
     resultNode = {
-      'text' : str(node.name),
+      'text' : urllib.unquote_plus(str(node.name)),
       'id' : base_path + str(node.name),
     }
 

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1058,7 +1058,7 @@ class LineGraph(Graph):
       for series in self.data:
         if series.name:
           if not (params.get('hideNullFromLegend', False) and all(v is None for v in list(series))):
-            elements.append((series.name,series.color,series.options.get('secondYAxis')))
+            elements.append((unquote_plus(series.name),series.color,series.options.get('secondYAxis')))
       if len(elements) > 0:
         self.drawLegend(elements, params.get('uniqueLegend', False))
 


### PR DESCRIPTION
This PR supersedes #120 and fixes #242, merging conflicts and making a couple minor changes.

In some cases, users may wish to encode special characters into their metric names. With this change, graph legends and the metrics tree will show the unencoded version of the metric name (although the actual graph link remains encoded).

Tested an encoded metric name:

```
$ echo "foo.xxx.%28bar%29test%7E 1 `date +%s`" | nc localhost 2003
```

Visibly unquoted metric name in the metrics tree and graph legend, but still encoded in the actual query:

<img width="1280" alt="screen shot 2016-08-23 at 3 37 11 pm" src="https://cloud.githubusercontent.com/assets/494338/17906973/9badbd6a-6947-11e6-8fe5-8e4ee9b659aa.png">
