### PR TITLE
pass consistent 'now' value to backend nodes

### DIFF
--- a/webapp/graphite/node.py
+++ b/webapp/graphite/node.py
@@ -25,8 +25,13 @@ class LeafNode(Node):
     self.reader = reader
     self.is_leaf = True
 
-  def fetch(self, startTime, endTime):
-    return self.reader.fetch(startTime, endTime)
+  def fetch(self, startTime, endTime, now=None, requestContext=None):
+    try:
+      result = self.reader.fetch(startTime, endTime, now, requestContext)
+    except TypeError:
+      result = self.reader.fetch(startTime, endTime)
+
+    return result
 
   @property
   def intervals(self):

--- a/webapp/graphite/readers.py
+++ b/webapp/graphite/readers.py
@@ -52,13 +52,13 @@ class MultiReader(object):
       interval_sets.extend( node.intervals.intervals )
     return IntervalSet( sorted(interval_sets) )
 
-  def fetch(self, startTime, endTime):
+  def fetch(self, startTime, endTime, now=None, requestContext=None):
     # Start the fetch on each node
     fetches = []
 
     for n in self.nodes:
       try:
-        fetches.append(n.fetch(startTime, endTime))
+        fetches.append(n.fetch(startTime, endTime, now, requestContext))
       except:
         log.exception("Failed to initiate subfetch for %s" % str(n))
 

--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -215,7 +215,7 @@ class RemoteReader(object):
   def get_intervals(self):
     return self.intervals
 
-  def fetch(self, startTime, endTime):
+  def fetch(self, startTime, endTime, now=None, requestContext=None):
     query_params = [
       ('target', self.query),
       ('format', 'pickle'),
@@ -224,6 +224,9 @@ class RemoteReader(object):
       ('from', str( int(startTime) )),
       ('until', str( int(endTime) ))
     ]
+    if now is not None:
+      query_params.append(('now', str( int(now) )))
+
     query_string = urlencode(query_params)
     urlpath = '/render/?' + query_string
     url = "http://%s%s" % (self.store.host, urlpath)

--- a/webapp/graphite/render/attime.py
+++ b/webapp/graphite/render/attime.py
@@ -20,7 +20,7 @@ from django.conf import settings
 months = ['jan','feb','mar','apr','may','jun','jul','aug','sep','oct','nov','dec']
 weekdays = ['sun','mon','tue','wed','thu','fri','sat']
 
-def parseATTime(s, tzinfo=None):
+def parseATTime(s, tzinfo=None, now=None):
   if tzinfo is None:
     tzinfo = pytz.timezone(settings.TIME_ZONE)
   s = s.strip().lower().replace('_','').replace(',','').replace(' ','')
@@ -39,10 +39,11 @@ def parseATTime(s, tzinfo=None):
     offset = '-' + offset
   else:
     ref,offset = s,''
-  return tzinfo.normalize(parseTimeReference(ref).astimezone(tzinfo) + parseTimeOffset(offset))
+  return tzinfo.normalize(parseTimeReference(ref or now).astimezone(tzinfo) + parseTimeOffset(offset))
 
 
 def parseTimeReference(ref):
+  if isinstance(ref, datetime): return ref
   if not ref or ref == 'now': return datetime.now(pytz.utc)
 
   #Time-of-day reference

--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -57,6 +57,13 @@ def epoch(dt):
   """
   return calendar.timegm(dt.astimezone(pytz.utc).timetuple())
 
+def timebounds(requestContext):
+  startTime = int(epoch(requestContext['startTime']))
+  endTime = int(epoch(requestContext['endTime']))
+  now = int(epoch(requestContext['now']))
+
+  return (startTime, endTime, now)
+
 def is_local_interface(host):
   is_ipv6 = False
   if ':' in host:


### PR DESCRIPTION
This patch sends a 'now' query parameter in requests to backend hosts in the same way as the 0.9.x branch.

It also passes `requestContext` through to `RemoteReader`, where it isn't used yet but will be by #1736 and #1818