### PR TITLE
render: more robust maxDataPoints

### DIFF
--- a/webapp/graphite/app_settings.py
+++ b/webapp/graphite/app_settings.py
@@ -20,11 +20,6 @@ from os.path import dirname, join, abspath
 #Django settings below, do not touch!
 APPEND_SLASH = False
 TEMPLATE_DEBUG = False
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
-    },
-}
 
 TEMPLATES = [
     {

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -247,6 +247,13 @@ if MEMCACHE_HOSTS:
         'OPTIONS': MEMCACHE_OPTIONS,
     }
 
+if not CACHES:
+  CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    },
+  }
+
 # Authentication shortcuts
 if USE_LDAP_AUTH and LDAP_URI is None:
   LDAP_URI = "ldap://%s:%d/" % (LDAP_SERVER, LDAP_PORT)


### PR DESCRIPTION
I'm not sure why we take the widest range possible to get the
number of points to remove, but this clearly needs to be done per
timeseries as they don't have any guarantee to all have the same
time range.