### PR TITLE
update metrics/find to support the same from/until specifications as render

### DIFF
--- a/webapp/tests/test_metrics.py
+++ b/webapp/tests/test_metrics.py
@@ -244,6 +244,17 @@ class MetricsTester(TestCase):
             data['metrics'] = sorted(data['metrics'])
             self.assertEqual(data, {u'metrics': [{u'name': u'hosts', u'is_leaf': u'0', u'path': u'hosts.'}]})
 
+            # Test from/until params
+            request=copy.deepcopy(request_default)
+            request['format']='completer'
+            request['query']='hosts'
+            request['from']='now-1min'
+            request['until']='now'
+            content = test_find_view_basics(request)
+            data = json.loads(content)
+            data['metrics'] = sorted(data['metrics'])
+            self.assertEqual(data, {u'metrics': [{u'name': u'hosts', u'is_leaf': u'0', u'path': u'hosts.'}]})
+
             # automatic_variants
             request=copy.deepcopy(request_default)
             request['format']='completer'


### PR DESCRIPTION
This patch updates metrics/find to use the same parsing library for from/until dates as render does, to keep things consistent across the endpoints.