### PR TITLE
Change dashboard find to only query for the name

### DIFF
--- a/webapp/graphite/dashboard/views.py
+++ b/webapp/graphite/dashboard/views.py
@@ -310,8 +310,8 @@ def find(request):
   results = []
 
   # Find all dashboard names that contain each of our query terms as a substring
-  for dashboard in Dashboard.objects.order_by('name'):
-    name = dashboard.name.lower()
+  for dashboard in Dashboard.objects.values('name').order_by('name'):
+    name = dashboard['name'].lower()
     if name.startswith('temporary-'):
       continue
 
@@ -324,7 +324,7 @@ def find(request):
         break
 
     if found:
-      results.append( dict(name=dashboard.name) )
+      results.append( dict(name=dashboard['name']) )
 
   return json_response( dict(dashboards=results) )
 

--- a/webapp/graphite/dashboard/views.py
+++ b/webapp/graphite/dashboard/views.py
@@ -310,8 +310,9 @@ def find(request):
   results = []
 
   # Find all dashboard names that contain each of our query terms as a substring
-  for dashboard in Dashboard.objects.values('name').order_by('name'):
-    name = dashboard['name'].lower()
+  for dashboard_name in Dashboard.objects.order_by('name').values_list('name', flat=True):
+    name = dashboard_name.lower()
+
     if name.startswith('temporary-'):
       continue
 
@@ -324,7 +325,7 @@ def find(request):
         break
 
     if found:
-      results.append( dict(name=dashboard['name']) )
+      results.append( dict(name=dashboard_name) )
 
   return json_response( dict(dashboards=results) )
 


### PR DESCRIPTION
This improves speed of loading the dashboard finder window because it does not query and sort the state column where it doesn't need it.