### PR TITLE
remote: do not forward non-present headers

### DIFF
--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -321,5 +321,7 @@ class RemoteReader(object):
 def extractForwardHeaders(request):
     headers = {}
     for name in settings.REMOTE_STORE_FORWARD_HEADERS:
-        headers[name] = request.META.get('HTTP_%s' % name.upper().replace('-', '_'))
+        value = request.META.get('HTTP_%s' % name.upper().replace('-', '_'))
+        if value is not None:
+            headers[name] = value
     return headers


### PR DESCRIPTION
This prevent stuff like:
```
GET /metrics/find/?local=1&format=pickle&query=%2A HTTP/1.1
Accept-Encoding: identity
Client-IP: None
HTTP_REFERER: None
```