### PR TITLE
Make readers.py more easilly importable by moving away models

### DIFF
--- a/webapp/graphite/account/views.py
+++ b/webapp/graphite/account/views.py
@@ -16,7 +16,7 @@ from django.contrib.auth import authenticate, login, logout
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import render_to_response
-from graphite.util import getProfile
+from graphite.user_util import getProfile
 
 
 def loginView(request):

--- a/webapp/graphite/browser/views.py
+++ b/webapp/graphite/browser/views.py
@@ -20,7 +20,8 @@ from django.utils.safestring import mark_safe
 from django.utils.html import escape
 from graphite.account.models import Profile
 from graphite.compat import HttpResponse
-from graphite.util import getProfile, getProfileByUsername, json
+from graphite.user_util import getProfile, getProfileByUsername
+from graphite.util import json
 from graphite.logger import log
 from hashlib import md5
 from urlparse import urlparse, parse_qsl

--- a/webapp/graphite/composer/views.py
+++ b/webapp/graphite/composer/views.py
@@ -22,7 +22,7 @@ from httplib import HTTPConnection
 from urlparse import urlsplit
 from time import ctime, strftime
 from traceback import format_exc
-from graphite.util import getProfile
+from graphite.user_util import getProfile
 from graphite.logger import log
 from graphite.account.models import MyGraph
 

--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -17,7 +17,8 @@ import urllib
 
 from django.conf import settings
 from graphite.compat import HttpResponse, HttpResponseBadRequest
-from graphite.util import getProfile, json
+from graphite.user_util import getProfile
+from graphite.util import json
 from graphite.logger import log
 from graphite.readers import RRDReader
 from graphite.storage import STORE

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -29,7 +29,8 @@ except ImportError:
   import pickle
 
 from graphite.compat import HttpResponse
-from graphite.util import getProfileByUsername, json, unpickle
+from graphite.user_util import getProfileByUsername
+from graphite.util import json, unpickle
 from graphite.remote_storage import connector_class_selector
 from graphite.logger import log
 from graphite.render.evaluator import evaluateTarget

--- a/webapp/graphite/user_util.py
+++ b/webapp/graphite/user_util.py
@@ -1,0 +1,47 @@
+"""Copyright 2008 Orbitz WorldWide
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License."""
+
+
+from django.contrib.auth.models import User
+from graphite.account.models import Profile
+from graphite.logger import log
+
+
+def getProfile(request, allowDefault=True):
+  if request.user.is_authenticated():
+    return Profile.objects.get_or_create(user=request.user)[0]
+  elif allowDefault:
+    return default_profile()
+
+
+def getProfileByUsername(username):
+  try:
+    return Profile.objects.get(user__username=username)
+  except Profile.DoesNotExist:
+    return None
+
+
+def default_profile():
+    # '!' is an unusable password. Since the default user never authenticates
+    # this avoids creating a default (expensive!) password hash at every
+    # default_profile() call.
+    user, created = User.objects.get_or_create(
+        username='default', defaults={'email': 'default@localhost.localdomain',
+                                      'password': '!'})
+    if created:
+        log.info("Default user didn't exist, created it")
+    profile, created = Profile.objects.get_or_create(user=user)
+    if created:
+        log.info("Default profile didn't exist, created it")
+    return profile

--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -35,8 +35,6 @@ except ImportError:
   from StringIO import StringIO
 
 from django.conf import settings
-from django.contrib.auth.models import User
-from graphite.account.models import Profile
 from graphite.logger import log
 
 
@@ -58,19 +56,6 @@ def epoch(dt):
   Returns the epoch timestamp of a timezone-aware datetime object.
   """
   return calendar.timegm(dt.astimezone(pytz.utc).timetuple())
-
-def getProfile(request, allowDefault=True):
-  if request.user.is_authenticated():
-    return Profile.objects.get_or_create(user=request.user)[0]
-  elif allowDefault:
-    return default_profile()
-
-
-def getProfileByUsername(username):
-  try:
-    return Profile.objects.get(user__username=username)
-  except Profile.DoesNotExist:
-    return None
 
 def is_local_interface(host):
   is_ipv6 = False
@@ -121,21 +106,6 @@ def find_escaped_pattern_fields(pattern_string):
   for index,part in enumerate(pattern_parts):
     if is_escaped_pattern(part):
       yield index
-
-
-def default_profile():
-    # '!' is an unusable password. Since the default user never authenticates
-    # this avoids creating a default (expensive!) password hash at every
-    # default_profile() call.
-    user, created = User.objects.get_or_create(
-        username='default', defaults={'email': 'default@localhost.localdomain',
-                                      'password': '!'})
-    if created:
-        log.info("Default user didn't exist, created it")
-    profile, created = Profile.objects.get_or_create(user=user)
-    if created:
-        log.info("Default profile didn't exist, created it")
-    return profile
 
 
 def load_module(module_path, member=None):

--- a/webapp/tests/test_user_util.py
+++ b/webapp/tests/test_user_util.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+from django.http import HttpRequest
+
+#from django.contrib.auth import authenticate
+from django.contrib.auth.models import User
+
+from graphite import user_util
+from graphite.wsgi import application  # NOQA makes sure we have a working WSGI app
+
+
+class UserUtilTest(TestCase):
+
+    def test_getProfile(self):
+        request = HttpRequest()
+        request.user = User.objects.create_user('testuser', 'testuser@test.com', 'testuserpassword')
+        self.assertEqual( str(user_util.getProfile(request, False)), 'Profile for testuser' )
+
+    def test_getProfileByUsername(self):
+        request = HttpRequest()
+        request.user = User.objects.create_user('testuser', 'testuser@test.com', 'testuserpassword')
+        user_util.getProfile(request, False)
+        self.assertEqual( str(user_util.getProfileByUsername('testuser')), 'Profile for testuser' )
+        self.assertEqual( user_util.getProfileByUsername('nonexistentuser'), None )

--- a/webapp/tests/test_util.py
+++ b/webapp/tests/test_util.py
@@ -4,10 +4,6 @@ import time
 import whisper
 
 from django.test import TestCase
-from django.http import HttpRequest
-
-#from django.contrib.auth import authenticate
-from django.contrib.auth.models import User
 
 from django.conf import settings
 from graphite import util
@@ -15,18 +11,6 @@ from graphite.wsgi import application  # NOQA makes sure we have a working WSGI 
 
 
 class UtilTest(TestCase):
-
-    def test_getProfile(self):
-        request = HttpRequest()
-        request.user = User.objects.create_user('testuser', 'testuser@test.com', 'testuserpassword')
-        self.assertEqual( str(util.getProfile(request, False)), 'Profile for testuser' )
-
-    def test_getProfileByUsername(self):
-        request = HttpRequest()
-        request.user = User.objects.create_user('testuser', 'testuser@test.com', 'testuserpassword')
-        util.getProfile(request, False)
-        self.assertEqual( str(util.getProfileByUsername('testuser')), 'Profile for testuser' )
-        self.assertEqual( util.getProfileByUsername('nonexistentuser'), None )
 
     def test_is_local_interface_ipv4(self):
         addresses = ['127.0.0.1', '127.0.0.1:8080', '8.8.8.8']


### PR DESCRIPTION
In recent versions of Django you can't import models until
late in the process, which is an issue because util.py does that
and is imported all over the place, including by readers.py.

Since readers.py is a kind of external API (mainly for FetchInProgress
we need to make sure it is easilly importable).