### PR TITLE
Optimizing brace expansion

### DIFF
--- a/webapp/graphite/finders/__init__.py
+++ b/webapp/graphite/finders/__init__.py
@@ -62,13 +62,12 @@ def expand_braces(s):
   m = EXPAND_BRACES_RE.search(s)
   if m is not None:
     sub = m.group(1)
-    open_brace = s.find(sub)
-    close_brace = open_brace + len(sub) - 1
-    if sub.find(',') != -1:
+    open_brace, close_brace = m.span(1)
+    if ',' in sub:
       for pat in sub.strip('{}').split(','):
-        res.extend(expand_braces(s[:open_brace] + pat + s[close_brace + 1:]))
+        res.extend(expand_braces(s[:open_brace] + pat + s[close_brace:]))
     else:
-        res.extend(expand_braces(s[:open_brace] + sub.replace('}', '\\}') + s[close_brace + 1:]))
+        res.extend(expand_braces(s[:open_brace] + sub.replace('}', '\\}') + s[close_brace:]))
   else:
       res.append(s.replace('\\}', '}'))
 

--- a/webapp/graphite/finders/__init__.py
+++ b/webapp/graphite/finders/__init__.py
@@ -43,33 +43,33 @@ def extract_variants(pattern):
 
 
 def match_entries(entries, pattern):
-    # First we check for pattern variants (ie. {foo,bar}baz = foobaz or barbaz)
-    matching = []
+  # First we check for pattern variants (ie. {foo,bar}baz = foobaz or barbaz)
+  matching = []
 
-    for variant in expand_braces(pattern):
-      matching.extend(fnmatch.filter(entries, variant))
+  for variant in expand_braces(pattern):
+    matching.extend(fnmatch.filter(entries, variant))
 
-    return list(_deduplicate(matching))
+  return list(_deduplicate(matching))
 
 
 """
-    Brace expanding patch for python3 borrowed from:
-    https://bugs.python.org/issue9584
+  Brace expanding patch for python3 borrowed from:
+  https://bugs.python.org/issue9584
 """
 def expand_braces(s):
-    res = list()
+  res = list()
 
-    m = EXPAND_BRACES_RE.search(s)
-    if m is not None:
-      sub = m.group(1)
-      open_brace = s.find(sub)
-      close_brace = open_brace + len(sub) - 1
-      if sub.find(',') != -1:
-        for pat in sub.strip('{}').split(','):
-          res.extend(expand_braces(s[:open_brace] + pat + s[close_brace + 1:]))
-      else:
-          res.extend(expand_braces(s[:open_brace] + sub.replace('}', '\\}') + s[close_brace + 1:]))
+  m = EXPAND_BRACES_RE.search(s)
+  if m is not None:
+    sub = m.group(1)
+    open_brace = s.find(sub)
+    close_brace = open_brace + len(sub) - 1
+    if sub.find(',') != -1:
+      for pat in sub.strip('{}').split(','):
+        res.extend(expand_braces(s[:open_brace] + pat + s[close_brace + 1:]))
     else:
+        res.extend(expand_braces(s[:open_brace] + sub.replace('}', '\\}') + s[close_brace + 1:]))
+  else:
       res.append(s.replace('\\}', '}'))
 
-    return list(set(res))
+  return list(set(res))

--- a/webapp/graphite/finders/__init__.py
+++ b/webapp/graphite/finders/__init__.py
@@ -2,6 +2,7 @@ import fnmatch
 import os.path
 import re
 
+EXPAND_BRACES_RE = re.compile(r'.*(\{.+?[^\\]\})')
 
 def get_real_metric_path(absolute_path, metric_path):
   # Support symbolic links (real_metric_path ensures proper cache queries)
@@ -55,14 +56,10 @@ def match_entries(entries, pattern):
     Brace expanding patch for python3 borrowed from:
     https://bugs.python.org/issue9584
 """
-def expand_braces(orig):
-    r = r'.*(\{.+?[^\\]\})'
-    p = re.compile(r)
-
-    s = orig[:]
+def expand_braces(s):
     res = list()
 
-    m = p.search(s)
+    m = EXPAND_BRACES_RE.search(s)
     if m is not None:
       sub = m.group(1)
       open_brace = s.find(sub)


### PR DESCRIPTION
According to @iain-buclaw-sociomantic comments in https://github.com/graphite-project/graphite-web/pull/1713/files `expand_braces()` is not really optimized.
I tested that using `timeit` - https://gist.github.com/deniszh/1e7eb64cb372d83d9ecd46d11c813193
According to tests, optimized version is 20% faster, so, it's worth trying.

Also change indentation back to 2 spaces.