### PR TITLE
move _fetchData out of fetchData

### DIFF
--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -104,96 +104,96 @@ class TimeSeries(list):
       'values' : list(self),
     }
 
+def _fetchData(pathExpr,startTime, endTime, requestContext, seriesList):
+  matching_nodes = STORE.find(pathExpr, startTime, endTime, local=requestContext['localOnly'])
+  fetches = [(node, node.fetch(startTime, endTime)) for node in matching_nodes if node.is_leaf]
+
+  for node, results in fetches:
+    if isinstance(results, FetchInProgress):
+      results = results.waitForResults()
+
+    if not results:
+      log.info("render.datalib.fetchData :: no results for %s.fetch(%s, %s)" % (node, startTime, endTime))
+      continue
+
+    try:
+        (timeInfo, values) = results
+    except ValueError as e:
+        raise Exception("could not parse timeInfo/values from metric '%s': %s" % (node.path, e))
+    (start, end, step) = timeInfo
+
+    series = TimeSeries(node.path, start, end, step, values)
+    series.pathExpression = pathExpr #hack to pass expressions through to render functions
+
+    # Used as a cache to avoid recounting series None values below.
+    series_best_nones = {}
+
+    if series.name in seriesList:
+      # This counts the Nones in each series, and is unfortunately O(n) for each
+      # series, which may be worth further optimization. The value of doing this
+      # at all is to avoid the "flipping" effect of loading a graph multiple times
+      # and having inconsistent data returned if one of the backing stores has
+      # inconsistent data. This is imperfect as a validity test, but in practice
+      # nicely keeps us using the "most complete" dataset available. Think of it
+      # as a very weak CRDT resolver.
+      candidate_nones = 0
+      if not settings.REMOTE_STORE_MERGE_RESULTS:
+        candidate_nones = len(
+          [val for val in series['values'] if val is None])
+
+      known = seriesList[series.name]
+      # To avoid repeatedly recounting the 'Nones' in series we've already seen,
+      # cache the best known count so far in a dict.
+      if known.name in series_best_nones:
+        known_nones = series_best_nones[known.name]
+      else:
+        known_nones = len([val for val in known if val is None])
+
+      if known_nones > candidate_nones:
+        if settings.REMOTE_STORE_MERGE_RESULTS:
+          # This series has potential data that might be missing from
+          # earlier series.  Attempt to merge in useful data and update
+          # the cache count.
+          log.info("Merging multiple TimeSeries for %s" % known.name)
+          for i, j in enumerate(known):
+            if j is None and series[i] is not None:
+              known[i] = series[i]
+              known_nones -= 1
+          # Store known_nones in our cache
+          series_best_nones[known.name] = known_nones
+        else:
+          # Not merging data -
+          # we've found a series better than what we've already seen. Update
+          # the count cache and replace the given series in the array.
+          series_best_nones[known.name] = candidate_nones
+          seriesList[known.name] = series
+      else:
+        # In case if we are merging data - the existing series has no gaps and there is nothing to merge
+        # together.  Save ourselves some work here.
+        #
+        # OR - if we picking best serie:
+        #
+        # We already have this series in the seriesList, and the
+        # candidate is 'worse' than what we already have, we don't need
+        # to compare anything else. Save ourselves some work here.
+        break
+
+        # If we looked at this series above, and it matched a 'known'
+        # series already, then it's already in the series list (or ignored).
+        # If not, append it here.
+    else:
+      seriesList[series.name] = series
+
+  # Stabilize the order of the results by ordering the resulting series by name.
+  # This returns the result ordering to the behavior observed pre PR#1010.
+  return [seriesList[k] for k in sorted(seriesList)]
+
 
 # Data retrieval API
 def fetchData(requestContext, pathExpr):
   seriesList = {}
   startTime = int( epoch( requestContext['startTime'] ) )
   endTime   = int( epoch( requestContext['endTime'] ) )
-
-  def _fetchData(pathExpr,startTime, endTime, requestContext, seriesList):
-    matching_nodes = STORE.find(pathExpr, startTime, endTime, local=requestContext['localOnly'])
-    fetches = [(node, node.fetch(startTime, endTime)) for node in matching_nodes if node.is_leaf]
-
-    for node, results in fetches:
-      if isinstance(results, FetchInProgress):
-        results = results.waitForResults()
-
-      if not results:
-        log.info("render.datalib.fetchData :: no results for %s.fetch(%s, %s)" % (node, startTime, endTime))
-        continue
-
-      try:
-          (timeInfo, values) = results
-      except ValueError as e:
-          raise Exception("could not parse timeInfo/values from metric '%s': %s" % (node.path, e))
-      (start, end, step) = timeInfo
-
-      series = TimeSeries(node.path, start, end, step, values)
-      series.pathExpression = pathExpr #hack to pass expressions through to render functions
-
-      # Used as a cache to avoid recounting series None values below.
-      series_best_nones = {}
-
-      if series.name in seriesList:
-        # This counts the Nones in each series, and is unfortunately O(n) for each
-        # series, which may be worth further optimization. The value of doing this
-        # at all is to avoid the "flipping" effect of loading a graph multiple times
-        # and having inconsistent data returned if one of the backing stores has
-        # inconsistent data. This is imperfect as a validity test, but in practice
-        # nicely keeps us using the "most complete" dataset available. Think of it
-        # as a very weak CRDT resolver.
-        candidate_nones = 0
-        if not settings.REMOTE_STORE_MERGE_RESULTS:
-          candidate_nones = len(
-            [val for val in series['values'] if val is None])
-
-        known = seriesList[series.name]
-        # To avoid repeatedly recounting the 'Nones' in series we've already seen,
-        # cache the best known count so far in a dict.
-        if known.name in series_best_nones:
-          known_nones = series_best_nones[known.name]
-        else:
-          known_nones = len([val for val in known if val is None])
-
-        if known_nones > candidate_nones:
-          if settings.REMOTE_STORE_MERGE_RESULTS:
-            # This series has potential data that might be missing from
-            # earlier series.  Attempt to merge in useful data and update
-            # the cache count.
-            log.info("Merging multiple TimeSeries for %s" % known.name)
-            for i, j in enumerate(known):
-              if j is None and series[i] is not None:
-                known[i] = series[i]
-                known_nones -= 1
-            # Store known_nones in our cache
-            series_best_nones[known.name] = known_nones
-          else:
-            # Not merging data -
-            # we've found a series better than what we've already seen. Update
-            # the count cache and replace the given series in the array.
-            series_best_nones[known.name] = candidate_nones
-            seriesList[known.name] = series
-        else:
-          # In case if we are merging data - the existing series has no gaps and there is nothing to merge
-          # together.  Save ourselves some work here.
-          #
-          # OR - if we picking best serie:
-          #
-          # We already have this series in the seriesList, and the
-          # candidate is 'worse' than what we already have, we don't need
-          # to compare anything else. Save ourselves some work here.
-          break
-
-          # If we looked at this series above, and it matched a 'known'
-          # series already, then it's already in the series list (or ignored).
-          # If not, append it here.
-      else:
-        seriesList[series.name] = series
-
-    # Stabilize the order of the results by ordering the resulting series by name.
-    # This returns the result ordering to the behavior observed pre PR#1010.
-    return [seriesList[k] for k in sorted(seriesList)]
 
   retries = 1 # start counting at one to make log output and settings more readable
   while True:


### PR DESCRIPTION
This patch simply moves the definition of `_fetchData` out of `fetchData` and makes it a separate top-level function.

The advantage of this change is that it makes it easier for a user to understand the logic flow in `fetchData` as it's no longer interrupted midway by the definition of `_fetchData`.