### PR TITLE
Add install_requires for pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ try:
         ['templates/*', 'local_settings.py.example']},
       scripts=glob('bin/*'),
       data_files=webapp_content.items() + storage_dirs + conf_files + examples,
+      install_requires=['Django', 'django-tagging', 'pytz', 'pyparsing', 'cairocffi', 'whitenoise'],
       classifiers=[
           'Intended Audience :: Developers',
           'Natural Language :: English',

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ try:
         ['templates/*', 'local_settings.py.example']},
       scripts=glob('bin/*'),
       data_files=webapp_content.items() + storage_dirs + conf_files + examples,
-      install_requires=['Django', 'django-tagging', 'pytz', 'pyparsing', 'cairocffi', 'whitenoise'],
+      install_requires=['Django', 'django-tagging', 'pytz', 'pyparsing', 'cairocffi'],
       classifiers=[
           'Intended Audience :: Developers',
           'Natural Language :: English',


### PR DESCRIPTION
When installing via pip we should handle these dependencies automatically, like Carbon does with Twisted.