### PR TITLE
Fix datalib mergeResults function to properly handle time frames that are in the future compared to the cached results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,6 @@ dropin.cache
 *.egg-info
 docs/_build
 *.log
+*.iml
+storage
 *.pyc

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -496,6 +496,13 @@ def mergeResults(dbResults, cacheResults, lowest_step):
 
     try:
       i = int(interval - start) / step
+      if i < 0:
+          # cached data point is earlier then the requested data point.
+          # meaning we can definitely ignore the cache result.
+          # note that we cannot rely on the 'except'
+          # in this case since 'values[-n]=' is
+          # is equivalent to 'values[values.length - n]='
+          continue
       values[i] = value
     except:
       pass

--- a/webapp/tests/test_datalib.py
+++ b/webapp/tests/test_datalib.py
@@ -1,0 +1,41 @@
+from django.test import TestCase
+
+from graphite.render import datalib
+
+
+class DataLibTest(TestCase):
+
+    def test_mergeResults_query_window_when_previous_window_in_cache(self):
+
+        start = 1465844460  # (Mon Jun 13 19:01:00 UTC 2016)
+        window_size = 3600  # (1 hour)
+        step = 60           # (1 minute)
+
+        # simulate db data, no datapoints for the given
+        # time window
+        db_values = self._create_none_window(step)
+        time_info = (start, start + window_size, step)
+        db_results = (time_info, db_values)
+
+        # simulate cached data with datapoints only
+        # from the previous window
+        cache_results = []
+        prev_window_start = start - window_size
+        prev_window_end = prev_window_start + window_size
+        for i in range(prev_window_start, prev_window_end, step):
+            cache_results.append((i, 1))
+
+        # merge the db results with the cached results
+        merged_results = datalib.mergeResults(
+            dbResults=db_results,
+            cacheResults=cache_results,
+            lowest_step=step
+        )
+        # the merged results should be a None window because:
+        # - db results for the window are None
+        # - cache does not contain relevant points
+        self.assertEqual(self._create_none_window(step), merged_results[1])
+
+    @staticmethod
+    def _create_none_window(points_per_window):
+        return [None for _ in range(0, points_per_window)]


### PR DESCRIPTION
This PR resolves issue #1671 

The problem was that if it takes a long time writing data to disk, the carbon-cache will hold the results in memory. When graphite-web asks carbon for its data, it gives him the entire cache, which may hold older data than the query's time frame. The ``mergeResults`` function doesn't handle this scenario properly, and will mistakenly return the cache data, even though it is irrelevant.

Note that this issue exists in [master](https://github.com/graphite-project/graphite-web/blob/master/webapp/graphite/readers.py#L144) as well, however, only in the ``CeresReader``.

Should i create a PR against master as well?