### PR TITLE
Duplicate instance of DEFAULT_CACHE_DURATION setting

### DIFF
--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -29,9 +29,6 @@
 # Override this to provide documentation specific to your Graphite deployment
 #DOCUMENTATION_URL = "http://graphite.readthedocs.io/"
 
-# Metric data and graphs are cached for one minute by default
-#DEFAULT_CACHE_DURATION = 60
-
 # Logging
 #LOG_ROTATION = True
 #LOG_ROTATION_COUNT = 1


### PR DESCRIPTION
A "missing" instance of `DEFAULT_CACHE_DURATION` was added to `local_settings.py.example` in  037f05d even though it was in fact already added back in f18bb3c. Let's remove the latter since the former is grouped with similar settings.