### PR TITLE
This fixes an encoding error when starting Graphite Web UI

### DIFF
--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -1,5 +1,6 @@
 ## Graphite local_settings.py
 # -*- coding: utf-8 -*-
+
 # Edit this file to customize the default Graphite webapp settings
 #
 # Additional customizations to Django settings can be added to this file as well

--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -1,5 +1,4 @@
 ## Graphite local_settings.py
-# -*- coding: utf-8 -*-
 
 # Edit this file to customize the default Graphite webapp settings
 #
@@ -293,7 +292,7 @@
 
 # Type of metric hashing function.
 # The default `carbon_ch` is Graphite's traditional consistent-hashing implementation.
-# Alternatively, you can use `fnv1a_ch`, which supports the Fowler–Noll–Vo hash
+# Alternatively, you can use `fnv1a_ch`, which supports the Fowler-Noll-Vo hash
 # function (FNV-1a) hash implementation offered by the carbon-c-relay project
 # https://github.com/grobian/carbon-c-relay
 #


### PR DESCRIPTION
```
[Fri Oct 21 09:29:16.262857 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512] mod_wsgi (pid=569): Target WSGI script '/opt/graphite/conf/graphite.wsgi' cannot be loaded as Python module.
[Fri Oct 21 09:29:16.262928 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512] mod_wsgi (pid=569): Exception occurred processing WSGI script '/opt/graphite/conf/graphite.wsgi'.
[Fri Oct 21 09:29:16.262961 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512] Traceback (most recent call last):
[Fri Oct 21 09:29:16.263017 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512]   File "/opt/graphite/conf/graphite.wsgi", line 4, in <module>
[Fri Oct 21 09:29:16.263098 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512]     from graphite.wsgi import application
[Fri Oct 21 09:29:16.263110 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512]   File "/opt/graphite/webapp/graphite/wsgi.py", line 14, in <module>
[Fri Oct 21 09:29:16.263130 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512]     application = get_wsgi_application()
[Fri Oct 21 09:29:16.263141 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512]   File "/usr/lib/python2.7/dist-packages/django/core/wsgi.py", line 14, in get_wsgi_application
[Fri Oct 21 09:29:16.263159 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512]     django.setup()
[Fri Oct 21 09:29:16.263168 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512]   File "/usr/lib/python2.7/dist-packages/django/__init__.py", line 20, in setup
[Fri Oct 21 09:29:16.263183 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512]     configure_logging(settings.LOGGING_CONFIG, settings.LOGGING)
[Fri Oct 21 09:29:16.263193 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512]   File "/usr/lib/python2.7/dist-packages/django/conf/__init__.py", line 46, in __getattr__
[Fri Oct 21 09:29:16.263208 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512]     self._setup(name)
[Fri Oct 21 09:29:16.263218 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512]   File "/usr/lib/python2.7/dist-packages/django/conf/__init__.py", line 42, in _setup
[Fri Oct 21 09:29:16.263232 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512]     self._wrapped = Settings(settings_module)
[Fri Oct 21 09:29:16.263242 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512]   File "/usr/lib/python2.7/dist-packages/django/conf/__init__.py", line 94, in __init__
[Fri Oct 21 09:29:16.263256 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512]     mod = importlib.import_module(self.SETTINGS_MODULE)
[Fri Oct 21 09:29:16.263265 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512]   File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
[Fri Oct 21 09:29:16.263289 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512]     __import__(name)
[Fri Oct 21 09:29:16.263299 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512]   File "/opt/graphite/webapp/graphite/settings.py", line 145, in <module>
[Fri Oct 21 09:29:16.263314 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512]     from graphite.local_settings import *  # noqa
[Fri Oct 21 09:29:16.263348 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512]   File "/opt/graphite/webapp/graphite/local_settings.py", line 294
[Fri Oct 21 09:29:16.263355 2016] [wsgi:error] [pid 569] [remote 127.0.0.1:512] SyntaxError: Non-ASCII character '\\xe2' in file /opt/graphite/webapp/graphite/local_settings.py on line 294, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```