### PR TITLE
Update tools.rst

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -108,6 +108,9 @@ Forwarding
 `Gruffalo`_
   An asynchronous Netty based graphite proxy, for large scale installations. It protects Graphite from the herds of clients by minimizing context switches and interrupts; by batching and aggregating metrics. Gruffalo also allows you to replicate metrics between Graphite installations for DR scenarios, for example.
 
+`Icinga 2 - graphite feature <http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/icinga2-features#graphite-carbon-cache-writer>`_
+  Icinga 2 will directly write metrics to the defined Graphite Carbon daemon tcp socket if the graphite feature is enabled. This feature is a more simple integration compared to Icinga 1.x and Graphios.
+
 `Ledbetter`_
   A simple script for gathering Nagios problem statistics and submitting them to Graphite. It focuses on summary (overall, servicegroup and hostgroup) statistics and writes them to the nagios.problems metrics namespace within Graphite.
 


### PR DESCRIPTION
Added a link to the URL for more info, as suggested. The graphite feature can be seen as an embedded Graphios script into the icinga2 software that automatically feeds performance data to the carbon daemon.