### PR TITLE
fix perSecond null handling, use explicit integer division

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -12,6 +12,10 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
+# make / work consistently between python 2.x and 3.x
+# https://www.python.org/dev/peps/pep-0238/
+from __future__ import division
+
 import math
 import random
 import re
@@ -59,7 +63,7 @@ def safeLen(values):
 def safeDiv(a, b):
   if a is None: return None
   if b in (0,None): return None
-  return float(a) / float(b)
+  return a / b
 
 def safePow(a, b):
   if a is None: return None
@@ -133,7 +137,7 @@ def gcd(a, b):
 def lcm(a, b):
   if a == b: return a
   if a < b: (a, b) = (b, a) #ensure a > b
-  return a / gcd(a,b) * b
+  return a // gcd(a,b) * b
 
 def normalize(seriesLists):
   if seriesLists:
@@ -141,7 +145,7 @@ def normalize(seriesLists):
     if seriesList:
       step = reduce(lcm,[s.step for s in seriesList])
       for s in seriesList:
-        s.consolidate( step / s.step )
+        s.consolidate( step // s.step )
       start = min([s.start for s in seriesList])
       end = max([s.end for s in seriesList])
       end -= (end - start) % step
@@ -637,7 +641,7 @@ def divideSeriesLists(requestContext, dividendSeriesList, divisorSeriesList):
     step = reduce(lcm,[s.step for s in bothSeries])
 
     for s in bothSeries:
-      s.consolidate( step / s.step )
+      s.consolidate( step // s.step )
 
     start = min([s.start for s in bothSeries])
     end = max([s.end for s in bothSeries])
@@ -685,7 +689,7 @@ def divideSeries(requestContext, dividendSeriesList, divisorSeries):
     step = reduce(lcm,[s.step for s in bothSeries])
 
     for s in bothSeries:
-      s.consolidate( step / s.step )
+      s.consolidate( step // s.step )
 
     start = min([s.start for s in bothSeries])
     end = max([s.end for s in bothSeries])
@@ -840,7 +844,7 @@ def exponentialMovingAverage(requestContext, seriesList, windowSize):
 
   for series in previewList:
     if windowInterval:
-      windowPoints = windowInterval / series.step
+      windowPoints = windowInterval // series.step
     else:
       windowPoints = int(windowSize)
 
@@ -912,7 +916,7 @@ def movingMedian(requestContext, seriesList, windowSize):
 
   for series in previewList:
     if windowInterval:
-      windowPoints = windowInterval / series.step
+      windowPoints = windowInterval // series.step
     else:
       windowPoints = int(windowSize)
 
@@ -928,7 +932,7 @@ def movingMedian(requestContext, seriesList, windowSize):
       window = series[i - windowPoints:i]
       nonNull = [v for v in window if v is not None]
       if nonNull:
-        m_index = len(nonNull) / 2
+        m_index = len(nonNull) // 2
         newSeries.append(sorted(nonNull)[m_index])
       else:
         newSeries.append(None)
@@ -1178,7 +1182,7 @@ def movingAverage(requestContext, seriesList, windowSize):
 
   for series in previewList:
     if windowInterval:
-      windowPoints = windowInterval / series.step
+      windowPoints = windowInterval // series.step
     else:
       windowPoints = int(windowSize)
 
@@ -1245,7 +1249,7 @@ def movingSum(requestContext, seriesList, windowSize):
 
   for series in previewList:
     if windowInterval:
-      windowPoints = windowInterval / series.step
+      windowPoints = windowInterval // series.step
     else:
       windowPoints = int(windowSize)
 
@@ -1309,7 +1313,7 @@ def movingMin(requestContext, seriesList, windowSize):
 
   for series in previewList:
     if windowInterval:
-      windowPoints = windowInterval / series.step
+      windowPoints = windowInterval // series.step
     else:
       windowPoints = int(windowSize)
 
@@ -1367,7 +1371,7 @@ def movingMax(requestContext, seriesList, windowSize):
 
   for series in previewList:
     if windowInterval:
-      windowPoints = windowInterval / series.step
+      windowPoints = windowInterval // series.step
     else:
       windowPoints = int(windowSize)
 
@@ -1497,14 +1501,14 @@ def perSecond(requestContext, seriesList, maxValue=None):
         continue
       if val is None:
         newValues.append(None)
-        step = step * 2
+        step += series.step
         continue
 
       diff = val - prev
       if diff >= 0:
-        newValues.append(diff / step)
+        newValues.append(diff // step)
       elif maxValue is not None and maxValue >= val:
-        newValues.append( ((maxValue - prev) + val  + 1) / step )
+        newValues.append( ((maxValue - prev) + val  + 1) // step )
       else:
         newValues.append(None)
 
@@ -1608,7 +1612,7 @@ def integralByInterval(requestContext, seriesList, intervalUnit):
     current = 0.0 # current accumulated value
     for val in series:
       # reset integral value if crossing an interval boundary
-      if (currentTime - startTime)/intervalDuration != (currentTime - startTime - series.step)/intervalDuration:
+      if (currentTime - startTime)//intervalDuration != (currentTime - startTime - series.step)//intervalDuration:
         current = 0.0
       if val is None:
         # keep previous value since val can be None when resetting current to 0.0
@@ -2724,7 +2728,7 @@ def holtWintersAnalysis(series):
   alpha = gamma = 0.1
   beta = 0.0035
   # season is currently one day
-  season_length = (24*60*60) / series.step
+  season_length = (24*60*60) // series.step
   intercept = 0
   slope = 0
   pred = 0
@@ -2828,7 +2832,7 @@ def holtWintersForecast(requestContext, seriesList, bootstrapInterval='7d'):
   for series in previewList:
     analysis = holtWintersAnalysis(series)
     predictions = analysis['predictions']
-    windowPoints = previewSeconds / predictions.step
+    windowPoints = previewSeconds // predictions.step
     result = TimeSeries("holtWintersForecast(%s)" % series.name, predictions.start + previewSeconds, predictions.end, predictions.step, predictions[windowPoints:])
     result.pathExpression = result.name
     results.append(result)
@@ -2851,12 +2855,12 @@ def holtWintersConfidenceBands(requestContext, seriesList, delta=3, bootstrapInt
     analysis = holtWintersAnalysis(series)
 
     data = analysis['predictions']
-    windowPoints = previewSeconds / data.step
+    windowPoints = previewSeconds // data.step
     forecast = TimeSeries(data.name, data.start + previewSeconds, data.end, data.step, data[windowPoints:])
     forecast.pathExpression = data.pathExpression
 
     data = analysis['deviations']
-    windowPoints = previewSeconds / data.step
+    windowPoints = previewSeconds // data.step
     deviation = TimeSeries(data.name, data.start + previewSeconds, data.end, data.step, data[windowPoints:])
     deviation.pathExpression = data.pathExpression
 
@@ -2939,7 +2943,7 @@ def linearRegressionAnalysis(series):
     return None
   else:
     factor = (n * sumIV - sumI * sumV) / denominator / series.step
-    offset = (sumII * sumV - sumIV * sumI) /denominator - factor * series.start
+    offset = (sumII * sumV - sumIV * sumI) / denominator - factor * series.start
     return factor, offset
 
 def linearRegression(requestContext, seriesList, startSourceAt=None, endSourceAt=None):
@@ -3816,7 +3820,7 @@ def summarize(requestContext, seriesList, intervalString, func='sum', alignToFro
 
     for timestamp_, value in datapoints:
       if alignToFrom:
-        bucketInterval = int((timestamp_ - series.start) / interval)
+        bucketInterval = int((timestamp_ - series.start) // interval)
       else:
         bucketInterval = timestamp_ - (timestamp_ % interval)
 
@@ -3837,7 +3841,7 @@ def summarize(requestContext, seriesList, intervalString, func='sum', alignToFro
     for timestamp_ in range(newStart, newEnd, interval):
       if alignToFrom:
         newEnd = timestamp_
-        bucketInterval = int((timestamp_ - series.start) / interval)
+        bucketInterval = int((timestamp_ - series.start) // interval)
       else:
         bucketInterval = timestamp_ - (timestamp_ % interval)
 
@@ -3897,13 +3901,13 @@ def hitcount(requestContext, seriesList, intervalString, alignToInterval = False
     # the modified requestContext.
     seriesList = evaluateTokens(requestContext, requestContext['args'][0])
     for series in seriesList:
-      intervalCount = int((series.end - series.start) / interval)
+      intervalCount = int((series.end - series.start) // interval)
       series.end = series.start + (intervalCount * interval) + interval
 
   for series in seriesList:
     length = len(series)
     step = int(series.step)
-    bucket_count = int(math.ceil(float(series.end - series.start) / interval))
+    bucket_count = int(math.ceil(float(series.end - series.start) // interval))
     buckets = [[] for _ in range(bucket_count)]
     newStart = int(series.end - bucket_count * interval)
 
@@ -4084,7 +4088,7 @@ def events(requestContext, *tags):
   start_timestamp = start_timestamp - start_timestamp % step
   end_timestamp = epoch(requestContext["endTime"])
   end_timestamp = end_timestamp - end_timestamp % step
-  points = (end_timestamp - start_timestamp)/step
+  points = (end_timestamp - start_timestamp) // step
 
   events = models.Event.find_events(epoch_to_dt(start_timestamp),
                                     epoch_to_dt(end_timestamp),
@@ -4093,7 +4097,7 @@ def events(requestContext, *tags):
   values = [None] * points
   for event in events:
     event_timestamp = epoch(event.when)
-    value_offset = (event_timestamp - start_timestamp)/step
+    value_offset = (event_timestamp - start_timestamp) // step
 
     if values[value_offset] is None:
       values[value_offset] = 1

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -1244,19 +1244,22 @@ class FunctionsTest(TestCase):
         seriesList = self._gen_series_list_with_data(key='test',start=0,end=600,step=60,data=[0, 120, 240, 480, 960, 1920, 3840, 7680, 15360, 30720])
         expected = [TimeSeries('perSecond(test)', 0, 600, 60, [None, 2, 2, 4, 8, 16, 32, 64, 128, 256])]
         result = functions.perSecond({}, seriesList)
-        self.assertEqual(expected, result, 'perSecond result incorrect')
+        self.assertEqual(list(expected[0]), list(result[0]))
+        self.assertEqual(expected, result)
 
     def test_perSecond_nones(self):
-        seriesList = self._gen_series_list_with_data(key='test',start=0,end=600,step=60,data=[0, 60, None, 180, None, 300, None, 420, None, 540])
-        expected = [TimeSeries('perSecond(test)', 0, 600, 60, [None, 1, None, 1, None, 1, None, 1, None, 1])]
+        seriesList = self._gen_series_list_with_data(key='test',start=0,end=600,step=60,data=[0, 60, None, 180, None, None, None, 420, None, 540])
+        expected = [TimeSeries('perSecond(test)', 0, 600, 60, [None, 1, None, 1, None, None, None, 1, None, 1])]
         result = functions.perSecond({}, seriesList)
-        self.assertEqual(expected, result, 'perSecond result incorrect')
+        self.assertEqual(list(expected[0]), list(result[0]))
+        self.assertEqual(expected, result)
 
     def test_perSecond_max(self):
         seriesList = self._gen_series_list_with_data(key='test',start=0,end=600,step=60,data=[0, 120, 240, 480, 960, 900, 120, 240, 120, 0])
         expected = [TimeSeries('perSecond(test)', 0, 600, 60, [None, 2, 2, 4, 8, None, -5, 2, 6, 6])]
         result = functions.perSecond({}, seriesList, 480)
-        self.assertEqual(expected, result, 'perSecond result incorrect')
+        self.assertEqual(list(expected[0]), list(result[0]))
+        self.assertEqual(expected, result)
 
     def test_integral(self):
         seriesList = self._gen_series_list_with_data(key='test',start=0,end=600,step=60,data=[None, 1, 2, 3, 4, 5, None, 6, 7, 8])


### PR DESCRIPTION
As reported in #2028 there is an issue with how null values are handled in `perSecond`, it doubles the step value for every null encountered instead of incrementing it by the series step.  This has been corrected and the test suite has been updated to test the scenario where multiple null values are encountered.

While debugging this issue I saw that there are many places in `functions.py` including in `perSecond` where the code is reliant on the non-intuitive Python 2.3-2.7 behavior where the division operator `/` performs integer/floor division if both arguments are integers and regular division if one or more are floats.

See https://www.python.org/dev/peps/pep-0238/ for a discussion of division in Python and the changes introduced in 2.3 and in 3.0.

To both make it clearer in the code which type of division is being used and to bring us closer to 3.x compatibility, I added `from __future__ import division` and converted all instances of integer division in `functions.py` to use `//`.