### PR TITLE
Remove pyparsing pinning requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ try:
         ['templates/*', 'local_settings.py.example']},
       scripts=glob('bin/*'),
       data_files=webapp_content.items() + storage_dirs + conf_files + examples,
-      install_requires=['Django>=1.9,<1.9.99', 'django-tagging==0.4.3', 'pytz', 'pyparsing<2.1', 'cairocffi'],
+      install_requires=['Django>=1.9,<1.9.99', 'django-tagging==0.4.3', 'pytz', 'pyparsing', 'cairocffi'],
       classifiers=[
           'Intended Audience :: Developers',
           'Natural Language :: English',

--- a/webapp/graphite/render/grammar.py
+++ b/webapp/graphite/render/grammar.py
@@ -1,23 +1,19 @@
 from pyparsing import (
     ParserElement, Forward, Combine, Optional, Word, Literal, CaselessKeyword,
     CaselessLiteral, Group, FollowedBy, LineEnd, OneOrMore, ZeroOrMore,
-    nums, alphas, alphanums, printables, delimitedList, quotedString,
+    nums, alphas, alphanums, printables, delimitedList, quotedString, Regex,
     __version__,
 )
 
-ParserElement.enablePackrat()
 grammar = Forward()
 
 expression = Forward()
 
 # Literals
-intNumber = Combine(
-  Optional('-') + Word(nums)
-)('integer')
 
-floatNumber = Combine(
-  Optional('-') + Word(nums) + Literal('.') + Word(nums)
-)('float')
+intNumber = Regex(r'-?\d+')('integer')
+
+floatNumber = Regex(r'-?\d+\.\d+')('float')
 
 sciNumber = Combine(
   (floatNumber | intNumber) + CaselessLiteral('e') + intNumber

--- a/webapp/graphite/render/grammar.py
+++ b/webapp/graphite/render/grammar.py
@@ -1,7 +1,7 @@
 from pyparsing import (
-    ParserElement, Forward, Combine, Optional, Word, Literal, CaselessKeyword,
+    Forward, Combine, Optional, Word, Literal, CaselessKeyword,
     CaselessLiteral, Group, FollowedBy, LineEnd, OneOrMore, ZeroOrMore,
-    nums, alphas, alphanums, printables, delimitedList, quotedString, Regex,
+    alphas, alphanums, printables, delimitedList, quotedString, Regex,
     __version__,
 )
 


### PR DESCRIPTION
By using a Regex parser instead of building the rule we are able to get rid of the concurrency issue while loading multiple graphs.

From Paul McGuire, Pyparsing author :

> That KeyError is being raised inside the collections.OrderedDict code, and the key is extracted just a couple of lines prior to the place where the exception is raised, so we know it is a valid key. But there is a (small) window of time in which the same key could be popped by two different threads, and so the second thread will fail as the key will no longer be there.

> I've found in other parsers that building up numeric values with Combine, Word, etc. is a real slowdown compared to using a Regex, and there is not that much loss in readability or maintainability. These re's aren't that long or complicated.