### PR TITLE
is_local_interface and IPv6

### DIFF
--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -75,18 +75,19 @@ def timebounds(requestContext):
 
 def is_local_interface(host):
   is_ipv6 = False
-  if ':' in host:
-    try:
-      if host.find('[', 0, 2) != -1:
-        last_bracket_position  = host.rfind(']')
-        last_colon_position = host.rfind(':')
-        if last_colon_position > last_bracket_position:
-          host = host.rsplit(':', 1)[0]
-        host = host.strip('[]')
-      socket.inet_pton(socket.AF_INET6, host)
-      is_ipv6 = True
-    except socket.error:
-      host = host.split(':',1)[0]
+  if ':' not in host:
+    pass
+  elif host.count(':') == 1:
+    host = host.split(':', 1)[0]
+  else:
+    is_ipv6 = True
+
+    if host.find('[', 0, 2) != -1:
+      last_bracket_position  = host.rfind(']')
+      last_colon_position = host.rfind(':')
+      if last_colon_position > last_bracket_position:
+        host = host.rsplit(':', 1)[0]
+      host = host.strip('[]')
 
   try:
     if is_ipv6:

--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -94,17 +94,13 @@ def is_local_interface(host):
       sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
     else:
       sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.connect( (host, 4242) )
-    local_ip = sock.getsockname()[0]
-    sock.close()
+    sock.bind( (host, 0) )
   except:
-    log.exception("Failed to open socket with %s" % host)
-    raise
+    return False
+  finally:
+    sock.close()
 
-  if local_ip == host:
-    return True
-
-  return False
+  return True
 
 
 def is_pattern(s):

--- a/webapp/tests/test_util.py
+++ b/webapp/tests/test_util.py
@@ -18,14 +18,9 @@ class UtilTest(TestCase):
         self.assertEqual( results, [True, True, False] )
 
     def test_is_local_interface_ipv6(self):
-        addresses = ['::1', '[::1]:8080', '[::1]']
+        addresses = ['::1', '[::1]:8080', '[::1]', '::1:8080']
         results = [ util.is_local_interface(a) for a in addresses ]
-        self.assertEqual( results, [True, True, True] )
-
-    def test_is_local_interface_bad_ipv6(self):
-        with self.assertRaises(Exception):
-            addresses = ['::1:8080']
-            results = [ util.is_local_interface(a) for a in addresses ]
+        self.assertEqual( results, [True, True, True, False] )
 
     def test_is_escaped_pattern(self):
         self.assertFalse( util.is_escaped_pattern('asdf') )

--- a/webapp/tests/test_util.py
+++ b/webapp/tests/test_util.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import socket
 import time
 import whisper
 
@@ -21,6 +22,11 @@ class UtilTest(TestCase):
         addresses = ['::1', '[::1]:8080', '[::1]', '::1:8080']
         results = [ util.is_local_interface(a) for a in addresses ]
         self.assertEqual( results, [True, True, True, False] )
+
+    def test_is_local_interface_dns(self):
+        addresses = ['localhost', socket.gethostname(), 'google.com']
+        results = [ util.is_local_interface(a) for a in addresses ]
+        self.assertEqual( results, [True, True, False] )
 
     def test_is_escaped_pattern(self):
         self.assertFalse( util.is_escaped_pattern('asdf') )


### PR DESCRIPTION
This patch makes a couple of changes to the way that `is_local_interface` works, which allow it to work consistently across hosts with and without IPv6 interfaces.

- detect IPv6 based on the number of colons, an IPv4 address will always have 0 or 1
- test the given hostname for local-ness by attempting to bind to it as a source address rather than connecting to it and seeing whether the local (source) ip matched
- change behavior for `::1:8080` which is treated as a valid IP on hosts with IPv6 connectivity
- add tests for checking local-ness of dns names as well as ip addresses