### PR TITLE
Use latest minor Django version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@
 #   deactivate
 #
 
-Django==1.9
+Django>=1.9,<1.9.99
 python-memcached==1.47
 txAMQP==0.4
 simplejson==2.1.6


### PR DESCRIPTION
Use the most up to date security / bugfix minor version of Django available instead of only 1.9.0.

Not using `Django>=1.9,<1.10` syntax due to https://groups.google.com/forum/#!msg/python-virtualenv/DvG1InRGdR0/14b9CISO2AcJ