### PR TITLE
add json format option for find api

### DIFF
--- a/webapp/graphite/intervals.py
+++ b/webapp/graphite/intervals.py
@@ -19,6 +19,12 @@ class IntervalSet:
   def __iter__(self):
     return iter(self.intervals)
 
+  def __len__(self):
+    return len(self.intervals)
+
+  def __getitem__(self, i):
+    return self.intervals[i]
+
   def __nonzero__(self):
     return self.size != 0
 

--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -157,6 +157,10 @@ def find_view(request):
     content = pickle_nodes(matches)
     response = HttpResponse(content, content_type='application/pickle')
 
+  elif format == 'json':
+    content = json_nodes(matches)
+    response = json_response_for(request, content, jsonp=jsonp)
+
   elif format == 'completer':
     results = []
     for node in matches:
@@ -340,6 +344,19 @@ def pickle_nodes(nodes):
     nodes_info.append(info)
 
   return pickle.dumps(nodes_info, protocol=-1)
+
+
+def json_nodes(nodes):
+  nodes_info = []
+
+  for node in nodes:
+    info = dict(path=node.path, is_leaf=node.is_leaf)
+    if node.is_leaf:
+      info['intervals'] = [{'start': i.start, 'end': i.end} for i in node.intervals]
+
+    nodes_info.append(info)
+
+  return nodes_info
 
 
 def json_response_for(request, data, content_type='application/json',

--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -356,7 +356,7 @@ def json_nodes(nodes):
 
     nodes_info.append(info)
 
-  return nodes_info
+  return sorted(nodes_info, key=lambda item: item['path'])
 
 
 def json_response_for(request, data, content_type='application/json',


### PR DESCRIPTION
This patch adds a lightweight json output format option for find requests.  It was initially implemented as part of the work on clustering.  The json format is pretty simple, supporting leaf and branch nodes and looks like this:
```
[
  {
    "is_leaf": true,
    "path": "carbon.agents.dev-a.cpuUsage",
    "intervals": [
      {"start": 1478989692.654787, "end": 1486765671.553646}
      ...
    ]
  },
  {
    "is_leaf": false,
    "path": "carbon.agents.dev-a"
  }
  ...
]
```
It also supports the jsonp parameter with the same semantics as the existing `completer` format and is roughly 20% more compact than the existing `pickle` encoding.