### PR TITLE
Changed wording for clarity.

### DIFF
--- a/docs/config-database-setup.rst
+++ b/docs/config-database-setup.rst
@@ -14,10 +14,10 @@ See the
 for full documentation of the DATABASES setting.
 
 .. note ::
-  Remember, setting up a new database requires running ``PYTHONPATH=$GRAPHITE_ROOT/webapp django-admin.py migrate --settings=graphite.settings --run-syncdb`` to create the initial schema.
-
-.. note ::
   If you are using a custom database backend (other than SQLite) you must first create a $GRAPHITE_ROOT/webapp/graphite/local_settings.py file that overrides the database related settings from settings.py. Use $GRAPHITE_ROOT/webapp/graphite/local_settings.py.example as a template.
+
+To set up a new database and create the initial schema, run:
+``PYTHONPATH=$GRAPHITE_ROOT/webapp django-admin.py migrate --settings=graphite.settings --run-syncdb``
 
 If you are experiencing problems, uncomment the following line in /opt/graphite/webapp/graphite/local_settings.py:
 

--- a/docs/config-database-setup.rst
+++ b/docs/config-database-setup.rst
@@ -17,7 +17,10 @@ for full documentation of the DATABASES setting.
   If you are using a custom database backend (other than SQLite) you must first create a $GRAPHITE_ROOT/webapp/graphite/local_settings.py file that overrides the database related settings from settings.py. Use $GRAPHITE_ROOT/webapp/graphite/local_settings.py.example as a template.
 
 To set up a new database and create the initial schema, run:
-``PYTHONPATH=$GRAPHITE_ROOT/webapp django-admin.py migrate --settings=graphite.settings --run-syncdb``
+
+.. code-block:: none
+
+  PYTHONPATH=$GRAPHITE_ROOT/webapp django-admin.py migrate --settings=graphite.settings --run-syncdb``
 
 If you are experiencing problems, uncomment the following line in /opt/graphite/webapp/graphite/local_settings.py:
 

--- a/docs/config-database-setup.rst
+++ b/docs/config-database-setup.rst
@@ -20,7 +20,7 @@ To set up a new database and create the initial schema, run:
 
 .. code-block:: none
 
-  PYTHONPATH=$GRAPHITE_ROOT/webapp django-admin.py migrate --settings=graphite.settings --run-syncdb``
+  PYTHONPATH=$GRAPHITE_ROOT/webapp django-admin.py migrate --settings=graphite.settings --run-syncdb
 
 If you are experiencing problems, uncomment the following line in /opt/graphite/webapp/graphite/local_settings.py:
 


### PR DESCRIPTION
Starting a required directive for creating the default django db with "remember," is not clear. I reworded and made it not a note, as it's a requirement to make this functional.