### PR TITLE
Fixes for issue #1740

### DIFF
--- a/webapp/graphite/finders/__init__.py
+++ b/webapp/graphite/finders/__init__.py
@@ -2,7 +2,7 @@ import fnmatch
 import os.path
 import re
 
-EXPAND_BRACES_RE = re.compile(r'.*(\{.+?[^\\]\})')
+EXPAND_BRACES_RE = re.compile(r'.*(\{.*?[^\\]?\})')
 
 def get_real_metric_path(absolute_path, metric_path):
   # Support symbolic links (real_metric_path ensures proper cache queries)
@@ -60,6 +60,13 @@ def match_entries(entries, pattern):
 def expand_braces(s):
   res = list()
 
+  # Used instead of s.strip('{}') because strip is greedy.
+  # We want to remove only ONE leading { and ONE trailing }, if both exist
+  def remove_outer_braces(s):
+    if s[0]== '{' and s[-1]=='}':
+      return s[1:-1]
+    return s
+
   m = EXPAND_BRACES_RE.search(s)
   if m is not None:
     sub = m.group(1)
@@ -68,7 +75,7 @@ def expand_braces(s):
       for pat in sub.strip('{}').split(','):
         res.extend(expand_braces(s[:open_brace] + pat + s[close_brace:]))
     else:
-        res.extend(expand_braces(s[:open_brace] + sub.replace('}', '\\}') + s[close_brace:]))
+        res.extend(expand_braces(s[:open_brace] + remove_outer_braces(sub) + s[close_brace:]))
   else:
       res.append(s.replace('\\}', '}'))
 

--- a/webapp/tests/test_finders.py
+++ b/webapp/tests/test_finders.py
@@ -110,7 +110,42 @@ class StandardFinderTest(TestCase):
             self.assertEqual(self._listdir_counter, 5)
 
             self._listdir_counter = 0
+            nodes = finder.find_nodes(FindQuery('{foo}.bar.*', None, None))
+            self.assertEqual(len(list(nodes)), 1)
+            self.assertEqual(self._listdir_counter, 2)
+
+            self._listdir_counter = 0
             nodes = finder.find_nodes(FindQuery('foo.{ba{r,z},baz}.baz', None, None))
+            self.assertEqual(len(list(nodes)), 1)
+            self.assertEqual(self._listdir_counter, 1)
+
+            self._listdir_counter = 0
+            nodes = finder.find_nodes(FindQuery('{foo,garbage}.bar.baz', None, None))
+            self.assertEqual(len(list(nodes)), 1)
+            self.assertEqual(self._listdir_counter, 1)
+
+            self._listdir_counter = 0
+            nodes = finder.find_nodes(FindQuery('{fo{o}}.bar.baz', None, None))
+            self.assertEqual(len(list(nodes)), 1)
+            self.assertEqual(self._listdir_counter, 1)
+
+            self._listdir_counter = 0
+            nodes = finder.find_nodes(FindQuery('foo{}.bar.baz', None, None))
+            self.assertEqual(len(list(nodes)), 1)
+            self.assertEqual(self._listdir_counter, 1)
+
+            self._listdir_counter = 0
+            nodes = finder.find_nodes(FindQuery('{fo,ba}{o}.bar.baz', None, None))
+            self.assertEqual(len(list(nodes)), 1)
+            self.assertEqual(self._listdir_counter, 1)
+
+            self._listdir_counter = 0
+            nodes = finder.find_nodes(FindQuery('{fo,ba}{o,o}.bar.baz', None, None))
+            self.assertEqual(len(list(nodes)), 1)
+            self.assertEqual(self._listdir_counter, 1)
+
+            self._listdir_counter = 0
+            nodes = finder.find_nodes(FindQuery('{fo,ba}{o,z}.bar.baz', None, None))
             self.assertEqual(len(list(nodes)), 1)
             self.assertEqual(self._listdir_counter, 1)
 


### PR DESCRIPTION
Proposed fixes for #1740.

Adjust EXPAND_BRACES_RE to match {} without anything inside of it.

Change expand_braces to expand `{foo}` to `foo`.

Add a handful of unit tests for different brace usages.