### PR TITLE
Fix CeresReader fetch function to properly handle time frames that are in the future compared to the cached results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ docs/_build
 *.swp
 .idea
 *.iml
+storage

--- a/webapp/graphite/readers.py
+++ b/webapp/graphite/readers.py
@@ -137,16 +137,12 @@ class CeresReader(object):
       log.exception("Failed CarbonLink query '%s'" % self.real_metric_path)
       cached_datapoints = []
 
-    for (timestamp, value) in cached_datapoints:
-      interval = timestamp - (timestamp % data.timeStep)
+    values = merge_with_cache(cached_datapoints,
+                              data.startTime,
+                              data.timeStep,
+                              values)
 
-      try:
-        i = int(interval - data.startTime) / data.timeStep
-        values[i] = value
-      except:
-        pass
-
-    return (time_info, values)
+    return time_info, values
 
 
 class WhisperReader(object):
@@ -184,18 +180,12 @@ class WhisperReader(object):
     if isinstance(cached_datapoints, dict):
       cached_datapoints = cached_datapoints.items()
 
-    for (timestamp, value) in cached_datapoints:
-      interval = timestamp - (timestamp % step)
+    values = merge_with_cache(cached_datapoints,
+                              start,
+                              step,
+                              values)
 
-      try:
-        i = int(interval - start) / step
-        if i < 0:
-            continue
-        values[i] = value
-      except:
-        pass
-
-    return (time_info, values)
+    return time_info, values
 
 
 class GzippedWhisperReader(WhisperReader):
@@ -283,3 +273,19 @@ class RRDReader:
         retention_points = points
 
     return  retention_points * info['step']
+
+
+def merge_with_cache(cached_datapoints, start, step, values):
+
+  for (timestamp, value) in cached_datapoints:
+      interval = timestamp - (timestamp % step)
+
+      try:
+          i = int(interval - start) / step
+          if i < 0:
+              continue
+          values[i] = value
+      except:
+          pass
+
+  return values

--- a/webapp/graphite/readers.py
+++ b/webapp/graphite/readers.py
@@ -283,6 +283,11 @@ def merge_with_cache(cached_datapoints, start, step, values):
       try:
           i = int(interval - start) / step
           if i < 0:
+              # cached data point is earlier then the requested data point.
+              # meaning we can definitely ignore the cache result.
+              # note that we cannot rely on the 'except'
+              # in this case since 'values[-n]='
+              # is equivalent to 'values[len(values) - n]='
               continue
           values[i] = value
       except:

--- a/webapp/tests/test_readers.py
+++ b/webapp/tests/test_readers.py
@@ -1,0 +1,40 @@
+from django.test import TestCase
+
+from graphite import readers
+
+
+class ReadersTest(TestCase):
+
+    def test_merge_with_cache_when_previous_window_in_cache(self):
+
+        start = 1465844460  # (Mon Jun 13 19:01:00 UTC 2016)
+        window_size = 3600  # (1 hour)
+        step = 60           # (1 minute)
+
+        # simulate db data, no datapoints for the given
+        # time window
+        values = self._create_none_window(step)
+
+        # simulate cached data with datapoints only
+        # from the previous window
+        cache_results = []
+        prev_window_start = start - window_size
+        prev_window_end = prev_window_start + window_size
+        for i in range(prev_window_start, prev_window_end, step):
+            cache_results.append((i, 1))
+
+        # merge the db results with the cached results
+        values = readers.merge_with_cache(
+            cached_datapoints=cache_results,
+            start=start,
+            step=step,
+            values=values
+        )
+        # the merged results should be a None window because:
+        # - db results for the window are None
+        # - cache does not contain relevant points
+        self.assertEqual(self._create_none_window(step), values)
+
+    @staticmethod
+    def _create_none_window(points_per_window):
+        return [None for _ in range(0, points_per_window)]


### PR DESCRIPTION
This PR resolves issue #1671 for the master branch.