### PR TITLE
supporting refactors for #1818

### DIFF
--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -245,7 +245,7 @@
 # used.
 #CLUSTER_SERVERS = ["10.0.2.2:80", "10.0.2.3:80"]
 
-# This settings control wether https is used to communicate between cluster members
+# This setting controls whether https is used to communicate between cluster members
 #INTRACLUSTER_HTTPS = False
 
 # These are timeout values (in seconds) for requests to remote webapps

--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -4,12 +4,12 @@ from urllib import urlencode
 from threading import Lock
 from django.conf import settings
 from django.core.cache import cache
+from graphite.intervals import Interval, IntervalSet
 from graphite.node import LeafNode, BranchNode
-from graphite.readers import FetchInProgress
 from graphite.logger import log
 from graphite.util import unpickle
+from graphite.readers import FetchInProgress
 from graphite.render.hashing import compactHash
-from graphite.intervals import Interval, IntervalSet
 
 def connector_class_selector(https_support=False):
     return httplib.HTTPSConnection if https_support else httplib.HTTPConnection

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -110,7 +110,8 @@ def renderView(request):
     if cachedData is not None:
       requestContext['data'] = data = cachedData
     else: # Have to actually retrieve the data now
-      for target in requestOptions['targets']:
+      targets = requestOptions['targets']
+      for target in targets:
         if not target.strip():
           continue
         t = time()

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -35,10 +35,10 @@ class Store:
 
 
   def find(self, pattern, startTime=None, endTime=None, local=False, headers=None):
-    query = FindQuery(pattern, startTime, endTime)
+    query = FindQuery(pattern, startTime, endTime, local)
 
     # Start remote searches
-    if not local:
+    if not query.local:
       random.shuffle(self.remote_stores)
       remote_requests = [ r.find(query, headers) for r in self.remote_stores if r.available ]
 
@@ -51,7 +51,7 @@ class Store:
         matching_nodes.add(node)
 
     # Gather remote search results
-    if not local:
+    if not query.local:
       for request in remote_requests:
         for node in request.get_results():
           #log.info("find() :: remote :: %s from %s" % (node,request.store.host))
@@ -156,13 +156,14 @@ class Store:
 
 
 class FindQuery:
-  def __init__(self, pattern, startTime, endTime):
+  def __init__(self, pattern, startTime, endTime, local=False):
     self.pattern = pattern
     self.startTime = startTime
     self.endTime = endTime
     self.isExact = is_pattern(pattern)
     self.interval = Interval(float('-inf') if startTime is None else startTime,
                              float('inf') if endTime is None else endTime)
+    self.local = local
 
 
   def __repr__(self):

--- a/webapp/tests/test_render_datalib.py
+++ b/webapp/tests/test_render_datalib.py
@@ -46,7 +46,7 @@ class TimeSeriesTest(TestCase):
     def test_TimeSeries_getInfo(self):
       values = range(0,100)
       series = TimeSeries("collectd.test-db.load.value", 0, len(values), 1, values)
-      self.assertEqual(series.getInfo(), {'name': 'collectd.test-db.load.value', 'values': values, 'start': 0, 'step': 1, 'end': len(values)} )
+      self.assertEqual(series.getInfo(), {'name': 'collectd.test-db.load.value', 'values': values, 'start': 0, 'step': 1, 'end': len(values), 'pathExpression': 'collectd.test-db.load.value'} )
 
     def test_TimeSeries_consolidate(self):
       values = range(0,100)


### PR DESCRIPTION
This patch implements support for the REMOTE_STORE_FORWARD_HEADERS config option, and adds some supporting changes for #1818.  The general approach is the same as #1736 and if desired we could apply that separately which (after some cleanup & conflict resolution) would reduce this patch to an update to  pass an explicit "now" value to backends, make the requestContext available in more places, and some other supporting refactor work to reduce the size of the #1818 patch.