### PR TITLE
Use 0 cacheTimeout for ranges not covered by DEFAULT_CACHE_POLICY

### DIFF
--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -376,7 +376,8 @@ def parseOptions(request):
     timeRange = endTime - startTime
     queryTime = timeRange.days * 86400 + timeRange.seconds # convert the time delta to seconds
     if settings.DEFAULT_CACHE_POLICY and not queryParams.get('cacheTimeout'):
-      requestOptions['cacheTimeout'] = max(timeout for period,timeout in settings.DEFAULT_CACHE_POLICY if period <= queryTime)
+      timeouts = [timeout for period,timeout in settings.DEFAULT_CACHE_POLICY if period <= queryTime]
+      requestOptions['cacheTimeout'] = max(timeouts or (0,))
 
   return (graphOptions, requestOptions)
 


### PR DESCRIPTION
~~avoids~~

~~ValueError: max() arg is an empty sequence~~

~~if queryTime is not covered by `DEFAULT_CACHE_POLICY`which can happen if it doesn't have key `0`~~

On the second thought,if POLICY is specified, then user doesn't want to use default timeout. Futhermore, only possible uncovered interval is `[0,min(key))`, and cache intervals tend to be lower with lower interval values,  so it is natural to use cacheTimeout == 0 for uncovered intervals.

Together with #1680 it would mean "disable caching for short intervals"