### PR TITLE
Enhance get_real_path to handle symlinks in any part of the path

### DIFF
--- a/webapp/graphite/finders/__init__.py
+++ b/webapp/graphite/finders/__init__.py
@@ -6,11 +6,12 @@ EXPAND_BRACES_RE = re.compile(r'.*(\{.+?[^\\]\})')
 
 def get_real_metric_path(absolute_path, metric_path):
   # Support symbolic links (real_metric_path ensures proper cache queries)
-  if os.path.islink(absolute_path):
-    real_fs_path = os.path.realpath(absolute_path)
+  real_fs_path = os.path.realpath(absolute_path)
+  if absolute_path != real_fs_path:
     relative_fs_path = metric_path.replace('.', os.sep)
-    base_fs_path = absolute_path[:-len(relative_fs_path)]
-    relative_real_fs_path = real_fs_path[len(base_fs_path):]
+    base_fs_path = os.path.dirname(absolute_path[:-len(relative_fs_path)])
+    real_base_fs_path = os.path.realpath(base_fs_path)
+    relative_real_fs_path = real_fs_path[len(real_base_fs_path):].lstrip('/')
     return fs_to_metric(relative_real_fs_path)
 
   return metric_path


### PR DESCRIPTION
The conditional in get_real_path only worked when the file was a symlink.

This changes it so that if any part of the path is a symlink, then obtain the real metrics path, so that carbonlink lookups work.