### PR TITLE
Revert "update django version specifier syntax"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@
 #   deactivate
 #
 
-Django~=1.9.0
+Django>=1.9,<1.9.99
 python-memcached==1.47
 txAMQP==0.4
 simplejson==2.1.6

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ try:
         ['templates/*', 'local_settings.py.example']},
       scripts=glob('bin/*'),
       data_files=webapp_content.items() + storage_dirs + conf_files + examples,
-      install_requires=['Django~=1.9.0', 'django-tagging==0.4.3', 'pytz', 'pyparsing==1.5.7', 'cairocffi'],
+      install_requires=['Django>=1.9,<1.9.99', 'django-tagging==0.4.3', 'pytz', 'pyparsing==1.5.7', 'cairocffi'],
       classifiers=[
           'Intended Audience :: Developers',
           'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
 	git+git://github.com/graphite-project/whisper.git#egg=whisper
 	git+git://github.com/graphite-project/ceres.git#egg=ceres
 	pyparsing2: pyparsing
-	django19: Django~=1.9.0
+	django19: Django>=1.9,<1.9.99
 
 [testenv:docs]
 basepython = python2.7


### PR DESCRIPTION
This reverts commit be7fca6e436a42b0bc4ee0f5c005395c6deb901c.

The `~=` requirement syntax isn't supported by older pip releases including but not limited to 1.5.4, see #1753 for further discussion.