### PR TITLE
LDAP broken since Graphite 1.0

### DIFF
--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -123,6 +123,7 @@ LDAP_BASE_USER = "" # "CN=some_readonly_account,DC=mydomain,DC=com"
 LDAP_BASE_PASS = "" # "my_password"
 LDAP_USER_QUERY = "" # "(username=%s)"  For Active Directory use "(sAMAccountName=%s)"
 LDAP_URI = None
+LDAP_USER_DN_TEMPLATE = None
 
 #Set this to True to delegate authentication to the web server
 USE_REMOTE_USER_AUTHENTICATION = False


### PR DESCRIPTION
LDAP_BASE_USER/LDAP_BASE_PASS setting has been broken since
the LDAP_USER_DN_TEMPLATE setting was introduced in commit
871a6cb427cbb1d8a1c33905d6f25e4b39d8a5b7.

By not giving LDAP_USER_DN_TEMPLATE a default value in
settings.py, the expected attribute could not be fetched in
ldapBackend.py and logins fails with:

AttributeError: 'Settings' object has no attribute
	'LDAP_USER_DN_TEMPLATE'
