### PR TITLE
Clustering, skipping find

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,3 +50,4 @@ git+git://github.com/graphite-project/whisper.git#egg=whisper
 git+git://github.com/graphite-project/ceres.git#egg=ceres
 whitenoise
 scandir
+urllib3==1.19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,4 +50,4 @@ git+git://github.com/graphite-project/whisper.git#egg=whisper
 git+git://github.com/graphite-project/ceres.git#egg=ceres
 whitenoise
 scandir
-urllib3==1.19.1
+urllib3

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ try:
         ['templates/*', 'local_settings.py.example']},
       scripts=glob('bin/*'),
       data_files=webapp_content.items() + storage_dirs + conf_files + examples,
-      install_requires=['Django>=1.9,<1.9.99', 'django-tagging==0.4.3', 'pytz', 'pyparsing', 'cairocffi'],
+      install_requires=['Django>=1.9,<1.9.99', 'django-tagging==0.4.3', 'pytz', 'pyparsing', 'cairocffi', 'urllib3==1.19.1'],
       classifiers=[
           'Intended Audience :: Developers',
           'Natural Language :: English',

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ try:
         ['templates/*', 'local_settings.py.example']},
       scripts=glob('bin/*'),
       data_files=webapp_content.items() + storage_dirs + conf_files + examples,
