### PR TITLE
Update setup to include worker_pool to fix install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ try:
         'graphite.url_shortener',
         'graphite.version',
         'graphite.whitelist',
+        'graphite.worker_pool',
       ],
       package_data={'graphite' :
         ['templates/*', 'local_settings.py.example']},


### PR DESCRIPTION
using:
pip install https://github.com/graphite-project/graphite-web/tarball/master

Is currently broken as worker_pool is not included in the list of things to install. I've added that and installed successfully via my own fork.