### PR TITLE
webapp/glyph.py: fix incorrect display of 'title' URI parameter

### DIFF
--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1046,11 +1046,11 @@ class LineGraph(Graph):
     self.setColor( self.foregroundColor )
 
     if params.get('title'):
-      self.drawTitle( unicode(params['title']) )
+      self.drawTitle( unicode( unquote_plus(params['title']) ) )
     if params.get('vtitle'):
-      self.drawVTitle( unicode(params['vtitle']) )
+      self.drawVTitle( unicode( unquote_plus(params['vtitle']) ) )
     if self.secondYAxis and params.get('vtitleRight'):
-      self.drawVTitle( unicode(params['vtitleRight']), rightAlign=True )
+      self.drawVTitle( unicode( unquote_plus(params['vtitleRight']) ), rightAlign=True )
     self.setFont()
 
     if not params.get('hideLegend', len(self.data) > settings.LEGEND_MAX_ITEMS):
@@ -1792,7 +1792,7 @@ class PieGraph(Graph):
     self.setFont( size=titleSize )
     self.setColor( self.foregroundColor )
     if params.get('title'):
-      self.drawTitle( params['title'] )
+      self.drawTitle( unquote_plus(params['title']) )
     self.setFont()
 
     if not params.get('hideLegend',False):


### PR DESCRIPTION
When passing an URI-encoded string (e.g. '&title=Hello%20World%21'), display 'Hello World!' instead in graph title.

Graph before the fix:
![test_uri_bad](https://cloud.githubusercontent.com/assets/5499488/21607734/7583acec-d1b8-11e6-99b8-e7384454d8e6.png)

Fixed version:
![test_uri_good](https://cloud.githubusercontent.com/assets/5499488/21607743/7dfe1b46-d1b8-11e6-92d2-95055b948a75.png)

