### PR TITLE
Add settings to limit metrics fetched by queries

### DIFF
--- a/docs/carbon-daemons.rst
+++ b/docs/carbon-daemons.rst
@@ -103,3 +103,21 @@ and whisper file sizes due to lower retention policies.
   interval, the values received are aggregated and published to
   ``carbon-cache.py`` as a single metric.
 
+carbon-aggregator-cache.py
+--------------------------
+
+``carbon-aggregator-cache.py`` combines both ``carbon-aggregator.py`` and
+``carbon-cache.py``. This is useful to reduce the resource and administration
+overhead of running both daemons.
+
+``carbon-aggregator-cache.py`` is configured via:
+
+:doc:`carbon.conf </config-carbon>`
+  The ``[aggregator-cache]`` section defines listener and destination host/ports.
+  
+:doc:`relay-rules.conf </config-carbon>`
+  See `carbon-relay.py` section.
+
+:doc:`aggregation-rules.conf </config-carbon>`
+  See `carbon-aggregator.py` section.
+

--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -30,6 +30,8 @@
 #DOCUMENTATION_URL = "http://graphite.readthedocs.io/"
 
 # Logging
+# These can also be configured using Django's LOGGING:
+# https://docs.djangoproject.com/en/1.11/topics/logging/
 #LOG_ROTATION = True
 #LOG_ROTATION_COUNT = 1
 #LOG_RENDERING_PERFORMANCE = True

--- a/webapp/graphite/logger.py
+++ b/webapp/graphite/logger.py
@@ -34,33 +34,40 @@ logging.addLevelName(30,"cache")
 
 class GraphiteLogger:
   def __init__(self):
-    self.infoLogger = self._config_logger('info.log',
-                                          'info',
-                                          True,
-                                          level = logging.INFO,
-                                          )
-    self.exceptionLogger = self._config_logger('exception.log',
-                                               'exception',
-                                               True,
-                                               )
-    self.cacheLogger = self._config_logger('cache.log',
-                                           'cache',
-                                           settings.LOG_CACHE_PERFORMANCE,
-                                           )
-    self.renderingLogger = self._config_logger('rendering.log',
-                                               'rendering',
-                                               settings.LOG_RENDERING_PERFORMANCE,
-                                               )
+    self.infoLogger = self._config_logger(
+        'info.log',
+        'info',
+        True,
+        level = logging.INFO,
+    )
+    self.exceptionLogger = self._config_logger(
+        'exception.log',
+        'exception',
+        True,
+    )
+    self.cacheLogger = self._config_logger(
+        'cache.log',
+        'cache',
+        settings.LOG_CACHE_PERFORMANCE,
+    )
+    self.renderingLogger = self._config_logger(
+        'rendering.log',
+        'rendering',
+        settings.LOG_RENDERING_PERFORMANCE,
+    )
 
   @staticmethod
   def _config_logger(log_file_name, name, activate,
-                     level=None, when='midnight', backupCount=settings.LOG_ROTATION_COUNT):
+                     level=None, when='midnight',
+                     backupCount=settings.LOG_ROTATION_COUNT):
     log_file = os.path.join(settings.LOG_DIR, log_file_name)
     logger = logging.getLogger(name)
     if level is not None:
         logger.setLevel(level)
     if activate:  # if want to log this one
-        formatter = logging.Formatter(fmt='%(asctime)s.%(msecs)03d :: %(message)s',datefmt='%Y-%m-%d,%H:%M:%S')
+        formatter = logging.Formatter(
+            fmt='%(asctime)s.%(msecs)03d :: %(message)s',
+            datefmt='%Y-%m-%d,%H:%M:%S')
         if settings.LOG_ROTATION:  # if we want to rotate logs
             handler = Rotater(log_file, when=when, backupCount=backupCount)
         else:  # let someone else, e.g. logrotate, rotate the logs

--- a/webapp/graphite/logger.py
+++ b/webapp/graphite/logger.py
@@ -81,6 +81,9 @@ class GraphiteLogger:
   def info(self,msg,*args,**kwargs):
     return self.infoLogger.info(msg,*args,**kwargs)
 
+  def warning(self,msg,*args,**kwargs):
+    return self.infoLogger.warn(msg,*args,**kwargs)
+
   def exception(self,msg="Exception Caught",**kwargs):
     return self.exceptionLogger.exception(msg,**kwargs)
 

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -90,6 +90,10 @@ LOG_ROTATION_COUNT = 1
 
 MAX_FETCH_RETRIES = 2
 
+# This settings limit metrics find to prevent from too large query
+METRICS_FIND_WARNING_THRESHOLD = float('Inf') # Print a warning if more than X metrics are returned
+METRICS_FIND_FAILURE_THRESHOLD = float('Inf') # Fail if more than X metrics are returned
+
 #Remote rendering settings
 REMOTE_RENDERING = False #if True, rendering is delegated to RENDERING_HOSTS
 RENDERING_HOSTS = []

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -81,16 +81,19 @@ FIND_TOLERANCE = 2 * FIND_CACHE_DURATION
 DEFAULT_CACHE_DURATION = 60 #metric data and graphs are cached for one minute by default
 DEFAULT_CACHE_POLICY = []
 
+# These can also be configured using:
+# https://docs.djangoproject.com/en/1.11/topics/logging/
+LOG_RENDERING_PERFORMANCE = False
 LOG_CACHE_PERFORMANCE = False
 LOG_ROTATION = True
 LOG_ROTATION_COUNT = 1
+
 MAX_FETCH_RETRIES = 2
 
 #Remote rendering settings
 REMOTE_RENDERING = False #if True, rendering is delegated to RENDERING_HOSTS
 RENDERING_HOSTS = []
 REMOTE_RENDER_CONNECT_TIMEOUT = 1.0
-LOG_RENDERING_PERFORMANCE = False
 
 #Miscellaneous settings
 SMTP_SERVER = "localhost"


### PR DESCRIPTION
This is kind of a "slow query" log. This allow the administrator to abort huge requests before they impact everybody.

A finder/reader could use these settings to abort early instead of doing it a the end, but this isn't implemented yet.

cc: @Thib17