### PR TITLE
correct install instructions

### DIFF
--- a/docs/config-local-settings.rst
+++ b/docs/config-local-settings.rst
@@ -86,7 +86,11 @@ STATIC_ROOT
 
   This directory doesn't even exist once you've installed graphite. It needs to be populated with the following command::
 
-      PYTHONPATH=$GRAPHITE_ROOT/webapp django-admin.py collectstatic --noinput --settings=graphite.settings
+      $GRAPHITE_ROOT/bin/django-admin.py collectstatic --noinput --settings=graphite.settings
+
+  You can either replace ``$GRAPHITE_ROOT`` above with your own root, or export it into the environment::
+  
+      export GRAPHITE_ROOT=/opt/graphite
 
   This collects static files for graphite-web and external apps (namely, the Django admin app) and puts them in a directory that needs to be available under the ``/static/`` URL of your web server. To configure Apache::
 


### PR DESCRIPTION
I thought I was having a stroke because I couldn't understand the install instructions.  Then I realized they were just wrong.  I'm guessing this got mutilated by a find/replace, and my PR is somewhat closer to what was intended?

at this point in the install, `$GRAPHITE_ROOT/webapp` only has the graphite_web python package as `graphite` and `graphite_web-1.1.0-py2.7.egg-info`

`django-admin.py` is located in $GRAPHITE_ROOT/bin/
