### PR TITLE
Use hashlib sha256 to enable use in FIPS mode

### DIFF
--- a/webapp/graphite/browser/views.py
+++ b/webapp/graphite/browser/views.py
@@ -23,7 +23,7 @@ from graphite.compat import HttpResponse
 from graphite.user_util import getProfile, getProfileByUsername
 from graphite.util import json
 from graphite.logger import log
-from hashlib import md5
+from hashlib import sha256
 from urlparse import urlparse, parse_qsl
 from urllib import urlencode
 
@@ -137,7 +137,7 @@ def myGraphLookup(request):
         node.update(branchNode)
 
       else:
-        m = md5()
+        m = sha256()
         m.update(name.encode('utf-8'))
 
         # Sanitize target
@@ -234,7 +234,7 @@ def userGraphLookup(request):
           }
           node.update(branchNode)
         else: # leaf
-          m = md5()
+          m = sha256()
           m.update(nodeName.encode('utf-8'))
 
           # Sanitize target

--- a/webapp/graphite/render/hashing.py
+++ b/webapp/graphite/render/hashing.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-from hashlib import md5
+from hashlib import sha256
 from itertools import chain
 import bisect
 
@@ -55,7 +55,7 @@ def hashData(targets, startTime, endTime):
 
 
 def compactHash(string):
-  hash = md5()
+  hash = sha256()
   hash.update(string.encode('utf-8'))
   return hash.hexdigest()
 
@@ -76,7 +76,7 @@ class ConsistentHashRing:
       big_hash = '{:x}'.format(int(fnv32a( str(key) )))
       small_hash = int(big_hash[:4], 16) ^ int(big_hash[4:], 16)
     else:
-      big_hash = md5(str(key)).hexdigest()
+      big_hash = sha256(str(key)).hexdigest()
       small_hash = int(big_hash[:4], 16)
     return small_hash
 


### PR DESCRIPTION
Fix for https://github.com/graphite-project/graphite-web/issues/2019

Use hashlib's sha256 for hashing rather than md5.