### PR TITLE
Duplicated results when using remote prefetch with multiple targets

### DIFF
--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -142,7 +142,7 @@ def _fetchData(pathExpr, startTime, endTime, now, requestContext, seriesList):
           continue
 
         for result in fetch:
-          if result['path'] == pathExpr:
+          if result['pathExpression'] == pathExpr:
             yield (
               result['path'],
               (

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -142,13 +142,14 @@ def _fetchData(pathExpr, startTime, endTime, now, requestContext, seriesList):
           continue
 
         for result in fetch:
-          yield (
-            result['path'],
-            (
-              (result['start'], result['end'], result['step']),
-              result['values'],
-            ),
-          )
+          if result['path'] == pathExpr:
+            yield (
+              result['path'],
+              (
+                (result['start'], result['end'], result['step']),
+                result['values'],
+              ),
+            )
 
     result_queue = result_queue_generator()
   else:


### PR DESCRIPTION
This patch fixes an issue when using multiple targets in a single query with remote prefetch enabled.

Without this patch, a query with 2 targets will return the results twice, a query with 3 targets will return them 3 times, etc.

To test, try a query like `ttp://localhost:8000/render?format=json&target=collectd.*.cpu-0.cpu-idle&target=collectd.*.cpu-1.cpu-idle&from=-1min`