### PR TITLE
webapp/glyph.py: fix blank space below the legend

### DIFF
--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -727,7 +727,7 @@ class Graph:
       numberOfLines = max(len(elements) - numRight, numRight)
       columns = math.floor(columns / 2.0)
       if columns < 1: columns = 1
-      legendHeight = max(1, (numberOfLines / columns)) * (lineHeight + padding)
+      legendHeight = max(1, (numberOfLines / columns)) * lineHeight + padding
       self.area['ymax'] -= legendHeight #scoot the drawing area up to fit the legend
       self.ctx.set_line_width(1.0)
       x = self.area['xmin']
@@ -768,7 +768,7 @@ class Graph:
       columns = math.floor( self.width / labelWidth )
       if columns < 1: columns = 1
       numberOfLines = math.ceil( float(len(elements)) / columns )
-      legendHeight = numberOfLines * (lineHeight + padding)
+      legendHeight = numberOfLines * lineHeight + padding
       self.area['ymax'] -= legendHeight #scoot the drawing area up to fit the legend
       self.ctx.set_line_width(1.0)
       x = self.area['xmin']

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -727,7 +727,7 @@ class Graph:
       numberOfLines = max(len(elements) - numRight, numRight)
       columns = math.floor(columns / 2.0)
       if columns < 1: columns = 1
-      legendHeight = max(1, (numberOfLines / columns)) * lineHeight + padding
+      legendHeight = (max(1, (numberOfLines / columns)) * lineHeight) + padding
       self.area['ymax'] -= legendHeight #scoot the drawing area up to fit the legend
       self.ctx.set_line_width(1.0)
       x = self.area['xmin']
@@ -768,7 +768,7 @@ class Graph:
       columns = math.floor( self.width / labelWidth )
       if columns < 1: columns = 1
       numberOfLines = math.ceil( float(len(elements)) / columns )
-      legendHeight = numberOfLines * lineHeight + padding
+      legendHeight = (numberOfLines * lineHeight) + padding
       self.area['ymax'] -= legendHeight #scoot the drawing area up to fit the legend
       self.ctx.set_line_width(1.0)
       x = self.area['xmin']


### PR DESCRIPTION
        Don't add padding (5px) for each line of legend; only add it
        once to separate the graph area from the legend.

Before and after fix graphs:
1 line: http://tinypic.com/r/muabys/9
5 lines: http://tinypic.com/r/2wmniiv/9
6 lines: http://tinypic.com/r/23h7lgw/9
5 lines, with the fix: http://tinypic.com/r/2db2i6f/9
6 lines, with the fix: http://tinypic.com/r/2s8pvzn/9