### PR TITLE
Min-Max Normalization Function

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -4168,6 +4168,7 @@ SeriesFunctions = {
   'hitcount': hitcount,
   'absolute': absolute,
   'interpolate': interpolate,
+  'minMax': minMax,
 
   # Calculate functions
   'movingAverage': movingAverage,

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -4053,14 +4053,10 @@ def events(requestContext, *tags):
   """
   Returns the number of events at this point in time. Usable with
   drawAsInfinite.
-
   Example:
-
   .. code-block:: none
-
     &target=events("tag-one", "tag-two")
     &target=events("*")
-
   Returns all events tagged as "tag-one" and "tag-two" and the second one
   returns all events.
   """
@@ -4078,6 +4074,20 @@ def events(requestContext, *tags):
   events = models.Event.find_events(epoch_to_dt(start_timestamp),
                                     epoch_to_dt(end_timestamp),
                                     tags=tags)
+
+  values = [None] * points
+  for event in events:
+    event_timestamp = epoch(event.when)
+    value_offset = (event_timestamp - start_timestamp)/step
+
+    if values[value_offset] is None:
+      values[value_offset] = 1
+    else:
+      values[value_offset] += 1
+
+  result_series = TimeSeries(name, start_timestamp, end_timestamp, step, values, 'sum')
+  result_series.pathExpression = name
+  return [result_series]
 
 def minMax(requestContext, seriesList):
   """

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -4053,10 +4053,14 @@ def events(requestContext, *tags):
   """
   Returns the number of events at this point in time. Usable with
   drawAsInfinite.
+
   Example:
+
   .. code-block:: none
+
     &target=events("tag-one", "tag-two")
     &target=events("*")
+
   Returns all events tagged as "tag-one" and "tag-two" and the second one
   returns all events.
   """

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -4650,6 +4650,29 @@ class FunctionsTest(TestCase):
 
         self.assertEqual(result, expectedResults)
 
+    # test_minMax
+    def test_minMax(self):
+        seriesList = self._generate_series_list()
+        # get the results from minMax normalization
+        results = functions.minMax({}, copy.deepcopy(seriesList))
+        for i, series in enumerate(results):
+            # loop and check if result value matches formula
+            min_val = functions.safeMin(seriesList[i])
+            max_val = functions.safeMax(seriesList[i])
+            if min_val is None:
+                min_val = 0.0
+            if max_val is None:
+                max_val = 0.0
+            for counter, value in enumerate(series):
+                if value is None:
+                    continue
+                original_value = seriesList[i][counter]
+                try:
+                    expected_value = (original_value - min_val) / (max_val - min_val)
+                except ZeroDivisionError:
+                    expected_value = 0.0
+                self.assertEqual(value, expected_value)
+
     def _build_requestContext(self, startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)), endTime=datetime(1970, 1, 1, 0, 59, 0, 0, pytz.timezone(settings.TIME_ZONE)), data=[], tzinfo=pytz.utc):
         """
         Helper method to create request contexts

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -4652,26 +4652,25 @@ class FunctionsTest(TestCase):
 
     # test_minMax
     def test_minMax(self):
-        seriesList = self._generate_series_list()
-        # get the results from minMax normalization
-        results = functions.minMax({}, copy.deepcopy(seriesList))
-        for i, series in enumerate(results):
-            # loop and check if result value matches formula
-            min_val = functions.safeMin(seriesList[i])
-            max_val = functions.safeMax(seriesList[i])
-            if min_val is None:
-                min_val = 0.0
-            if max_val is None:
-                max_val = 0.0
-            for counter, value in enumerate(series):
-                if value is None:
-                    continue
-                original_value = seriesList[i][counter]
-                try:
-                    expected_value = (original_value - min_val) / (max_val - min_val)
-                except ZeroDivisionError:
-                    expected_value = 0.0
-                self.assertEqual(value, expected_value)
+        # generate data to test
+        seriesList = self._gen_series_list_with_data(
+            key=[
+                'collectd.test-db4.load.value',
+                'collectd.test-db3.load.value'
+            ],
+            end=1,
+            data=[
+                [10,20,30,40,50],
+                [0,0,0,0,0]
+            ]
+        )
+        # get the expected result (calculated)
+        expectedResult = [
+            TimeSeries('minMax(collectd.test-db4.load.value)',0,1,1,[0.0,0.25,0.50,0.75,1.0]),
+            TimeSeries('minMax(collectd.test-db3.load.value)',0,1,1,[0.0,0.0,0.0,0.0,0.0])
+        ]
+        result = functions.minMax({}, seriesList)
+        self.assertEqual(result, expectedResult)
 
     def _build_requestContext(self, startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)), endTime=datetime(1970, 1, 1, 0, 59, 0, 0, pytz.timezone(settings.TIME_ZONE)), data=[], tzinfo=pytz.utc):
         """


### PR DESCRIPTION
When processing data, various normalization and scaling techniques are utilized, and a very popular technique is Min-Max normalization. I have noticed that many people use this technique, especially when working with various machine learning algorithms, to process raw data, which is why I thought this function should be added as a graphite function. The formula is very simple, for each point do the following: (point - min) / (max - min). You can read more about it here: http://sebastianraschka.com/Articles/2014_about_feature_scaling.html#about-min-max-scaling

I have tested this new function on my own simple graphite server. If you want to see how it normalizes raw data live then look at: http://34.207.148.148/render/?target=minMax(collectd.ip-172-31-22-200_ec2_internal.entropy.entropy) and then look at http://34.207.148.148/render/?target=collectd.ip-172-31-22-200_ec2_internal.entropy.entropy to see how the raw data looks. This is a simple `Ubuntu 16.04.2` server I setup, which is running `Python 2.7.12`. It is also running `Django 1.8.7` and the Graphite version is `0.9.15`. Please let me know if I need to provide anything else for this function.