-      install_requires=['Django>=1.9,<1.9.99', 'django-tagging==0.4.3', 'pytz', 'pyparsing', 'cairocffi', 'urllib3==1.19.1'],
+      install_requires=['Django>=1.9,<1.9.99', 'django-tagging==0.4.3', 'pytz', 'pyparsing', 'cairocffi', 'urllib3'],
       classifiers=[
           'Intended Audience :: Developers',
           'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ deps =
 	pyparsing2: pyparsing
 	django19: Django>=1.9,<1.9.99
 	scandir
+	urllib3==1.19.1
 
 [testenv:docs]
 basepython = python2.7
@@ -42,6 +43,7 @@ deps =
 	Sphinx<1.4
 	sphinx_rtd_theme
 	scandir
+	urllib3==1.19.1
 commands =
 	mkdir -p {envsitepackagesdir}/../storage/ceres
 	sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
 	pyparsing2: pyparsing
 	django19: Django>=1.9,<1.9.99
 	scandir
-	urllib3==1.19.1
+	urllib3
 
 [testenv:docs]
 basepython = python2.7
@@ -43,7 +43,7 @@ deps =
 	Sphinx<1.4
 	sphinx_rtd_theme
 	scandir
-	urllib3==1.19.1
+	urllib3
 commands =
 	mkdir -p {envsitepackagesdir}/../storage/ceres
 	sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html

--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -245,6 +245,22 @@
 # used.
 #CLUSTER_SERVERS = ["10.0.2.2:80", "10.0.2.3:80"]
 
+# Creates a pool of worker threads to which tasks can be dispatched. This makes
+# sense if there are multiple CLUSTER_SERVERS because then the communication
+# with them can be parallelized
+#USE_WORKER_POOL = True
+
+# The number of worker threads that should be created per backend server.
+# It makes sense to have more than one thread per backend server because
+# the graphite-web web server itself is multi threaded and can handle multiple
+# incoming requests at once.
+#POOL_WORKERS_PER_BACKEND = 10
+
+# A baseline number of workers that should always be created, no matter how many
+# cluster servers are configured. These are used for other tasks that can be
+# off-loaded from the request handling threads.
+#POOL_WORKERS = 10
+
 # This setting controls whether https is used to communicate between cluster members
 #INTRACLUSTER_HTTPS = False
 
@@ -266,6 +282,8 @@
 # remote systems have data we don't have locally, which we probably do.
 #FIND_TOLERANCE = 2 * FIND_CACHE_DURATION
 
+#REMOTE_STORE_USE_POST = False    # Use POST instead of GET for remote requests
+
 # During a rebalance of a consistent hash cluster, after a partition event on a replication > 1 cluster,
 # or in other cases we might receive multiple TimeSeries data for a metric key.  Merge them together rather
 # that choosing the "most complete" one (pre-0.9.14 behaviour).
@@ -274,6 +292,13 @@
 # Provide a list of HTTP headers that you want forwarded on from this host
 # when making a request to a remote webapp server in CLUSTER_SERVERS
 #REMOTE_STORE_FORWARD_HEADERS = [] # An iterable of HTTP header names
+
+## Prefetch cache
+# set to True to fetch all metrics using a single http request per remote server
+# instead of one http request per target, per remote server.
+# Especially useful when generating graphs with more than 4-5 targets or if
+# there's significant latency between this server and the backends.
+#REMOTE_PREFETCH_DATA = False
 
 ## Remote rendering settings
 # Set to True to enable rendering of Graphs on a remote webapp

--- a/webapp/graphite/readers.py
+++ b/webapp/graphite/readers.py
@@ -60,34 +60,32 @@ class MultiReader(object):
     return IntervalSet( sorted(interval_sets) )
 
   def fetch(self, startTime, endTime, now=None, requestContext=None):
-    # Start the fetch on each node
-    fetches = []
+    try:
+      results = [
+        node.fetch(startTime, endTime, now, requestContext)
+        for node in self.nodes
+        if node.is_leaf
+      ]
+    except Exception as exc:
+      log.exception(
+        'Failed to initiate subfetch: {exc}'
+        .format(exc=str(exc))
+      )
 
-    for n in self.nodes:
-      try:
-        fetches.append(n.fetch(startTime, endTime, now, requestContext))
-      except:
-        log.exception("Failed to initiate subfetch for %s" % str(n))
+    result = []
+    for r in results:
+      if isinstance(r, FetchInProgress):
+        r = r.waitForResults()
 
-    def merge_results():
-      results = {}
+      if r is None:
+        continue
+      result.append(r)
 
-      # Wait for any asynchronous operations to complete
-      for i, result in enumerate(fetches):
-        if isinstance(result, FetchInProgress):
-          try:
-            results[i] = result.waitForResults()
-          except:
-            log.exception("Failed to complete subfetch")
-            results[i] = None
+    if not result:
+      raise Exception("All sub-fetches failed")
 
-      results = [r for r in results.values() if r is not None]
-      if not results:
-        raise Exception("All sub-fetches failed")
+    return reduce(self.merge, result)
 
-      return reduce(self.merge, results)
-
-    return FetchInProgress(merge_results)
 
   def merge(self, results1, results2):
     # Ensure results1 is finer than results2

--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -1,5 +1,4 @@
 import time
-import httplib
 import urllib3
 from Queue import Queue
 from urllib import urlencode
@@ -15,9 +14,6 @@ from graphite.render.hashing import compactHash
 from graphite.worker_pool.pool import get_pool
 
 http = urllib3.PoolManager(num_pools=10, maxsize=5)
-
-def connector_class_selector(https_support=False):
-    return httplib.HTTPSConnection if https_support else httplib.HTTPConnection
 
 
 def prefetchRemoteData(remote_stores, requestContext, pathExpressions):

--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -226,9 +226,10 @@ class RemoteReader(object):
 
       q = Queue()
       if settings.USE_WORKER_POOL:
-        get_pool().put(
-          job=(self._fetch, url, query_string, query_params, headers),
-          result_queue=q,
+        get_pool().apply_async(
+          func=self._fetch,
+          args=[url, query_string, query_params, headers],
+          callback=lambda x: q.put(x),
         )
       else:
         q.put(

--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -1,44 +1,48 @@
 import time
 import httplib
+import urllib3
+from Queue import Queue
 from urllib import urlencode
-from threading import Lock
+from threading import Lock, current_thread
 from django.conf import settings
 from django.core.cache import cache
 from graphite.intervals import Interval, IntervalSet
 from graphite.node import LeafNode, BranchNode
+from graphite.readers import FetchInProgress
 from graphite.logger import log
 from graphite.util import unpickle
-from graphite.readers import FetchInProgress
 from graphite.render.hashing import compactHash
+from graphite.worker_pool.pool import get_pool
+
+http = urllib3.PoolManager(num_pools=10, maxsize=5)
 
 def connector_class_selector(https_support=False):
     return httplib.HTTPSConnection if https_support else httplib.HTTPConnection
 
+
 class RemoteStore(object):
-  lastFailure = 0.0
-  available = property(lambda self: time.time() - self.lastFailure > settings.REMOTE_RETRY_DELAY)
 
   def __init__(self, host):
     self.host = host
+    self.last_failure = 0
+
+  @property
+  def available(self):
+    return time.time() - self.last_failure > settings.REMOTE_RETRY_DELAY
 
   def find(self, query, headers=None):
-    request = FindRequest(self, query)
-    request.send(headers)
-    return request
+    return list(FindRequest(self, query).send(headers))
 
   def fail(self):
-    self.lastFailure = time.time()
+    self.last_failure = time.time()
 
 
 class FindRequest(object):
-  __slots__ = ('store', 'query', 'connection',
-               'failed', 'cacheKey', 'cachedResult')
+  __slots__ = ('store', 'query', 'cacheKey')
 
   def __init__(self, store, query):
     self.store = store
     self.query = query
-    self.connection = None
-    self.failed = False
 
     if query.startTime:
       start = query.startTime - (query.startTime % settings.FIND_CACHE_DURATION)
@@ -51,67 +55,54 @@ class FindRequest(object):
       end = ""
 
     self.cacheKey = "find:%s:%s:%s:%s" % (store.host, compactHash(query.pattern), start, end)
-    self.cachedResult = None
 
   def send(self, headers=None):
+    t = time.time()
     log.info("FindRequest.send(host=%s, query=%s) called" % (self.store.host, self.query))
 
     if headers is None:
       headers = {}
 
-    self.cachedResult = cache.get(self.cacheKey)
-    if self.cachedResult is not None:
-      log.info("FindRequest(host=%s, query=%s) using cached result" % (self.store.host, self.query))
-      return
-
-    query_params = [
-      ('local', '1'),
-      ('format', 'pickle'),
-      ('query', self.query.pattern),
-    ]
-    if self.query.startTime:
-      query_params.append( ('from', self.query.startTime) )
-
-    if self.query.endTime:
-      query_params.append( ('until', self.query.endTime) )
-
-    query_string = urlencode(query_params)
-
-    try:
-      connector_class = connector_class_selector(settings.INTRACLUSTER_HTTPS)
-      self.connection = connector_class(self.store.host)
-      self.connection.timeout = settings.REMOTE_FIND_TIMEOUT
-      self.connection.request('GET', '/metrics/find/?' + query_string, None, headers)
-    except:
-      log.exception("FindRequest.send(host=%s, query=%s) exception during request" % (self.store.host, self.query))
-      self.store.fail()
-      self.failed = True
-
-  def get_results(self):
-    if self.failed:
-      return
-
-    if self.cachedResult is not None:
-      results = self.cachedResult
+    results = cache.get(self.cacheKey)
+    if results is not None:
+      log.info("FindRequest.send(host=%s, query=%s) using cached result" % (self.store.host, self.query))
     else:
-      if self.connection is None:
-        self.send()
+      url = "%s://%s/metrics/find/" % ('https' if settings.INTRACLUSTER_HTTPS else 'http', self.store.host)
+
+      query_params = [
+        ('local', '1'),
+        ('format', 'pickle'),
+        ('query', self.query.pattern),
+      ]
+      if self.query.startTime:
+        query_params.append( ('from', self.query.startTime) )
+
+      if self.query.endTime:
+        query_params.append( ('until', self.query.endTime) )
 
       try:
-        try: # Python 2.7+, use buffering of HTTP responses
-          response = self.connection.getresponse(buffering=True)
-        except TypeError:  # Python 2.6 and older
-          response = self.connection.getresponse()
-        assert response.status == 200, "received error response %s - %s" % (response.status, response.reason)
-        result_data = response.read()
-        results = unpickle.loads(result_data)
-
+        result = http.request('POST' if settings.REMOTE_STORE_USE_POST else 'GET',
+                              url, fields=query_params, headers=headers, timeout=settings.REMOTE_FIND_TIMEOUT)
       except:
-        log.exception("FindRequest.get_results(host=%s, query=%s) exception processing response" % (self.store.host, self.query))
+        log.exception("FindRequest.send(host=%s, query=%s) exception during request" % (self.store.host, self.query))
+        self.store.fail()
+        return
+
+      if result.status != 200:
+        log.exception("FindRequest.send(host=%s, query=%s) error response %d from %s?%s" % (self.store.host, self.query, result.status, url, urlencode(query_params)))
+        self.store.fail()
+        return
+
+      try:
+        results = unpickle.loads(result.data)
+      except:
+        log.exception("FindRequest.send(host=%s, query=%s) exception processing response" % (self.store.host, self.query))
         self.store.fail()
         return
 
       cache.set(self.cacheKey, results, settings.FIND_CACHE_DURATION)
+
+    log.info("FindRequest.send(host=%s, query=%s) completed in %fs" % (self.store.host, self.query, time.time() - t))
 
     for node_info in results:
       # handle both 1.x and 0.9.x output
@@ -137,94 +128,62 @@ class FindRequest(object):
       yield node
 
 
-class ReadResult(object):
-  __slots__ = ('lock', 'store', 'has_done_response_read', 'result', 'done_cb', 'connection', 'urlpath', 'headers')
-
-  def __init__(self, store, urlpath, done_cb, headers=None):
-    self.lock = Lock()
-    self.store = store
-    self.has_done_response_read = False
-    self.result = None
-    self.done_cb = done_cb
-    self.headers = {} if headers is None else headers
-    self.urlpath = urlpath
-    self._connect(urlpath)
-
-  def _connect(self, urlpath):
-    url = "http://%s%s" % (self.store.host, urlpath)
-    try:
-      log.info("ReadResult :: requesting %s" % url)
-      connector_class = connector_class_selector(settings.INTRACLUSTER_HTTPS)
-      self.connection = connector_class(self.store.host)
-      self.connection.timeout = settings.REMOTE_FETCH_TIMEOUT
-      self.connection.request('GET', urlpath, None, self.headers)
-    except:
-      self.store.fail()
-      log.exception("Error requesting %s" % url)
-      raise
-
-  def get(self):
-    """
-    First thread to call `get` will read a response from alrady established connections
-    Subsequent calls will get memoized response
-    """
-    with self.lock:
-      if not self.has_done_response_read:  # we are first one to call for result
-        return self.read_response()
-      else:  # result was already read, return it
-        if self.result is None:
-          raise Exception("Passive remote fetch failed to find cached results")
-        return self.result
-
-  def read_response(self): # called under self.lock
-    try:
-      self.has_done_response_read = True
-
-      # safe if self.connection.timeout works as advertised
-      try: # Python 2.7+, use buffering of HTTP responses
-        response = self.connection.getresponse(buffering=True)
-      except TypeError:  # Python 2.6 and older
-        response = self.connection.getresponse()
-
-      if response.status != 200:
-        raise Exception("Error response %d %s from http://%s%s" % (response.status, response.reason, self.store.host, self.urlpath))
-      pickled_response = response.read()
-      self.result = {
-          series['name']: series
-          for series in unpickle.loads(pickled_response)
-      }
-      return self.result
-    except:
-      self.store.fail()
-      log.exception("Error requesting http://%s%s" % (self.store.host, self.urlpath))
-      raise
-    finally:
-      self.done_cb()
-
 class RemoteReader(object):
   __slots__ = ('store', 'metric_path', 'intervals', 'query', 'connection')
-  inflight_requests = {}
   inflight_lock = Lock()
 
   def __init__(self, store, node_info, bulk_query=None):
     self.store = store
-    self.metric_path = node_info['path']
+    self.metric_path = node_info.get('path') or node_info.get('metric_path')
     self.intervals = node_info['intervals']
-    self.query = bulk_query or node_info['path']
+    self.query = bulk_query or self.metric_path
     self.connection = None
 
   def __repr__(self):
     return '<RemoteReader[%x]: %s>' % (id(self), self.store.host)
 
+  @staticmethod
+  def _log(msg, logger):
+    logger(('thread %s at %fs ' % (current_thread().name, time.time())) + msg)
+
+  @classmethod
+  def log_debug(cls, msg):
+    if settings.DEBUG:
+      cls._log(msg, log.info)
+
+  @classmethod
+  def log_error(cls, msg):
+    cls._log(msg, log.exception)
+
   def get_intervals(self):
     return self.intervals
 
   def fetch(self, startTime, endTime, now=None, requestContext=None):
+    seriesList = self.fetch_list(startTime, endTime, now, requestContext)
+
+    def _fetch(seriesList):
+      if seriesList is None:
+        return None
+
+      for series in seriesList:
+        if series['name'] == self.metric_path:
+          time_info = (series['start'], series['end'], series['step'])
+          return (time_info, series['values'])
+
+      return None
+
+    if isinstance(seriesList, FetchInProgress):
+      return FetchInProgress(lambda: _fetch(seriesList.waitForResults()))
+
+    return _fetch(seriesList)
+
+  def fetch_list(self, startTime, endTime, now=None, requestContext=None):
+    t = time.time()
+
     query_params = [
       ('target', self.query),
       ('format', 'pickle'),
       ('local', '1'),
-      ('noCache', '1'),
       ('from', str( int(startTime) )),
       ('until', str( int(endTime) ))
     ]
@@ -232,30 +191,113 @@ class RemoteReader(object):
       query_params.append(('now', str( int(now) )))
 
     query_string = urlencode(query_params)
-    urlpath = '/render/?' + query_string
-    url = "http://%s%s" % (self.store.host, urlpath)
+    urlpath = '/render/'
+    url = "%s://%s%s" % ('https' if settings.INTRACLUSTER_HTTPS else 'http', self.store.host, urlpath)
     headers = requestContext.get('forwardHeaders') if requestContext else None
 
-    fetch_result = self.get_inflight_requests(url, urlpath, headers)
+    cacheKey = "%s?%s" % (url, query_string)
 
-    def extract_my_results():
-      series = fetch_result.get().get(self.metric_path, None)
-      if not series:
-        return None
-      time_info = (series['start'], series['end'], series['step'])
-      return (time_info, series['values'])
+    if requestContext is not None and 'inflight_requests' in requestContext and cacheKey in requestContext['inflight_requests']:
+      self.log_debug("RemoteReader:: Returning cached FetchInProgress %s?%s" % (url, query_string))
+      return requestContext['inflight_requests'][cacheKey]
 
-    return FetchInProgress(extract_my_results)
+    if requestContext is None or 'inflight_locks' not in requestContext or cacheKey not in requestContext['inflight_locks']:
+      with self.inflight_lock:
+        self.log_debug("RemoteReader:: Got global lock %s?%s" % (url, query_string))
+        if requestContext is None:
+          requestContext = {}
+        if 'inflight_locks' not in requestContext:
+          requestContext['inflight_locks'] = {}
+        if 'inflight_requests' not in requestContext:
+          requestContext['inflight_requests'] = {}
+        if cacheKey not in requestContext['inflight_locks']:
+          self.log_debug("RemoteReader:: Creating lock %s?%s" % (url, query_string))
+          requestContext['inflight_locks'][cacheKey] = Lock()
+      self.log_debug("RemoteReader:: Released global lock %s?%s" % (url, query_string))
 
-  def get_inflight_requests(self, url, urlpath, headers=None):
-    with self.inflight_lock:
-      if url not in self.inflight_requests:
-        self.inflight_requests[url] = ReadResult(self.store, urlpath, lambda: self.done_inflight_request(url), headers)
-      return self.inflight_requests[url]
+    cacheLock = requestContext['inflight_locks'][cacheKey]
 
-  def done_inflight_request(self, url):
-    with self.inflight_lock:
-      del self.inflight_requests[url]
+    with cacheLock:
+      self.log_debug("RemoteReader:: got url lock %s?%s" % (url, query_string))
+
+      if cacheKey in requestContext['inflight_requests']:
+        self.log_debug("RemoteReader:: Returning cached FetchInProgress %s?%s" % (url, query_string))
+        return requestContext['inflight_requests'][cacheKey]
+
+      q = Queue()
+      if settings.USE_WORKER_POOL:
+        get_pool().put(
+          job=(self._fetch, url, query_string, query_params, headers),
+          result_queue=q,
+        )
+      else:
+        q.put(
+          self._fetch(url, query_string, query_params, headers),
+        )
+
+      def retrieve():
+        with retrieve.lock:
+          # if the result is known we return it directly
+          if hasattr(retrieve, '_result'):
+            results = getattr(retrieve, '_result')
+            self.log_debug(
+              'RemoteReader:: retrieve completed (cached) %s' %
+              (', '.join([result['path'] for result in results])),
+            )
+            return results
+
+          # otherwise we get it from the queue and keep it for later
+          results = q.get(block=True)
+
+          for i in range(len(results)):
+            results[i]['path'] = results[i]['name']
+
+          if not results:
+            self.log_debug('RemoteReader:: retrieve has received no results')
+
+          setattr(retrieve, '_result', results)
+          self.log_debug(
+            'RemoteReader:: retrieve completed %s' %
+            (', '.join([result['path'] for result in results])),
+          )
+          return results
+
+      self.log_debug(
+        'RemoteReader:: Storing FetchInProgress with cacheKey {cacheKey}'
+        .format(cacheKey=cacheKey),
+      )
+      retrieve.lock = Lock()
+      data = FetchInProgress(retrieve)
+      requestContext['inflight_requests'][cacheKey] = data
+
+    self.log_debug("RemoteReader:: Returning %s?%s in %fs" % (url, query_string, time.time() - t))
+    return data
+
+  def _fetch(self, url, query_string, query_params, headers):
+    self.log_debug("RemoteReader:: Starting to execute _fetch %s?%s" % (url, query_string))
+    try:
+      self.log_debug("ReadResult:: Requesting %s?%s" % (url, query_string))
+      result = http.request(
+        'POST' if settings.REMOTE_STORE_USE_POST else 'GET',
+        url,
+        fields=query_params,
+        headers=headers,
+        timeout=settings.REMOTE_FETCH_TIMEOUT,
+      )
+
+      if result.status != 200:
+        self.store.fail()
+        self.log_error("ReadResult:: Error response %d from %s?%s" % (result.status, url, query_string))
+        data = []
+      else:
+        data = unpickle.loads(result.data)
+    except Exception as err:
+      self.store.fail()
+      self.log_error("ReadResult:: Error requesting %s?%s: %s" % (url, query_string, err))
+      data = []
+
+    self.log_debug("RemoteReader:: Completed _fetch %s?%s" % (url, query_string))
+    return data
 
 
 def extractForwardHeaders(request):

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -244,26 +244,26 @@ def _fetchData(pathExpr, startTime, endTime, now, requestContext, seriesList):
           series_best_nones[known.name] = candidate_nones
           seriesList[known.name] = series
       else:
-        if not settings.REMOTE_PREFETCH_DATA:
-          # In case if we are merging data - the existing series has no gaps and
-          # there is nothing to merge together.  Save ourselves some work here.
-          #
-          # OR - if we picking best serie:
-          #
-          # We already have this series in the seriesList, and the
-          # candidate is 'worse' than what we already have, we don't need
-          # to compare anything else. Save ourselves some work here.
-          break
-        else:
+        if settings.REMOTE_PREFETCH_DATA:
           # if we're using REMOTE_PREFETCH_DATA we can save some time by skipping
           # find, but that means we don't know how many nodes to expect so we
           # have to iterate over all returned results
           continue
 
-        # If we looked at this series above, and it matched a 'known'
-        # series already, then it's already in the series list (or ignored).
-        # If not, append it here.
+        # In case if we are merging data - the existing series has no gaps and
+        # there is nothing to merge together.  Save ourselves some work here.
+        #
+        # OR - if we picking best serie:
+        #
+        # We already have this series in the seriesList, and the
+        # candidate is 'worse' than what we already have, we don't need
+        # to compare anything else. Save ourselves some work here.
+        break
+
     else:
+      # If we looked at this series above, and it matched a 'known'
+      # series already, then it's already in the series list (or ignored).
+      # If not, append it here.
       seriesList[series.name] = series
 
   log.info("render.datalib._fetchData :: completed in %fs" % (time.time() - t))

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -231,6 +231,7 @@ def _fetchData(pathExpr, startTime, endTime, now, requestContext, seriesList):
           # This series has potential data that might be missing from
           # earlier series.  Attempt to merge in useful data and update
           # the cache count.
+          log.info("Merging multiple TimeSeries for %s" % known.name)
           for i, j in enumerate(known):
             if j is None and series[i] is not None:
               known[i] = series[i]
@@ -285,7 +286,7 @@ def fetchData(requestContext, pathExpr):
     try:
       seriesList = _fetchData(pathExpr, startTime, endTime, now, requestContext, seriesList)
       break
-    except Exception, e:
+    except Exception:
       if retries >= settings.MAX_FETCH_RETRIES:
         log.exception("Failed after %s retry! Root cause:\n%s" %
             (settings.MAX_FETCH_RETRIES, format_exc()))

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -12,12 +12,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-from threading import current_thread
-
 from graphite.logger import log
 from graphite.storage import STORE
 from graphite.readers import FetchInProgress
-from graphite.remote_storage import RemoteReader
 from django.conf import settings
 from graphite.util import timebounds, logtime
 
@@ -108,24 +105,6 @@ class TimeSeries(list):
       'values' : list(self),
       'pathExpression' : self.pathExpression,
     }
-
-
-def prefetchRemoteData(requestContext, pathExpressions):
-  if requestContext['localOnly']:
-    return
-
-  if requestContext is None:
-    requestContext = {}
-
-  (startTime, endTime, now) = timebounds(requestContext)
-  log.info('thread %s prefetchRemoteData:: Starting fetch_list on all backends' % current_thread().name)
-
-  # Go through all of the remote nodes, and launch a fetch for each one.
-  # Each fetch will take place in its own thread, since it's naturally parallel work.
-  for pathExpr in pathExpressions:
-    for store in STORE.remote_stores:
-      reader = RemoteReader(store, {'path': pathExpr, 'intervals': []}, bulk_query=pathExpr)
-      reader.fetch_list(startTime, endTime, now, requestContext)
 
 
 @logtime()

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -133,6 +133,8 @@ def _fetchData(pathExpr, startTime, endTime, now, requestContext, seriesList):
   t = time.time()
 
   if settings.REMOTE_PREFETCH_DATA:
+    matching_nodes = [node for node in STORE.find(pathExpr, startTime, endTime, local=True)]
+
     # inflight_requests is only present if at least one remote store
     # has been queried
     if 'inflight_requests' in requestContext:
@@ -141,6 +143,10 @@ def _fetchData(pathExpr, startTime, endTime, now, requestContext, seriesList):
       fetches = {}
 
     def result_queue_generator():
+      for node in matching_nodes:
+        if node.is_leaf:
+          yield (node.path, node.fetch(startTime, endTime, now, requestContext))
+
       log.info(
         'render.datalib.fetchData:: result_queue_generator got {count} fetches'
         .format(count=len(fetches)),

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -86,23 +86,22 @@ def evaluateTokens(requestContext, tokens, replacements=None):
 def extractPathExpressions(targets):
   # Returns a list of unique pathExpressions found in the targets list
 
-  pathExpressions = []
+  pathExpressions = set()
 
   def extractPathExpression(tokens):
     if tokens.expression:
       return extractPathExpression(tokens.expression)
     elif tokens.pathExpression:
-      pathExpressions.append(tokens.pathExpression)
+      pathExpressions.add(tokens.pathExpression)
     elif tokens.call:
-      [extractPathExpression(arg) for arg in tokens.call.args]
+      for a in tokens.call.args:
+        extractPathExpression(a)
 
   for target in targets:
     tokens = grammar.parseString(target)
     extractPathExpression(tokens)
 
-  s = set(pathExpressions)
-  pathExpressions = list(s)
-  return pathExpressions
+  return list(pathExpressions)
 
 
 # Avoid import circularities

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -42,8 +42,7 @@ def evaluateTokens(requestContext, tokens, replacements=None):
             return val
         else:
           expression = expression.replace('$'+name, str(replacements[name]))
-    data = fetchData(requestContext, expression)
-    return data
+    return fetchData(requestContext, expression)
 
   elif tokens.call:
     if tokens.call.funcname == 'template':

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -1,6 +1,5 @@
 import re
 from graphite.render.grammar import grammar
-from graphite.util import logtime
 from graphite.render.datalib import fetchData, TimeSeries
 
 

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -1,7 +1,6 @@
 import re
-import time
-from graphite.logger import log
 from graphite.render.grammar import grammar
+from graphite.util import logtime
 from graphite.render.datalib import fetchData, TimeSeries
 
 
@@ -44,9 +43,7 @@ def evaluateTokens(requestContext, tokens, replacements=None):
             return val
         else:
           expression = expression.replace('$'+name, str(replacements[name]))
-    t = time.time()
     data = fetchData(requestContext, expression)
-    log.info("fetchData took %fs" % (time.time() - t))
     return data
 
   elif tokens.call:

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -31,10 +31,10 @@ except ImportError:
 from graphite.compat import HttpResponse
 from graphite.user_util import getProfileByUsername
 from graphite.util import json, unpickle
-from graphite.remote_storage import connector_class_selector, extractForwardHeaders
+from graphite.remote_storage import connector_class_selector, extractForwardHeaders, prefetchRemoteData
+from graphite.storage import STORE
 from graphite.logger import log
 from graphite.render.evaluator import evaluateTarget, extractPathExpressions
-from graphite.render.datalib import prefetchRemoteData
 from graphite.render.attime import parseATTime
 from graphite.render.functions import PieFunctions
 from graphite.render.hashing import hashRequest, hashData
@@ -115,7 +115,7 @@ def renderView(request):
       if settings.REMOTE_PREFETCH_DATA and not requestOptions.get('localOnly'):
         log.rendering("Prefetching remote data")
         pathExpressions = extractPathExpressions(targets)
-        prefetchRemoteData(requestContext, pathExpressions)
+        prefetchRemoteData(STORE.remote_stores, requestContext, pathExpressions)
 
       for target in targets:
         if not target.strip():

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -114,9 +114,9 @@ def renderView(request):
       targets = requestOptions['targets']
       if settings.REMOTE_PREFETCH_DATA and not requestOptions.get('localOnly'):
         log.rendering("Prefetching remote data")
-        t = time()
         pathExpressions = extractPathExpressions(targets)
         prefetchRemoteData(requestContext, pathExpressions)
+
       for target in targets:
         if not target.strip():
           continue

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -58,9 +58,9 @@ def renderView(request):
     'endTime' : requestOptions['endTime'],
     'now': requestOptions['now'],
     'localOnly' : requestOptions['localOnly'],
-    'forwardHeaders': extractForwardHeaders(request),
     'template' : requestOptions['template'],
     'tzinfo' : requestOptions['tzinfo'],
+    'forwardHeaders': extractForwardHeaders(request),
     'data' : []
   }
   data = requestContext['data']

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -14,10 +14,10 @@ limitations under the License."""
 import csv
 import math
 import pytz
+import httplib
 from datetime import datetime
 from time import time
 from random import shuffle
-from httplib import CannotSendRequest
 from urllib import urlencode
 from urlparse import urlsplit, urlunsplit
 from cgi import parse_qs
@@ -31,7 +31,7 @@ except ImportError:
 from graphite.compat import HttpResponse
 from graphite.user_util import getProfileByUsername
 from graphite.util import json, unpickle
-from graphite.remote_storage import connector_class_selector, extractForwardHeaders, prefetchRemoteData
+from graphite.remote_storage import extractForwardHeaders, prefetchRemoteData
 from graphite.storage import STORE
 from graphite.logger import log
 from graphite.render.evaluator import evaluateTarget, extractPathExpressions
@@ -422,6 +422,11 @@ def parseOptions(request):
 
 connectionPools = {}
 
+
+def connector_class_selector(https_support=False):
+    return httplib.HTTPSConnection if https_support else httplib.HTTPConnection
+
+
 def delegateRendering(graphType, graphOptions, headers=None):
   if headers is None:
     headers = {}
@@ -446,7 +451,7 @@ def delegateRendering(graphType, graphOptions, headers=None):
       # Send the request
       try:
         connection.request('POST','/render/local/', postData, headers)
-      except CannotSendRequest:
+      except httplib.CannotSendRequest:
         connection = connector_class(server) #retry once
         connection.timeout = settings.REMOTE_RENDER_CONNECT_TIMEOUT
         connection.request('POST', '/render/local/', postData, headers)

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -51,7 +51,11 @@ STANDARD_DIRS = []
 
 # Cluster settings
 CLUSTER_SERVERS = []
-# This settings control wether https is used to communicate between cluster members
+USE_WORKER_POOL = True
+POOL_WORKERS_PER_BACKEND = 10
+POOL_WORKERS = 10
+
+# This settings control whether https is used to communicate between cluster members
 INTRACLUSTER_HTTPS = False
 REMOTE_FIND_TIMEOUT = 3.0
 REMOTE_FETCH_TIMEOUT = 3.0
@@ -59,6 +63,8 @@ REMOTE_RETRY_DELAY = 60.0
 REMOTE_EXCLUDE_LOCAL = False
 REMOTE_STORE_MERGE_RESULTS = True
 REMOTE_STORE_FORWARD_HEADERS = []
+REMOTE_STORE_USE_POST = False
+REMOTE_PREFETCH_DATA = False
 CARBON_METRIC_PREFIX='carbon'
 CARBONLINK_HOSTS = ["127.0.0.1:7002"]
 CARBONLINK_TIMEOUT = 1.0

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -25,11 +25,6 @@ def get_finder(finder_path):
   return getattr(module, class_name)()
 
 
-def find_into_queue(finder, query, result_queue):
-  # iterate over the returned generator
-  result_queue.put([node for node in finder.find_nodes(query)])
-
-
 class Store:
   def __init__(self, finders=None, hosts=None):
     if finders is None:
@@ -57,6 +52,7 @@ class Store:
 
     # Start remote searches
     if not query.local:
+      random.shuffle(self.remote_stores)
       jobs.extend([
         (store.find, query, headers)
         for store in self.remote_stores if store.available

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -1,5 +1,7 @@
 import time
 import random
+import Queue
+from collections import defaultdict
 
 try:
   from importlib import import_module
@@ -8,17 +10,24 @@ except ImportError:  # python < 2.7 compatibility
 
 from django.conf import settings
 
+from graphite.logger import log
 from graphite.util import is_local_interface, is_pattern
 from graphite.remote_storage import RemoteStore
 from graphite.node import LeafNode
 from graphite.intervals import Interval, IntervalSet
 from graphite.readers import MultiReader
+from graphite.worker_pool.pool import get_pool
 
 
 def get_finder(finder_path):
   module_name, class_name = finder_path.rsplit('.', 1)
   module = import_module(module_name)
   return getattr(module, class_name)()
+
+
+def find_into_queue(finder, query, result_queue):
+  # iterate over the returned generator
+  result_queue.put([node for node in finder.find_nodes(query)])
 
 
 class Store:
@@ -37,33 +46,55 @@ class Store:
   def find(self, pattern, startTime=None, endTime=None, local=False, headers=None):
     query = FindQuery(pattern, startTime, endTime, local)
 
+    for match in self.find_all(query, headers):
+      yield match
+
+
+  def find_all(self, query, headers=None):
+    start = time.time()
+    result_queue = Queue.Queue()
+    jobs = []
+
     # Start remote searches
     if not query.local:
-      random.shuffle(self.remote_stores)
-      remote_requests = [ r.find(query, headers) for r in self.remote_stores if r.available ]
+      jobs.extend([
+        (store.find, query, headers)
+        for store in self.remote_stores if store.available
+      ])
 
-    matching_nodes = set()
-
-    # Search locally
+    # Start local searches
     for finder in self.finders:
-      for node in finder.find_nodes(query):
-        #log.info("find() :: local :: %s" % node)
-        matching_nodes.add(node)
+      jobs.append((finder.find_nodes, query))
 
-    # Gather remote search results
-    if not query.local:
-      for request in remote_requests:
-        for node in request.get_results():
-          #log.info("find() :: remote :: %s from %s" % (node,request.store.host))
-          matching_nodes.add(node)
+    if settings.USE_WORKER_POOL:
+      get_pool().put_multi(jobs, result_queue=result_queue)
+    else:
+      for job in jobs:
+        result_queue.put(job[0](*job[1:]))
 
     # Group matching nodes by their path
-    nodes_by_path = {}
-    for node in matching_nodes:
-      if node.path not in nodes_by_path:
-        nodes_by_path[node.path] = []
+    nodes_by_path = defaultdict(list)
 
-      nodes_by_path[node.path].append(node)
+    deadline = start + settings.REMOTE_FIND_TIMEOUT
+    result_cnt = 0
+
+    while result_cnt < len(jobs):
+      if time.time() > deadline:
+        log.info("Timed out in find_all after %fs" % (settings.REMOTE_FIND_TIMEOUT))
+        break
+
+      try:
+        nodes = result_queue.get(True, 0.01)
+      except Queue.Empty:
+        continue
+
+      log.info("Got a find result after %fs" % (time.time() - start))
+      result_cnt += 1
+      if nodes:
+        for node in nodes:
+          nodes_by_path[node.path].append(node)
+
+    log.info("Got all find results in %fs" % (time.time() - start))
 
     # Reduce matching nodes for each path to a minimal set
     found_branch_nodes = set()

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -63,7 +63,9 @@ class Store:
       jobs.append((finder.find_nodes, query))
 
     if settings.USE_WORKER_POOL:
-      get_pool().put_multi(jobs, result_queue=result_queue)
+      return_result = lambda x: result_queue.put(x)
+      for job in jobs:
+        get_pool().apply_async(func=job[0], args=job[1:], callback=return_result)
     else:
       for job in jobs:
         result_queue.put(job[0](*job[1:]))

--- a/webapp/graphite/worker_pool/pool.py
+++ b/webapp/graphite/worker_pool/pool.py
@@ -1,0 +1,151 @@
+import time
+from Queue import Queue, Full, Empty
+from threading import Thread, Lock
+
+from django.conf import settings
+
+from graphite.logger import log
+
+# we'll never want more than one instance of Pool
+init_lock = Lock()
+is_initialized = False
+
+
+def get_pool():
+  with init_lock:
+    instance = getattr(get_pool, 'instance', None)
+    if instance is None:
+      instance = Pool()
+      setattr(get_pool, 'instance', instance)
+      is_initialized = True
+  return instance
+
+
+def stop_pool():
+  with init_lock:
+    if not is_initialized:
+      return
+
+    get_pool().shutdown()
+
+
+class Pool(object):
+
+  def __init__(self):
+    self.workers = []
+    self.req_q = Queue()
+    self.pool_lock = Lock()
+    self.grow_by(
+      # the number of workers should increase linear with the number of
+      # backend servers
+      settings.POOL_WORKERS_PER_BACKEND * len(settings.CLUSTER_SERVERS) +
+      # plus we need some baseline for local finds and other stuff that
+      # always happens
+      settings.POOL_WORKERS
+    )
+
+  def grow_by(self, worker_count):
+    with self.pool_lock:
+      for i in range(worker_count):
+        self.workers.append(Worker(self.req_q, self))
+
+    log.info("got {workers} workers".format(workers=len(self.workers)))
+
+  def shutdown(self):
+    with self.pool_lock:
+      for worker in self.workers:
+        worker.shutdown = True
+
+      self.put_multi(
+        jobs=[
+          None
+          for i in range(len(self.workers))
+        ],
+        result_queue=False,
+      )
+
+      while self.workers:
+        self.workers.pop().t.join()
+
+  # takes a job to execute and a queue to put the result in
+  def put(self, job, result_queue=None):
+    try:
+      self.req_q.put(
+        (job, result_queue)
+      )
+    except Full:
+      raise Exception('All backend workers busy')
+
+  def put_multi(self, jobs, timeout=5, result_queue=None):
+    if result_queue is None:
+      q = Queue()
+    else:
+      q = result_queue
+
+    log_pre = 'put_multi ({inst}): '.format(inst=str(q))
+
+    i = 0
+    while i < len(jobs):
+      log.info(
+        '{pre}Submitting queue job {nr}/{tot}'
+        .format(pre=log_pre, nr=i+1, tot=len(jobs)),
+      )
+      self.put(jobs[i], q)
+      i += 1
+
+    if result_queue is not None:
+      return
+
+    start = time.time()
+    deadline = start + timeout
+    results = []
+
+    while i > 0:
+      if time.time() > deadline:
+        log.info("Timed out in pool.put_multi")
+
+      try:
+        results.append(q.get(block=True, timeout=0.1))
+        i -= 1
+      except Empty:
+        pass
+
+    log.info(
+      '{pre}Completed in {sec}s'
+      .format(sec=time.time()-start, pre=log_pre),
+    )
+    return results
+
+
+class Worker(object):
+
+  def __init__(self, req_q, pool):
+    self.pool = pool
+    self.req_q = req_q
+    self.shutdown = False
+    self.start()
+
+  def start(self):
+    self.t = Thread(target=self.loop)
+    self.t.start()
+
+  def loop(self):
+    self.ident = self.t.ident
+    while True:
+      self.process(self.req_q.get(block=True))
+      if self.shutdown:
+        break
+
+  def process(self, job):
+    if self.shutdown:
+      return
+
+    log.info('Thread {thread} at {time}: processing'.format(
+      thread=str(self.ident),
+      time=time.time(),
+    ))
+    self.respond(job[1], job[0][0](*job[0][1:]))
+
+  def respond(self, queue, reply):
+    if queue is not None:
+      queue.put(reply)

--- a/webapp/graphite/worker_pool/pool.py
+++ b/webapp/graphite/worker_pool/pool.py
@@ -1,21 +1,21 @@
-import time
-from Queue import Queue, Full, Empty
-from threading import Thread, Lock
-
+from threading import Lock
 from django.conf import settings
+from multiprocessing.pool import ThreadPool
 
-from graphite.logger import log
-
-# we'll never want more than one instance of Pool
 init_lock = Lock()
 is_initialized = False
 
+
+# the number of workers should increase linear with the number of
+# backend servers, plus we need some baseline for local finds and
+# other stuff that always happens
+thread_count = settings.POOL_WORKERS_PER_BACKEND * len(settings.CLUSTER_SERVERS) + settings.POOL_WORKERS
 
 def get_pool():
   with init_lock:
     instance = getattr(get_pool, 'instance', None)
     if instance is None:
-      instance = Pool()
+      instance = ThreadPool(thread_count)
       setattr(get_pool, 'instance', instance)
       is_initialized = True
   return instance
@@ -26,126 +26,4 @@ def stop_pool():
     if not is_initialized:
       return
 
-    get_pool().shutdown()
-
-
-class Pool(object):
-
-  def __init__(self):
-    self.workers = []
-    self.req_q = Queue()
-    self.pool_lock = Lock()
-    self.grow_by(
-      # the number of workers should increase linear with the number of
-      # backend servers
-      settings.POOL_WORKERS_PER_BACKEND * len(settings.CLUSTER_SERVERS) +
-      # plus we need some baseline for local finds and other stuff that
-      # always happens
-      settings.POOL_WORKERS
-    )
-
-  def grow_by(self, worker_count):
-    with self.pool_lock:
-      for i in range(worker_count):
-        self.workers.append(Worker(self.req_q, self))
-
-    log.info("got {workers} workers".format(workers=len(self.workers)))
-
-  def shutdown(self):
-    with self.pool_lock:
-      for worker in self.workers:
-        worker.shutdown = True
-
-      self.put_multi(
-        jobs=[
-          None
-          for i in range(len(self.workers))
-        ],
-        result_queue=False,
-      )
-
-      while self.workers:
-        self.workers.pop().t.join()
-
-  # takes a job to execute and a queue to put the result in
-  def put(self, job, result_queue=None):
-    try:
-      self.req_q.put(
-        (job, result_queue)
-      )
-    except Full:
-      raise Exception('All backend workers busy')
-
-  def put_multi(self, jobs, timeout=5, result_queue=None):
-    if result_queue is None:
-      q = Queue()
-    else:
-      q = result_queue
-
-    log_pre = 'put_multi ({inst}): '.format(inst=str(q))
-
-    i = 0
-    while i < len(jobs):
-      log.info(
-        '{pre}Submitting queue job {nr}/{tot}'
-        .format(pre=log_pre, nr=i+1, tot=len(jobs)),
-      )
-      self.put(jobs[i], q)
-      i += 1
-
-    if result_queue is not None:
-      return
-
-    start = time.time()
-    deadline = start + timeout
-    results = []
-
-    while i > 0:
-      if time.time() > deadline:
-        log.info("Timed out in pool.put_multi")
-
-      try:
-        results.append(q.get(block=True, timeout=0.1))
-        i -= 1
-      except Empty:
-        pass
-
-    log.info(
-      '{pre}Completed in {sec}s'
-      .format(sec=time.time()-start, pre=log_pre),
-    )
-    return results
-
-
-class Worker(object):
-
-  def __init__(self, req_q, pool):
-    self.pool = pool
-    self.req_q = req_q
-    self.shutdown = False
-    self.start()
-
-  def start(self):
-    self.t = Thread(target=self.loop)
-    self.t.start()
-
-  def loop(self):
-    self.ident = self.t.ident
-    while True:
-      self.process(self.req_q.get(block=True))
-      if self.shutdown:
-        break
-
-  def process(self, job):
-    if self.shutdown:
-      return
-
-    log.info('Thread {thread} at {time}: processing'.format(
-      thread=str(self.ident),
-      time=time.time(),
-    ))
-    self.respond(job[1], job[0][0](*job[0][1:]))
-
-  def respond(self, queue, reply):
-    if queue is not None:
-      queue.put(reply)
+    get_pool().close()

--- a/webapp/tests/base.py
+++ b/webapp/tests/base.py
@@ -1,0 +1,8 @@
+from django.test import TestCase
+from graphite.worker_pool.pool import stop_pool
+
+
+class BaseTestCase(TestCase):
+
+  def tearDown(self):
+    stop_pool()

--- a/webapp/tests/base.py
+++ b/webapp/tests/base.py
@@ -1,8 +1,8 @@
-from django.test import TestCase
+from django.test import TestCase as OriginalTestCase
 from graphite.worker_pool.pool import stop_pool
 
 
-class BaseTestCase(TestCase):
+class TestCase(OriginalTestCase):
 
   def tearDown(self):
     stop_pool()

--- a/webapp/tests/test_attime.py
+++ b/webapp/tests/test_attime.py
@@ -7,7 +7,7 @@ from graphite.render.attime import parseTimeReference, parseATTime, parseTimeOff
 from datetime import datetime, timedelta
 
 from django.utils import timezone
-from django.test import TestCase
+from .base import BaseTestCase as TestCase
 import pytz
 import mock
 

--- a/webapp/tests/test_attime.py
+++ b/webapp/tests/test_attime.py
@@ -7,7 +7,7 @@ from graphite.render.attime import parseTimeReference, parseATTime, parseTimeOff
 from datetime import datetime, timedelta
 
 from django.utils import timezone
-from .base import BaseTestCase as TestCase
+from .base import TestCase
 import pytz
 import mock
 

--- a/webapp/tests/test_browser.py
+++ b/webapp/tests/test_browser.py
@@ -4,7 +4,7 @@ import os
 
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
-from django.test import TestCase
+from .base import BaseTestCase as TestCase
 from django.test.utils import override_settings
 
 from . import DATA_DIR

--- a/webapp/tests/test_browser.py
+++ b/webapp/tests/test_browser.py
@@ -4,7 +4,7 @@ import os
 
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
-from .base import BaseTestCase as TestCase
+from .base import TestCase
 from django.test.utils import override_settings
 
 from . import DATA_DIR

--- a/webapp/tests/test_dashboard.py
+++ b/webapp/tests/test_dashboard.py
@@ -9,7 +9,7 @@ from . import TEST_CONF_DIR
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
-from django.test import TestCase
+from .base import BaseTestCase as TestCase
 from django.test.utils import override_settings
 try:
     from django.contrib.auth import get_user_model

--- a/webapp/tests/test_dashboard.py
+++ b/webapp/tests/test_dashboard.py
@@ -9,7 +9,7 @@ from . import TEST_CONF_DIR
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
-from .base import BaseTestCase as TestCase
+from .base import TestCase
 from django.test.utils import override_settings
 try:
     from django.contrib.auth import get_user_model

--- a/webapp/tests/test_events.py
+++ b/webapp/tests/test_events.py
@@ -4,7 +4,7 @@ import json
 from datetime import timedelta
 
 from django.core.urlresolvers import reverse
-from django.test import TestCase
+from .base import BaseTestCase as TestCase
 from django.utils import timezone
 
 from graphite.events.models import Event

--- a/webapp/tests/test_events.py
+++ b/webapp/tests/test_events.py
@@ -4,7 +4,7 @@ import json
 from datetime import timedelta
 
 from django.core.urlresolvers import reverse
-from .base import BaseTestCase as TestCase
+from .base import TestCase
 from django.utils import timezone
 
 from graphite.events.models import Event

--- a/webapp/tests/test_finders.py
+++ b/webapp/tests/test_finders.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     from mock import patch
 
-from django.test import TestCase
+from .base import BaseTestCase as TestCase
 from django.conf import settings
 
 from graphite.intervals import Interval, IntervalSet

--- a/webapp/tests/test_finders.py
+++ b/webapp/tests/test_finders.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     from mock import patch
 
-from .base import BaseTestCase as TestCase
+from .base import TestCase
 from django.conf import settings
 
 from graphite.intervals import Interval, IntervalSet

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from fnmatch import fnmatch
 from mock import patch, call, MagicMock
 
-from django.test import TestCase
+from .base import BaseTestCase as TestCase
 from django.conf import settings
 
 from graphite.render.datalib import TimeSeries

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from fnmatch import fnmatch
 from mock import patch, call, MagicMock
 
-from .base import BaseTestCase as TestCase
+from .base import TestCase
 from django.conf import settings
 
 from graphite.render.datalib import TimeSeries

--- a/webapp/tests/test_logger.py
+++ b/webapp/tests/test_logger.py
@@ -8,6 +8,7 @@ from logging import FileHandler
 from django.conf import settings
 
 from graphite.logger import log, GraphiteLogger
+from graphite.worker_pool.pool import get_pool
 
 
 class TestLogger(unittest.TestCase):
@@ -47,3 +48,6 @@ class TestLogger(unittest.TestCase):
         self.assertTrue(isinstance(log.infoLogger.handlers[0], FileHandler))
         self.assertTrue(isinstance(log.exceptionLogger.handlers[0], FileHandler))
         settings.LOG_ROTATION = old_val
+
+    def tearDown(self):
+        get_pool().shutdown()

--- a/webapp/tests/test_logger.py
+++ b/webapp/tests/test_logger.py
@@ -50,4 +50,4 @@ class TestLogger(unittest.TestCase):
         settings.LOG_ROTATION = old_val
 
     def tearDown(self):
-        get_pool().shutdown()
+        get_pool().close()

--- a/webapp/tests/test_metrics.py
+++ b/webapp/tests/test_metrics.py
@@ -6,7 +6,7 @@ import time
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from django.test import TestCase
+from .base import BaseTestCase as TestCase
 
 import whisper
 

--- a/webapp/tests/test_metrics.py
+++ b/webapp/tests/test_metrics.py
@@ -6,7 +6,7 @@ import time
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from .base import BaseTestCase as TestCase
+from .base import TestCase
 
 import whisper
 

--- a/webapp/tests/test_readers.py
+++ b/webapp/tests/test_readers.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from .base import BaseTestCase as TestCase
 
 from graphite import readers
 

--- a/webapp/tests/test_readers.py
+++ b/webapp/tests/test_readers.py
@@ -1,4 +1,4 @@
-from .base import BaseTestCase as TestCase
+from .base import TestCase
 
 from graphite import readers
 

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -12,7 +12,7 @@ import whisper
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import HttpRequest, QueryDict
-from django.test import TestCase
+from .base import BaseTestCase as TestCase
 
 # Silence logging during tests
 LOGGER = logging.getLogger()

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -7,12 +7,13 @@ import logging
 import shutil
 
 from graphite.render.hashing import ConsistentHashRing, hashRequest, hashData
+from graphite.render.evaluator import extractPathExpressions
 import whisper
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import HttpRequest, QueryDict
-from .base import BaseTestCase as TestCase
+from .base import TestCase
 
 # Silence logging during tests
 LOGGER = logging.getLogger()
@@ -55,6 +56,14 @@ class RenderTest(TestCase):
             shutil.rmtree(self.hostcpu.replace('hostname/cpu.wsp', ''))
         except OSError:
             pass
+
+    def test_render_evaluator(self):
+        test_input = ['somefunc(my.metri[cz].{one,two})=123', 'target1,target2']
+        expected_output = ['my.metri[cz].{one,two}', 'target1']
+        outputs = extractPathExpressions(test_input)
+
+        self.assertTrue(all(output in expected_output for output in outputs))
+        self.assertTrue(all(output in outputs for output in expected_output))
 
     def test_render_view(self):
         url = reverse('graphite.render.views.renderView')

--- a/webapp/tests/test_render_datalib.py
+++ b/webapp/tests/test_render_datalib.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from .base import BaseTestCase as TestCase
 
 from graphite.render.datalib import TimeSeries, nonempty
 

--- a/webapp/tests/test_render_datalib.py
+++ b/webapp/tests/test_render_datalib.py
@@ -1,4 +1,4 @@
-from .base import BaseTestCase as TestCase
+from .base import TestCase
 
 from graphite.render.datalib import TimeSeries, nonempty
 

--- a/webapp/tests/test_render_glyph.py
+++ b/webapp/tests/test_render_glyph.py
@@ -1,6 +1,6 @@
 import copy
 
-from django.test import TestCase
+from .base import BaseTestCase as TestCase
 
 from graphite.render import glyph
 from graphite.render.datalib import TimeSeries

--- a/webapp/tests/test_render_glyph.py
+++ b/webapp/tests/test_render_glyph.py
@@ -1,6 +1,6 @@
 import copy
 
-from .base import BaseTestCase as TestCase
+from .base import TestCase
 
 from graphite.render import glyph
 from graphite.render.datalib import TimeSeries

--- a/webapp/tests/test_storage.py
+++ b/webapp/tests/test_storage.py
@@ -3,7 +3,7 @@ import logging
 from graphite.storage import Store
 
 from django.conf import settings
-from django.test import TestCase
+from .base import BaseTestCase as TestCase
 
 # Silence logging during tests
 LOGGER = logging.getLogger()

--- a/webapp/tests/test_storage.py
+++ b/webapp/tests/test_storage.py
@@ -3,7 +3,7 @@ import logging
 from graphite.storage import Store
 
 from django.conf import settings
-from .base import BaseTestCase as TestCase
+from .base import TestCase
 
 # Silence logging during tests
 LOGGER = logging.getLogger()

--- a/webapp/tests/test_user_util.py
+++ b/webapp/tests/test_user_util.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from .base import BaseTestCase as TestCase
 from django.http import HttpRequest
 
 #from django.contrib.auth import authenticate

--- a/webapp/tests/test_user_util.py
+++ b/webapp/tests/test_user_util.py
@@ -1,4 +1,4 @@
-from .base import BaseTestCase as TestCase
+from .base import TestCase
 from django.http import HttpRequest
 
 #from django.contrib.auth import authenticate

--- a/webapp/tests/test_util.py
+++ b/webapp/tests/test_util.py
@@ -3,7 +3,7 @@ import shutil
 import time
 import whisper
 
-from django.test import TestCase
+from .base import BaseTestCase as TestCase
 
 from django.conf import settings
 from graphite import util

--- a/webapp/tests/test_util.py
+++ b/webapp/tests/test_util.py
@@ -3,7 +3,7 @@ import shutil
 import time
 import whisper
 
-from .base import BaseTestCase as TestCase
+from .base import TestCase
 
 from django.conf import settings
 from graphite import util

--- a/webapp/tests/test_versions.py
+++ b/webapp/tests/test_versions.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from django.test import TestCase
+from .base import BaseTestCase as TestCase
 
 
 class VersionTest(TestCase):

--- a/webapp/tests/test_versions.py
+++ b/webapp/tests/test_versions.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from .base import BaseTestCase as TestCase
+from .base import TestCase
 
 
 class VersionTest(TestCase):

--- a/webapp/tests/test_whitelist.py
+++ b/webapp/tests/test_whitelist.py
@@ -7,7 +7,7 @@ from . import DATA_DIR
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from django.test import TestCase
+from .base import BaseTestCase as TestCase
 
 from graphite.whitelist.views import load_whitelist, save_whitelist
 

--- a/webapp/tests/test_whitelist.py
+++ b/webapp/tests/test_whitelist.py
@@ -7,7 +7,7 @@ from . import DATA_DIR
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from .base import BaseTestCase as TestCase
+from .base import TestCase
 
 from graphite.whitelist.views import load_whitelist, save_whitelist
 


### PR DESCRIPTION
Improves the performance if CLUSTER_SERVERS are used, especially if there are multiple backend servers.

* On the first request to any backend node a pool of worker threads gets created
* Everything that can be offloaded from the request handling threads or that can be parallelized is sent to the worker pool via queues
* The request handling thread and the worker threads synchronize via locks and queues

In my benchmarks it performs better than both `master` and `0.9.15`