### PR TITLE
prevent exception on no targets

### DIFF
--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -23,6 +23,9 @@ def prefetchRemoteData(remote_stores, requestContext, pathExpressions):
   if requestContext is None:
     requestContext = {}
 
+  if pathExpressions is None:
+    return
+
   (startTime, endTime, now) = timebounds(requestContext)
   log.info('thread %s prefetchRemoteData:: Starting fetch_list on all backends' % current_thread().name)
 
@@ -200,6 +203,9 @@ class RemoteReader(object):
       ('from', str( int(startTime) )),
       ('until', str( int(endTime) ))
     ]
+
+    if len(self.bulk_query) < 1:
+      return []
 
     for target in self.bulk_query:
       query_params.append(('target', target))

--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -152,7 +152,9 @@ class RemoteReader(object):
     self.store = store
     self.metric_path = node_info.get('path') or node_info.get('metric_path')
     self.intervals = node_info['intervals']
-    self.bulk_query = bulk_query or [self.metric_path] if self.metric_path else []
+    self.bulk_query = bulk_query or (
+        [self.metric_path] if self.metric_path else []
+    )
     self.connection = None
 
   def __repr__(self):

--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -149,7 +149,7 @@ class RemoteReader(object):
     self.store = store
     self.metric_path = node_info.get('path') or node_info.get('metric_path')
     self.intervals = node_info['intervals']
-    self.bulk_query = bulk_query or [self.metric_path]
+    self.bulk_query = bulk_query or [self.metric_path] if self.metric_path else []
     self.connection = None
 
   def __repr__(self):


### PR DESCRIPTION
if `REMOTE_PREFETCH_DATA` is on and no targets are passed then there's an exception in the worker pool which gets swallowed. This happens due to the `RemoteReader`'s `self.bulk_query` being set to `[None]`.:

```
2017-05-19,17:21:02.768 :: thread Thread-5 at 1495214462.768827s ReadResult:: Error requesting http://mt-read-12574-small-ops:6060/render/?format=pickle&local=1&noCache=1&from=1495214162&until=1495214462&target=None&now=1495214462: 'NoneType' does not have the buffer interface
Traceback (most recent call last):
  File "/opt/graphite/webapp/graphite/remote_storage.py", line 303, in _fetch
    timeout=settings.REMOTE_FETCH_TIMEOUT,
  File "/opt/graphite/local/lib/python2.7/site-packages/urllib3/request.py", line 70, in request
    **urlopen_kw)
  File "/opt/graphite/local/lib/python2.7/site-packages/urllib3/request.py", line 138, in request_encode_body
    body, content_type = encode_multipart_formdata(fields, boundary=multipart_boundary)
  File "/opt/graphite/local/lib/python2.7/site-packages/urllib3/filepost.py", line 86, in encode_multipart_formdata
    body.write(data)
TypeError: 'NoneType' does not have the buffer interface
```

This is a major problem because that exception handler marks the backend that's been used as `unavailable` due to the exception.