### PR TITLE
Introducing configurable previewDays for Holt-Winters functions

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2812,12 +2812,12 @@ def holtWintersAnalysis(series):
         }
   return results
 
-def holtWintersForecast(requestContext, seriesList):
+def holtWintersForecast(requestContext, seriesList, previewDays=7):
   """
   Performs a Holt-Winters forecast using the series as input data. Data from
-  one week previous to the series is used to bootstrap the initial forecast.
+  `previewDays` days previous to the series (one week by default) is used to bootstrap the initial forecast.
   """
-  previewSeconds = 7 * 86400 # 7 days
+  previewSeconds = previewDays * 86400
   # ignore original data and pull new, including our preview
   newContext = requestContext.copy()
   newContext['startTime'] = requestContext['startTime'] -  timedelta(seconds=previewSeconds)
@@ -2832,12 +2832,12 @@ def holtWintersForecast(requestContext, seriesList):
     results.append(result)
   return results
 
-def holtWintersConfidenceBands(requestContext, seriesList, delta=3):
+def holtWintersConfidenceBands(requestContext, seriesList, delta=3, previewDays=7):
   """
   Performs a Holt-Winters forecast using the series as input data and plots
   upper and lower bands with the predicted forecast deviations.
   """
-  previewSeconds = 7 * 86400 # 7 days
+  previewSeconds = previewDays * 86400
   # ignore original data and pull new, including our preview
   newContext = requestContext.copy()
   newContext['startTime'] = requestContext['startTime'] -  timedelta(seconds=previewSeconds)
@@ -2884,14 +2884,14 @@ def holtWintersConfidenceBands(requestContext, seriesList, delta=3):
     results.append(upperSeries)
   return results
 
-def holtWintersAberration(requestContext, seriesList, delta=3):
+def holtWintersAberration(requestContext, seriesList, delta=3, previewDays=7):
   """
   Performs a Holt-Winters forecast using the series as input data and plots the
   positive or negative deviation of the series data from the forecast.
   """
   results = []
   for series in seriesList:
-    confidenceBands = holtWintersConfidenceBands(requestContext, [series], delta)
+    confidenceBands = holtWintersConfidenceBands(requestContext, [series], delta, previewDays)
     lowerBand = confidenceBands[0]
     upperBand = confidenceBands[1]
     aberration = list()
@@ -2910,12 +2910,12 @@ def holtWintersAberration(requestContext, seriesList, delta=3):
             , series.step, aberration))
   return results
 
-def holtWintersConfidenceArea(requestContext, seriesList, delta=3):
+def holtWintersConfidenceArea(requestContext, seriesList, delta=3, previewDays=7):
   """
   Performs a Holt-Winters forecast using the series as input data and plots the
   area between the upper and lower bands of the predicted forecast deviations.
   """
-  bands = holtWintersConfidenceBands(requestContext, seriesList, delta)
+  bands = holtWintersConfidenceBands(requestContext, seriesList, delta, previewDays)
   results = areaBetween(requestContext, bands)
   for series in results:
     series.name = series.name.replace('areaBetween', 'holtWintersConfidenceArea')


### PR DESCRIPTION
previewDays (7 days by default) is original interval for bootstrapping HW coefficients.
Probably fixing issue #1957 