### PR TITLE
CarbonLink() must return singleton to be accesible

### DIFF
--- a/webapp/graphite/carbonlink.py
+++ b/webapp/graphite/carbonlink.py
@@ -210,4 +210,4 @@ class GlobalCarbonLinkPool(CarbonLinkPool):
 
 def CarbonLink():
   """Handy accessor for the global singleton."""
-  GlobalCarbonLinkPool.instance()
+  return GlobalCarbonLinkPool.instance()


### PR DESCRIPTION
Sympton:
```
2017-04-05,17:45:51.784 :: Failed CarbonLink query 'carbon.agents.casar1_fyre_ibm_com-c.cache.queries'
Traceback (most recent call last):
  File "/opt/graphite/webapp/graphite/readers.py", line 211, in fetch
    cached_datapoints = CarbonLink().query(self.real_metric_path)
AttributeError: 'NoneType' object has no attribute 'query'
```

GlobalCarbonLinkPool.instance() is called to return global singleton, but the return function is missing. This causes carbon queries to fail with above message.