### PR TITLE
Add more test coverage for standard finder

### DIFF
--- a/webapp/graphite/readers.py
+++ b/webapp/graphite/readers.py
@@ -11,6 +11,11 @@ try:
 except ImportError:
   whisper = False
 
+# The parser was repalcing __readHeader with the <class>__readHeader
+# which was not working.
+if bool(whisper):
+  whisper__readHeader = whisper.__readHeader
+
 try:
   import rrdtool
 except ImportError:
@@ -194,7 +199,7 @@ class GzippedWhisperReader(WhisperReader):
   def get_intervals(self):
     fh = gzip.GzipFile(self.fs_path, 'rb')
     try:
-      info = whisper.__readHeader(fh) # evil, but necessary.
+      info = whisper__readHeader(fh) # evil, but necessary.
     finally:
       fh.close()
 


### PR DESCRIPTION
Fix the GzippedWhisperReader get_interval method to work
Add a little bit of coverate for finder of gzipped whisper files.