### PR TITLE
Failing functions when combining with events

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -3671,7 +3671,7 @@ def events(requestContext, *tags):
   returns all events.
   """
   step = 1
-  name = "events(" + ", ".join(tags) + ")"
+  name = "events(\"" + "\", \"".join(tags) + "\")"
   if tags == ("*",):
     tags = None
 

--- a/webapp/tests/test_events.py
+++ b/webapp/tests/test_events.py
@@ -162,3 +162,16 @@ class EventTest(TestCase):
         self.assertEqual(response.status_code, 404)
         event = json.loads(response.content)
         self.assertEqual(event['error'], 'Event matching query does not exist')
+
+    def test_render_events_issue_1749(self):
+        url = reverse('graphite.render.views.renderView')
+        response = self.client.get(url, {
+                 'target': 'timeShift(events("tag1"), "1d")',
+                 'format': 'json',
+        })
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get(url, {
+                 'target': 'timeShift(events("tag1", "tag2"), "1d")',
+                 'format': 'json',
+        })
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
For example combining timeShift or movingAverage with events throws the following exception.

Example query
`http://host/graphite/render?target=timeShift(transformNull(events("tag")), "1d")&from=-7d`

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 111, in get_response
    response = callback(request, *callback_args, **callback_kwargs)
  File "/opt/graphite/webapp/graphite/render/views.py", line 125, in renderView
    seriesList = evaluateTarget(requestContext, target)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 10, in evaluateTarget
    result = evaluateTokens(requestContext, tokens)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 21, in evaluateTokens
    return evaluateTokens(requestContext, tokens.expression)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 30, in evaluateTokens
    return func(requestContext, *args)
  File "/opt/graphite/webapp/graphite/render/functions.py", line 2252, in timeShift
    for shiftedSeries in evaluateTarget(myContext, series.pathExpression):
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 10, in evaluateTarget
    result = evaluateTokens(requestContext, tokens)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 21, in evaluateTokens
    return evaluateTokens(requestContext, tokens.expression)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 28, in evaluateTokens
    args = [evaluateTokens(requestContext, arg) for arg in tokens.call.args]
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 21, in evaluateTokens
    return evaluateTokens(requestContext, tokens.expression)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 30, in evaluateTokens
    return func(requestContext, *args)
  File "/opt/graphite/webapp/graphite/render/functions.py", line 2806, in events
    name = "events(" + ", ".join(tags) + ")"
TypeError: sequence item 0: expected string, list found
```

In this callstack events gets called with `([], )` as tags argument.
