### PR TITLE
add consecutiveNonZero and consecutiveSecondsNonZero functions

### DIFF
--- a/webapp/content/js/composer_widgets.js
+++ b/webapp/content/js/composer_widgets.js
@@ -1184,6 +1184,8 @@ function createFunctionsMenu() {
         {text: 'Changed', handler: applyFuncToEach('changed')},
         {text: 'Transform Nulls', handler: applyFuncToEachWithInput('transformNull', 'Please enter the value to transform null values to')},
         {text: 'Count non-nulls', handler: applyFuncToAll('isNonNull')},
+        {text: 'Consecutive non-zeros', handler: applyFuncToEach('consecutiveNonZero')},
+        {text: 'Consecutive seconds non-zeros', handler: applyFuncToEach('consecutiveSecondsNonZero')},
         {text: 'Substring', handler: applyFuncToEachWithInput('substr', 'Enter a starting position')},
         {text: 'Group', handler: applyFuncToAll('group')},
         {text: 'Area Between', handler: applyFuncToEach('areaBetween')},

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -3693,3 +3693,45 @@ class FunctionsTest(TestCase):
               },
               seriesList, "1minute", func, True)
           self.assertEqual(result, expectedResults[func])
+
+    def test_consecutiveNonZero(self):
+        seriesList = [
+            TimeSeries('servers.s1.queue_length', 0, 600, 60, [10, 10, 10, None, 10, 0, 1, 1, 0, 1])
+        ]
+
+        for series in seriesList:
+            series.pathExpression = series.name
+
+        expected = TimeSeries('consecutiveNonZero(servers.s1.queue_length)', 0, 600, 60, [1, 2, 3, 3, 4, 0, 1, 2, 0, 1])
+
+        result = functions.consecutiveNonZero(
+            {
+                'startTime': datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
+                'endTime': datetime(1970, 1, 1, 0, 10, 0, 0, pytz.timezone(settings.TIME_ZONE)),
+                'localOnly': False,
+            },
+            seriesList
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], expected)
+
+    def test_consecutiveSecondsNonZero(self):
+        seriesList = [
+            TimeSeries('servers.s1.queue_length', 0, 600, 60, [10, 10, 10, None, 10, 0, 1, 1, 0, 1])
+        ]
+
+        for series in seriesList:
+            series.pathExpression = series.name
+
+        expected = TimeSeries('consecutiveSecondsNonZero(servers.s1.queue_length)', 0, 600, 60, [60, 120, 180, 180, 240, 0, 60, 120, 0, 60])
+
+        result = functions.consecutiveSecondsNonZero(
+            {
+                'startTime': datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
+                'endTime': datetime(1970, 1, 1, 0, 4, 0, 0, pytz.timezone(settings.TIME_ZONE)),
+                'localOnly': False,
+            },
+            seriesList
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], expected)


### PR DESCRIPTION
This pair of functions returns the number of buckets or seconds (depending on the function called) where at least one of the invocant series has had a non-zero, non-null value. This kind of metric is particularly good for looking at things like the number of seconds that a system has been queueing traffic.