### PR TITLE
Remote storage fixes

### DIFF
--- a/webapp/graphite/finders/remote.py
+++ b/webapp/graphite/finders/remote.py
@@ -75,12 +75,12 @@ class RemoteFinder(BaseFinder):
                 else:
                     continue
 
-            log.debug("Got a find result after %fs" % (time.time() - start))
+            log.debug("Got a remote find result after %fs" % (time.time() - start))
             done += 1
             for node in nodes or []:
                 yield node
 
-        log.debug("Got all find results in %fs" % (time.time() - start))
+        log.debug("Got all remote find results in %fs" % (time.time() - start))
 
     def fetch(self, nodes_or_patterns, start_time, end_time, now=None, requestContext=None):
         # Go through all of the remote nodes, and launch a fetch for each one.

--- a/webapp/graphite/readers/remote.py
+++ b/webapp/graphite/readers/remote.py
@@ -140,7 +140,7 @@ class RemoteReader(BaseReader):
                 return request
 
             data = self._fetch_list_locked(url, query_string, query_params, headers)
-            in_flight.start_request(url, data)
+            in_flight.start_request(url_full, data)
 
         log.debug(
             "RemoteReader:: Returning %s in %fs" % (url_full, time.time() - t))

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -78,27 +78,6 @@ def evaluateTokens(requestContext, tokens, replacements=None):
     raise ValueError("unknown token in target evaluator")
 
 
-def extractPathExpressions(targets):
-  # Returns a list of unique pathExpressions found in the targets list
-
-  pathExpressions = set()
-
-  def extractPathExpression(tokens):
-    if tokens.expression:
-      return extractPathExpression(tokens.expression)
-    elif tokens.pathExpression:
-      pathExpressions.add(tokens.pathExpression)
-    elif tokens.call:
-      for a in tokens.call.args:
-        extractPathExpression(a)
-
-  for target in targets:
-    tokens = grammar.parseString(target)
-    extractPathExpression(tokens)
-
-  return list(pathExpressions)
-
-
 # Avoid import circularities
 from graphite.render.functions import (SeriesFunctions,
                                        NormalizeEmptyResultError)  # noqa

--- a/webapp/graphite/render/utils.py
+++ b/webapp/graphite/render/utils.py
@@ -1,0 +1,22 @@
+from graphite.render.grammar import grammar
+
+
+def extractPathExpressions(targets):
+  # Returns a list of unique pathExpressions found in the targets list
+
+  pathExpressions = set()
+
+  def extractPathExpression(tokens):
+    if tokens.expression:
+      return extractPathExpression(tokens.expression)
+    elif tokens.pathExpression:
+      pathExpressions.add(tokens.pathExpression)
+    elif tokens.call:
+      for a in tokens.call.args:
+        extractPathExpression(a)
+
+  for target in targets:
+    tokens = grammar.parseString(target)
+    extractPathExpression(tokens)
+
+  return list(pathExpressions)

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -15,7 +15,7 @@ import csv
 import math
 import pytz
 import httplib
-import collections
+
 from datetime import datetime
 from time import time
 from random import shuffle
@@ -33,15 +33,13 @@ from graphite.compat import HttpResponse
 from graphite.user_util import getProfileByUsername
 from graphite.util import json, unpickle
 from graphite.storage import extractForwardHeaders
-from graphite.storage import STORE
 from graphite.logger import log
-from graphite.render.evaluator import evaluateTarget, extractPathExpressions
+from graphite.render.evaluator import evaluateTarget
 from graphite.render.attime import parseATTime
 from graphite.render.functions import PieFunctions
 from graphite.render.hashing import hashRequest, hashData
 from graphite.render.glyph import GraphTypes
-from graphite.readers.utils import wait_for_result
-from graphite.future import Future
+from graphite.render.datalib import prefetchRemoteData
 
 from django.http import HttpResponseServerError, HttpResponseRedirect
 from django.template import Context, loader
@@ -49,52 +47,6 @@ from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
 from django.utils.cache import add_never_cache_headers, patch_response_headers
-
-
-class PrefetchedData(Future):
-  def __init__(self, results):
-    self._results = results
-    self._prefetched = None
-
-  def _data(self):
-    if self._prefetched is None:
-      self._fetch_data()
-    return self._prefetched
-
-  def _fetch_data(self):
-    prefetched = collections.defaultdict(list)
-    for result in self._results:
-      fetched = wait_for_result(result)
-
-      if fetched is None:
-        continue
-
-      for result in fetched:
-        prefetched[result['pathExpression']].append((
-          result['name'],
-          (
-            result['time_info'],
-            result['values'],
-          ),
-        ))
-
-    self._prefetched = prefetched
-
-
-def prefetchRemoteData(requestContext, targets):
-  """Prefetch a bunch of path expressions and stores them in the context.
-
-  The idea is that this will allow more batching that doing a query
-  each time evaluateTarget() needs to fetch a path. All the prefetched
-  data is stored in the requestContext, to be accessed later by datalib.
-  """
-  log.rendering("Prefetching remote data")
-  pathExpressions = extractPathExpressions(targets)
-  results = STORE.fetch_remote(pathExpressions, requestContext)
-
-  # TODO: instead of doing that it would be wait better to use
-  # the shared cache to cache pathExpr instead of full queries.
-  requestContext['prefetched'] = PrefetchedData(results)
 
 
 def renderView(request):
@@ -112,7 +64,7 @@ def renderView(request):
     'tzinfo' : requestOptions['tzinfo'],
     'forwardHeaders': extractForwardHeaders(request),
     'data' : [],
-    'prefetched' : collections.defaultdict(list),
+    'prefetched' : {},
   }
   data = requestContext['data']
 
@@ -164,7 +116,6 @@ def renderView(request):
     else: # Have to actually retrieve the data now
       targets = requestOptions['targets']
       if settings.REMOTE_PREFETCH_DATA and not requestOptions.get('localOnly'):
-        # TODO: This could be used for some local finders too.
         prefetchRemoteData(requestContext, targets)
 
       for target in targets:

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -7,7 +7,7 @@ import logging
 import shutil
 
 from graphite.render.hashing import ConsistentHashRing, hashRequest, hashData
-from graphite.render.evaluator import extractPathExpressions
+from graphite.render.utils import extractPathExpressions
 import whisper
 
 from django.conf import settings


### PR DESCRIPTION
This set fixes two bugs I discovered with the latest changes:
* When *not* using REMOTE_PREFTECH_DATA the code checking in flight requests suffered from a performance regression (re-fetching urls each time)
* When using REMOTE_PREFTECH_DATA and `timeShift()` the wrong data was behind used since we didn't check the start and end time of the query.