### PR TITLE
support whisper aggregation method "last" in readers.py

### DIFF
--- a/webapp/graphite/readers.py
+++ b/webapp/graphite/readers.py
@@ -308,6 +308,8 @@ def merge_with_cache(cached_datapoints, start, step, values, func=None):
           return max(usable)
       if func == 'min':
           return min(usable)
+      if func == 'last':
+          return usable[-1]
       raise Exception("Invalid consolidation function: '%s'" % func)
 
   if func:


### PR DESCRIPTION
This method gets called with the rollup aggregation method specified in the whisper file; Whisper supports the "last" aggregation method (as per <http://graphite.readthedocs.io/en/latest/whisper.html#rollup-aggregation>). This patch fixes reading whisper files with their aggregationMethod set to "last".