### PR TITLE
Don't fetch data from offline backends.

### DIFF
--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -322,7 +322,7 @@ def prefetchLookup(requestContext, node):
 
 def fetchRemoteData(requestContext, pathExpr, usePrefetchCache=settings.REMOTE_PREFETCH_DATA):
   (startTime, endTime, now) = _timebounds(requestContext)
-  remote_nodes = [ RemoteNode(store, pathExpr, True) for store in STORE.remote_stores ]
+  remote_nodes = [ RemoteNode(store, pathExpr, True) for store in STORE.remote_stores if store.available ]
 
   # Go through all of the remote_nodes, and launch a remote_fetch for each one.
   # Each fetch will take place in its own thread, since it's naturally parallel work.


### PR DESCRIPTION
I experienced that having a CLUSTER_NODE offline rendered Graphite
completely unresponsive, and found out that this was due to an uncaught
exception in HTTPConnectionWithTimeout.connect().

In addition to this, render/datalib.py always iterated through all
CLUSTER_NODEs, without considering their 'available' property, i.e. if
they'd been marked as offline.

render/datalib.py:
  When fetching remote data, bypass remote stores that aren't available.

remote_storage.py:
  Also mark stores unavailable if requests to them fail on network or
  transport level.