### PR TITLE
add /tags/findSeries, add filter and pretty parameters to tag list/details endpoints

### DIFF
--- a/webapp/graphite/tags/localdatabase.py
+++ b/webapp/graphite/tags/localdatabase.py
@@ -39,17 +39,7 @@ class LocalDatabaseTagDB(BaseTagDB):
 
         matches_empty = bool(re.match(spec, ''))
 
-        if connection.vendor == 'mysql':
-          db_operator = 'REGEXP'
-        elif connection.vendor == 'sqlite':
-          # django provides an implementation of REGEXP for sqlite
-          db_operator = 'REGEXP'
-        elif connection.vendor == 'postgresql':
-          db_operator = '~*'
-        else:
-          raise Exception('Database vendor ' + connection.vendor + ' does not support regular expressions')
-
-        where.append('v' + s + '.value ' + db_operator + ' %s')
+        where.append('v' + s + '.value ' + self._regexp_operator(connection) + ' %s')
         whereparams.append(spec)
 
       elif operator == '!=':
@@ -65,17 +55,7 @@ class LocalDatabaseTagDB(BaseTagDB):
 
         matches_empty = not re.match(spec, '')
 
-        if connection.vendor == 'mysql':
-          db_operator = 'NOT REGEXP'
-        elif connection.vendor == 'sqlite':
-          # django provides an implementation of REGEXP for sqlite
-          db_operator = 'NOT REGEXP'
-        elif connection.vendor == 'postgresql':
-          db_operator = '!~*'
-        else:
-          raise Exception('Database vendor ' + connection.vendor + ' does not support regular expressions')
-
-        where.append('v' + s + '.value ' + db_operator + ' %s')
+        where.append('v' + s + '.value ' + self._regexp_not_operator(connection) + ' %s')
         whereparams.append(spec)
 
       else:
@@ -131,17 +111,25 @@ class LocalDatabaseTagDB(BaseTagDB):
 
       return TaggedSeries(tags['name'], tags, series_id=series_id)
 
-  def list_tags(self):
+  def list_tags(self, filter=None):
     with connection.cursor() as cursor:
       sql = 'SELECT t.id, t.tag'
       sql += ' FROM tags_tag AS t'
-      sql += ' ORDER BY t.tag'
       params = []
+
+      if filter:
+        # make sure regex is anchored
+        if not filter.startswith('^'):
+          filter = '^' + filter
+        sql += ' WHERE t.tag ' + self._regexp_operator(connection) + ' %s'
+        params.append(filter)
+
+      sql += ' ORDER BY t.tag'
       cursor.execute(sql, params)
 
       return [{'id': tag_id, 'tag': tag} for (tag_id, tag) in cursor.fetchall()]
 
-  def get_tag(self, tag):
+  def get_tag(self, tag, filter=None):
     with connection.cursor() as cursor:
       sql = 'SELECT t.id, t.tag'
       sql += ' FROM tags_tag AS t'
@@ -159,19 +147,27 @@ class LocalDatabaseTagDB(BaseTagDB):
     return {
       'id': tag_id,
       'tag': tag,
-      'values': self.list_values(tag),
+      'values': self.list_values(tag, filter=filter),
     }
 
-  def list_values(self, tag):
+  def list_values(self, tag, filter=None ):
     with connection.cursor() as cursor:
       sql = 'SELECT v.id, v.value, COUNT(st.id)'
       sql += ' FROM tags_tagvalue AS v'
       sql += ' JOIN tags_seriestag AS st ON st.value_id=v.id'
       sql += ' JOIN tags_tag AS t ON t.id=st.tag_id'
       sql += ' WHERE t.tag=%s'
+      params = [tag]
+
+      if filter:
+        # make sure regex is anchored
+        if not filter.startswith('^'):
+          filter = '^' + filter
+        sql += ' AND v.value ' + self._regexp_operator(connection) + ' %s'
+        params.append(filter)
+
       sql += ' GROUP BY v.id, v.value'
       sql += ' ORDER BY v.value'
-      params = [tag]
       cursor.execute(sql, params)
 
       return [{'id': value_id, 'value': value, 'count': count} for (value_id, value, count) in cursor.fetchall()]
@@ -194,6 +190,28 @@ class LocalDatabaseTagDB(BaseTagDB):
 
     with connection.cursor() as cursor:
       cursor.execute(sql, params)
+
+  @staticmethod
+  def _regexp_operator(connection):
+    if connection.vendor == 'mysql':
+      return 'REGEXP'
+    if connection.vendor == 'sqlite':
+      # django provides an implementation of REGEXP for sqlite
+      return 'REGEXP'
+    if connection.vendor == 'postgresql':
+      return '~*'
+    raise Exception('Database vendor ' + connection.vendor + ' does not support regular expressions')
+
+  @staticmethod
+  def _regexp_not_operator(connection):
+    if connection.vendor == 'mysql':
+      return 'NOT REGEXP'
+    if connection.vendor == 'sqlite':
+      # django provides an implementation of REGEXP for sqlite
+      return 'NOT REGEXP'
+    if connection.vendor == 'postgresql':
+      return '!~*'
+    raise Exception('Database vendor ' + connection.vendor + ' does not support regular expressions')
 
   def tag_series(self, series):
     # extract tags and normalize path
@@ -237,7 +255,11 @@ class LocalDatabaseTagDB(BaseTagDB):
         series_id = cursor.fetchone()[0]
 
       # series tags
-      self._insert_ignore('tags_seriestag', ['series_id', 'tag_id', 'value_id'], [[series_id, tag_ids[tag], value_ids[value]] for tag, value in parsed.tags.items()])
+      self._insert_ignore(
+        'tags_seriestag',
+        ['series_id', 'tag_id', 'value_id'],
+        [[series_id, tag_ids[tag], value_ids[value]] for tag, value in parsed.tags.items()]
+      )
 
     return path
 

--- a/webapp/graphite/tags/localdatabase.py
+++ b/webapp/graphite/tags/localdatabase.py
@@ -282,11 +282,11 @@ class LocalDatabaseTagDB(BaseTagDB):
 
       (series_id, ) = row
 
-      sql = 'DELETE FROM tags_series WHERE id=%s'
+      sql = 'DELETE FROM tags_seriestag WHERE series_id=%s'
       params = [series_id]
       cursor.execute(sql, params)
 
-      sql = 'DELETE FROM tags_seriestag WHERE series_id=%s'
+      sql = 'DELETE FROM tags_series WHERE id=%s'
       params = [series_id]
       cursor.execute(sql, params)
 

--- a/webapp/graphite/tags/localdatabase.py
+++ b/webapp/graphite/tags/localdatabase.py
@@ -111,25 +111,25 @@ class LocalDatabaseTagDB(BaseTagDB):
 
       return TaggedSeries(tags['name'], tags, series_id=series_id)
 
-  def list_tags(self, filter=None):
+  def list_tags(self, tagFilter=None):
     with connection.cursor() as cursor:
       sql = 'SELECT t.id, t.tag'
       sql += ' FROM tags_tag AS t'
       params = []
 
-      if filter:
+      if tagFilter:
         # make sure regex is anchored
-        if not filter.startswith('^'):
-          filter = '^' + filter
+        if not tagFilter.startswith('^'):
+          tagFilter = '^' + tagFilter
         sql += ' WHERE t.tag ' + self._regexp_operator(connection) + ' %s'
-        params.append(filter)
+        params.append(tagFilter)
 
       sql += ' ORDER BY t.tag'
       cursor.execute(sql, params)
 
       return [{'id': tag_id, 'tag': tag} for (tag_id, tag) in cursor.fetchall()]
 
-  def get_tag(self, tag, filter=None):
+  def get_tag(self, tag, valueFilter=None):
     with connection.cursor() as cursor:
       sql = 'SELECT t.id, t.tag'
       sql += ' FROM tags_tag AS t'
@@ -147,10 +147,10 @@ class LocalDatabaseTagDB(BaseTagDB):
     return {
       'id': tag_id,
       'tag': tag,
-      'values': self.list_values(tag, filter=filter),
+      'values': self.list_values(tag, valueFilter=valueFilter),
     }
 
-  def list_values(self, tag, filter=None ):
+  def list_values(self, tag, valueFilter=None ):
     with connection.cursor() as cursor:
       sql = 'SELECT v.id, v.value, COUNT(st.id)'
       sql += ' FROM tags_tagvalue AS v'
@@ -159,12 +159,12 @@ class LocalDatabaseTagDB(BaseTagDB):
       sql += ' WHERE t.tag=%s'
       params = [tag]
 
-      if filter:
+      if valueFilter:
         # make sure regex is anchored
-        if not filter.startswith('^'):
-          filter = '^' + filter
+        if not valueFilter.startswith('^'):
+          valueFilter = '^' + valueFilter
         sql += ' AND v.value ' + self._regexp_operator(connection) + ' %s'
-        params.append(filter)
+        params.append(valueFilter)
 
       sql += ' GROUP BY v.id, v.value'
       sql += ' ORDER BY v.value'

--- a/webapp/graphite/tags/localdatabase.py
+++ b/webapp/graphite/tags/localdatabase.py
@@ -269,18 +269,25 @@ class LocalDatabaseTagDB(BaseTagDB):
 
     path = parsed.path
 
-    # check if path is already tagged
-    curr = self.get_series(path)
-    if not curr:
-      return True
-
     with connection.cursor() as cursor:
+      sql = 'SELECT id'
+      sql += ' FROM tags_series'
+      sql += ' WHERE path=%s'
+      params = [path]
+      cursor.execute(sql, params)
+
+      row = cursor.fetchone()
+      if not row:
+        return True
+
+      (series_id, ) = row
+
       sql = 'DELETE FROM tags_series WHERE id=%s'
-      params = [curr.id]
+      params = [series_id]
       cursor.execute(sql, params)
 
       sql = 'DELETE FROM tags_seriestag WHERE series_id=%s'
-      params = [curr.id]
+      params = [series_id]
       cursor.execute(sql, params)
 
     return True

--- a/webapp/graphite/tags/redis.py
+++ b/webapp/graphite/tags/redis.py
@@ -99,27 +99,27 @@ class RedisTagDB(BaseTagDB):
 
     return TaggedSeries(tags['name'], tags)
 
-  def list_tags(self, filter=None):
+  def list_tags(self, tagFilter=None):
     return sorted([
       {'tag': tag}
       for tag in self.r.sscan_iter('tags')
-      if not filter or re.match(filter, tag) is not None
+      if not tagFilter or re.match(tagFilter, tag) is not None
     ], key=lambda x: x['tag'])
 
-  def get_tag(self, tag, filter=None):
+  def get_tag(self, tag, valueFilter=None):
     if not self.r.sismember('tags', tag):
       return None
 
     return {
       'tag': tag,
-      'values': self.list_values(tag, filter=filter),
+      'values': self.list_values(tag, valueFilter=valueFilter),
     }
 
-  def list_values(self, tag, filter=None):
+  def list_values(self, tag, valueFilter=None):
     return sorted([
       {'value': value, 'count': self.r.scard('tags:' + tag + ':values:' + value)}
       for value in self.r.sscan_iter('tags:' + tag + ':values')
-      if not filter or re.match(filter, value) is not None
+      if not valueFilter or re.match(valueFilter, value) is not None
     ], key=lambda x: x['value'])
 
   def tag_series(self, series):

--- a/webapp/graphite/tags/redis.py
+++ b/webapp/graphite/tags/redis.py
@@ -99,25 +99,27 @@ class RedisTagDB(BaseTagDB):
 
     return TaggedSeries(tags['name'], tags)
 
-  def list_tags(self):
+  def list_tags(self, filter=None):
     return sorted([
       {'tag': tag}
       for tag in self.r.sscan_iter('tags')
+      if not filter or re.match(filter, tag) is not None
     ], key=lambda x: x['tag'])
 
-  def get_tag(self, tag):
+  def get_tag(self, tag, filter=None):
     if not self.r.sismember('tags', tag):
       return None
 
     return {
       'tag': tag,
-      'values': self.list_values(tag),
+      'values': self.list_values(tag, filter=filter),
     }
 
-  def list_values(self, tag):
+  def list_values(self, tag, filter=None):
     return sorted([
       {'value': value, 'count': self.r.scard('tags:' + tag + ':values:' + value)}
       for value in self.r.sscan_iter('tags:' + tag + ':values')
+      if not filter or re.match(filter, value) is not None
     ], key=lambda x: x['value'])
 
   def tag_series(self, series):

--- a/webapp/graphite/tags/urls.py
+++ b/webapp/graphite/tags/urls.py
@@ -18,6 +18,7 @@ from . import views
 urlpatterns = [
   url('tagSeries', views.tagSeries, name='tagSeries'),
   url('delSeries', views.delSeries, name='delSeries'),
+  url('findSeries', views.findSeries, name='findSeries'),
   url('^(.+)$', views.tagDetails, name='tagDetails'),
   url('^$', views.tagList, name='tagList'),
 ]

--- a/webapp/graphite/tags/urls.py
+++ b/webapp/graphite/tags/urls.py
@@ -20,5 +20,5 @@ urlpatterns = [
   url('delSeries', views.delSeries, name='delSeries'),
   url('findSeries', views.findSeries, name='findSeries'),
   url('^(.+)$', views.tagDetails, name='tagDetails'),
-  url('^$', views.tagList, name='tagList'),
+  url('', views.tagList, name='tagList'),
 ]

--- a/webapp/graphite/tags/utils.py
+++ b/webapp/graphite/tags/utils.py
@@ -157,7 +157,7 @@ class BaseTagDB(object):
     pass
 
   @abc.abstractmethod
-  def list_tags(self):
+  def list_tags(self, filter=None):
     """
     List defined tags, returns a list of dictionaries describing the tags stored in the TagDB.
 
@@ -171,11 +171,12 @@ class BaseTagDB(object):
         },
       ]
 
+    Accepts an optional filter parameter which is a regular expression used to filter the list of returned tags
     """
     pass
 
   @abc.abstractmethod
-  def get_tag(self, tag):
+  def get_tag(self, tag, filter=None):
     """
     Get details of a particular tag, accepts a tag name and returns a dict describing the tag.
 
@@ -194,11 +195,12 @@ class BaseTagDB(object):
         ],
       }
 
+    Accepts an optional filter parameter which is a regular expression used to filter the list of returned tags
     """
     pass
 
   @abc.abstractmethod
-  def list_values(self, tag):
+  def list_values(self, tag, filter=None):
     """
     List values for a particular tag, returns a list of dictionaries describing the values stored in the TagDB.
 
@@ -214,6 +216,7 @@ class BaseTagDB(object):
         },
       ]
 
+    Accepts an optional filter parameter which is a regular expression used to filter the list of returned tags
     """
     pass
 

--- a/webapp/graphite/tags/utils.py
+++ b/webapp/graphite/tags/utils.py
@@ -157,7 +157,7 @@ class BaseTagDB(object):
     pass
 
   @abc.abstractmethod
-  def list_tags(self, filter=None):
+  def list_tags(self, tagFilter=None):
     """
     List defined tags, returns a list of dictionaries describing the tags stored in the TagDB.
 
@@ -176,7 +176,7 @@ class BaseTagDB(object):
     pass
 
   @abc.abstractmethod
-  def get_tag(self, tag, filter=None):
+  def get_tag(self, tag, valueFilter=None):
     """
     Get details of a particular tag, accepts a tag name and returns a dict describing the tag.
 
@@ -200,7 +200,7 @@ class BaseTagDB(object):
     pass
 
   @abc.abstractmethod
-  def list_values(self, tag, filter=None):
+  def list_values(self, tag, valueFilter=None):
     """
     List values for a particular tag, returns a list of dictionaries describing the values stored in the TagDB.
 

--- a/webapp/graphite/tags/views.py
+++ b/webapp/graphite/tags/views.py
@@ -10,6 +10,7 @@ def tagSeries(request):
   if not path:
     return HttpResponse(
       json.dumps({'error': 'no path specified'}),
+      content_type='application/json',
       status=400
     )
 
@@ -26,6 +27,7 @@ def delSeries(request):
   if not path:
     return HttpResponse(
       json.dumps({'error': 'no path specified'}),
+      content_type='application/json',
       status=400
     )
 
@@ -34,12 +36,41 @@ def delSeries(request):
     content_type='application/json'
   )
 
+def findSeries(request):
+  if request.method not in ['GET', 'POST']:
+    return HttpResponse(status=405)
+
+  queryParams = request.GET.copy()
+  queryParams.update(request.POST)
+
+  exprs = []
+  # Normal format: ?expr=tag1=value1&expr=tag2=value2
+  if len(queryParams.getlist('expr')) > 0:
+    exprs = queryParams.getlist('expr')
+  # Rails/PHP/jQuery common practice format: ?expr[]=tag1=value1&expr[]=tag2=value2
+  elif len(queryParams.getlist('expr[]')) > 0:
+    exprs = queryParams.getlist('expr[]')
+
+  if not exprs:
+    return HttpResponse(
+      json.dumps({'error': 'no tag expressions specified'}),
+      content_type='application/json',
+      status=400
+    )
+
+  return HttpResponse(
+    json.dumps(STORE.tagdb.find_series(exprs) if STORE.tagdb else [],
+               indent=(2 if queryParams.get('pretty') else None)),
+    content_type='application/json'
+  )
+
 def tagList(request):
   if request.method != 'GET':
     return HttpResponse(status=405)
 
   return HttpResponse(
-    json.dumps(STORE.tagdb.list_tags() if STORE.tagdb else []),
+    json.dumps(STORE.tagdb.list_tags(filter=request.GET.get('filter')) if STORE.tagdb else [],
+               indent=(2 if request.GET.get('pretty') else None)),
     content_type='application/json'
   )
 
@@ -48,6 +79,7 @@ def tagDetails(request, tag):
     return HttpResponse(status=405)
 
   return HttpResponse(
-    json.dumps(STORE.tagdb.get_tag(tag) if STORE.tagdb else None),
+    json.dumps(STORE.tagdb.get_tag(tag, filter=request.GET.get('filter')) if STORE.tagdb else None,
+               indent=(2 if request.GET.get('pretty') else None)),
     content_type='application/json'
   )

--- a/webapp/graphite/tags/views.py
+++ b/webapp/graphite/tags/views.py
@@ -69,7 +69,7 @@ def tagList(request):
     return HttpResponse(status=405)
 
   return HttpResponse(
-    json.dumps(STORE.tagdb.list_tags(filter=request.GET.get('filter')) if STORE.tagdb else [],
+    json.dumps(STORE.tagdb.list_tags(tagFilter=request.GET.get('filter')) if STORE.tagdb else [],
                indent=(2 if request.GET.get('pretty') else None)),
     content_type='application/json'
   )
@@ -79,7 +79,7 @@ def tagDetails(request, tag):
     return HttpResponse(status=405)
 
   return HttpResponse(
-    json.dumps(STORE.tagdb.get_tag(tag, filter=request.GET.get('filter')) if STORE.tagdb else None,
+    json.dumps(STORE.tagdb.get_tag(tag, valueFilter=request.GET.get('filter')) if STORE.tagdb else None,
                indent=(2 if request.GET.get('pretty') else None)),
     content_type='application/json'
   )

--- a/webapp/graphite/tags/views.py
+++ b/webapp/graphite/tags/views.py
@@ -60,7 +60,8 @@ def findSeries(request):
 
   return HttpResponse(
     json.dumps(STORE.tagdb.find_series(exprs) if STORE.tagdb else [],
-               indent=(2 if queryParams.get('pretty') else None)),
+               indent=(2 if queryParams.get('pretty') else None),
+               sort_keys=bool(request.GET.get('pretty'))),
     content_type='application/json'
   )
 
@@ -70,7 +71,8 @@ def tagList(request):
 
   return HttpResponse(
     json.dumps(STORE.tagdb.list_tags(tagFilter=request.GET.get('filter')) if STORE.tagdb else [],
-               indent=(2 if request.GET.get('pretty') else None)),
+               indent=(2 if request.GET.get('pretty') else None),
+               sort_keys=bool(request.GET.get('pretty'))),
     content_type='application/json'
   )
 
@@ -80,6 +82,7 @@ def tagDetails(request, tag):
 
   return HttpResponse(
     json.dumps(STORE.tagdb.get_tag(tag, valueFilter=request.GET.get('filter')) if STORE.tagdb else None,
-               indent=(2 if request.GET.get('pretty') else None)),
+               indent=(2 if request.GET.get('pretty') else None),
+               sort_keys=bool(request.GET.get('pretty'))),
     content_type='application/json'
   )

--- a/webapp/graphite/urls.py
+++ b/webapp/graphite/urls.py
@@ -28,7 +28,7 @@ graphite_urls = [
     url('^whitelist/?', include('graphite.whitelist.urls')),
     url('^version/', include('graphite.version.urls')),
     url('^events/', include('graphite.events.urls')),
-    url('^tags(?:/|$)', include('graphite.tags.urls')),
+    url('^tags/?', include('graphite.tags.urls')),
     url('^s/(?P<path>.*)', shorten, name='shorten'),
     url('^S/(?P<link_id>[a-zA-Z0-9]+)/?$', follow, name='follow'),
     url('^$', browser, name='browser'),

--- a/webapp/tests/test_tags.py
+++ b/webapp/tests/test_tags.py
@@ -149,6 +149,13 @@ class TagsTest(TestCase):
 
   def test_tag_views(self):
     url = reverse('tagList')
+
+    expected = 'test.a;blah=blah;hello=tiger'
+
+    response = self.client.post(url + '/tagSeries', {'path': 'test.a;hello=tiger;blah=blah'})
+    self.assertEqual(response['Content-Type'], 'application/json')
+    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+
     expected = [{"tag": "hello"}]
 
     response = self.client.get(url, {'filter': 'hello$'})
@@ -159,25 +166,13 @@ class TagsTest(TestCase):
     self.assertEqual(response['Content-Type'], 'application/json')
     self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
-    expected = {"tag": "hello", "values": [{"count": 0, "value": "tiger"}]}
+    expected = {"tag": "hello", "values": [{"count": 1, "value": "tiger"}]}
 
     response = self.client.get(url + '/hello', {'filter': 'tiger$'})
     self.assertEqual(response['Content-Type'], 'application/json')
     self.assertEqual(json.loads(response.content), expected)
 
     response = self.client.get(url + '/hello', {'filter': 'tiger$', 'pretty': 1})
-    self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
-
-    expected = []
-
-    response = self.client.get(url + '/findSeries?expr=name=test.a&expr=hello=tiger&expr=blah=blah&pretty=1')
-    self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
-
-    expected = 'test.a;blah=blah;hello=tiger'
-
-    response = self.client.post(url + '/tagSeries', {'path': 'test.a;hello=tiger;blah=blah'})
     self.assertEqual(response['Content-Type'], 'application/json')
     self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
@@ -192,3 +187,9 @@ class TagsTest(TestCase):
     response = self.client.post(url + '/delSeries', {'path': 'test.a;hello=tiger;blah=blah'})
     self.assertEqual(response['Content-Type'], 'application/json')
     self.assertEqual(response.content, json.dumps(expected))
+
+    expected = []
+
+    response = self.client.get(url + '/findSeries?expr=name=test.a&expr=hello=tiger&expr=blah=blah&pretty=1')
+    self.assertEqual(response['Content-Type'], 'application/json')
+    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))

--- a/webapp/tests/test_tags.py
+++ b/webapp/tests/test_tags.py
@@ -160,21 +160,33 @@ class TagsTest(TestCase):
 
     response = self.client.get(url, {'filter': 'hello$'})
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(json.loads(response.content), expected)
+    result = json.loads(response.content)
+    self.assertEqual(len(result), len(expected))
+    self.assertEqual(result[0]['tag'], expected[0]['tag'])
 
     response = self.client.get(url, {'filter': 'hello$', 'pretty': 1})
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    result = json.loads(response.content)
+    self.assertEqual(len(result), len(expected))
+    self.assertEqual(result[0]['tag'], expected[0]['tag'])
 
     expected = {"tag": "hello", "values": [{"count": 1, "value": "tiger"}]}
 
     response = self.client.get(url + '/hello', {'filter': 'tiger$'})
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(json.loads(response.content), expected)
+    result = json.loads(response.content)
+    self.assertEqual(result['tag'], expected['tag'])
+    self.assertEqual(len(result['values']), len(expected['values']))
+    self.assertEqual(result['values'][0]['count'], expected['values'][0]['count'])
+    self.assertEqual(result['values'][0]['value'], expected['values'][0]['value'])
 
     response = self.client.get(url + '/hello', {'filter': 'tiger$', 'pretty': 1})
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    result = json.loads(response.content)
+    self.assertEqual(result['tag'], expected['tag'])
+    self.assertEqual(len(result['values']), len(expected['values']))
+    self.assertEqual(result['values'][0]['count'], expected['values'][0]['count'])
+    self.assertEqual(result['values'][0]['value'], expected['values'][0]['value'])
 
     expected = ['test.a;blah=blah;hello=tiger']
 
@@ -184,12 +196,12 @@ class TagsTest(TestCase):
 
     expected = True
 
-    response = self.client.post(url + '/delSeries', {'path': 'test.a;hello=tiger;blah=blah'})
+    response = self.client.post(url + '/delSeries', {'path': 'test.a;blah=blah;hello=tiger'})
     self.assertEqual(response['Content-Type'], 'application/json')
     self.assertEqual(response.content, json.dumps(expected))
 
     expected = []
 
-    response = self.client.get(url + '/findSeries?expr=name=test.a&expr=hello=tiger&expr=blah=blah&pretty=1')
+    response = self.client.get(url + '/findSeries?expr=name=test.a&expr=hello=tiger&expr=blah=blah')
     self.assertEqual(response['Content-Type'], 'application/json')
     self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))

--- a/webapp/tests/test_tags.py
+++ b/webapp/tests/test_tags.py
@@ -131,6 +131,10 @@ class TagsTest(TestCase):
     result = db.find_series(['name=test.b', 'hello='])
     self.assertEqual(result, ['test.b;blah=blah'])
 
+    # delete series we added
+    self.assertTrue(db.del_series('test.a;blah=blah;hello=tiger'))
+    self.assertTrue(db.del_series('test.a;blah=blah;hello=lion'))
+
   def test_local_tagdb(self):
     return self._test_tagdb(LocalDatabaseTagDB())
 

--- a/webapp/tests/test_tags.py
+++ b/webapp/tests/test_tags.py
@@ -72,28 +72,32 @@ class TagsTest(TestCase):
     self.assertEquals(tagList[2]['tag'], 'name')
 
     # get filtered list of tags
-    result = db.list_tags(filter='hello|bla')
+    result = db.list_tags(tagFilter='hello|bla')
     tagList = [tag for tag in result if tag['tag'] in ['name', 'hello', 'blah']]
     self.assertEquals(len(tagList), 2)
     self.assertEquals(tagList[0]['tag'], 'blah')
     self.assertEquals(tagList[1]['tag'], 'hello')
 
-    # get list of values
-    result = db.list_values('hello')
-    valueList = [value for value in result if value['value'] in ['tiger', 'lion']]
+
+    # get tag & list of values
+    result = db.get_tag('hello')
+    self.assertEquals(result['tag'], 'hello')
+    valueList = [value for value in result['values'] if value['value'] in ['tiger', 'lion']]
     self.assertEquals(len(valueList), 2)
     self.assertEquals(valueList[0]['value'], 'lion')
     self.assertEquals(valueList[1]['value'], 'tiger')
 
-    # get filtered list of values (match)
-    result = db.list_values('hello', filter='tig')
-    valueList = [value for value in result if value['value'] in ['tiger', 'lion']]
+    # get tag & filtered list of values (match)
+    result = db.get_tag('hello', valueFilter='tig')
+    self.assertEquals(result['tag'], 'hello')
+    valueList = [value for value in result['values'] if value['value'] in ['tiger', 'lion']]
     self.assertEquals(len(valueList), 1)
     self.assertEquals(valueList[0]['value'], 'tiger')
 
-    # get filtered list of values (no match)
-    result = db.list_values('hello', filter='tigr')
-    valueList = [value for value in result if value['value'] in ['tiger', 'lion']]
+    # get tag & filtered list of values (no match)
+    result = db.get_tag('hello', valueFilter='tigr')
+    self.assertEquals(result['tag'], 'hello')
+    valueList = [value for value in result['values'] if value['value'] in ['tiger', 'lion']]
     self.assertEquals(len(valueList), 0)
 
     # basic find
@@ -102,6 +106,10 @@ class TagsTest(TestCase):
 
     # find with regex
     result = db.find_series(['hello=tiger', 'blah=~b.*'])
+    self.assertEqual(result, ['test.a;blah=blah;hello=tiger'])
+
+    # find with not regex
+    result = db.find_series(['hello=tiger', 'blah!=~l.*'])
     self.assertEqual(result, ['test.a;blah=blah;hello=tiger'])
 
     # find with not equal

--- a/webapp/tests/test_tags.py
+++ b/webapp/tests/test_tags.py
@@ -55,12 +55,46 @@ class TagsTest(TestCase):
     self.assertEqual(result.metric, 'test.a')
     self.assertEqual(result.tags, {'blah': 'blah', 'hello': 'tiger', 'name': 'test.a'})
 
-    # tag more series
+    # tag the same series again
     result = db.tag_series('test.a;blah=blah;hello=tiger')
     self.assertEquals(result, 'test.a;blah=blah;hello=tiger')
 
+    # tag another series
     result = db.tag_series('test.a;blah=blah;hello=lion')
     self.assertEquals(result, 'test.a;blah=blah;hello=lion')
+
+    # get list of tags
+    result = db.list_tags()
+    tagList = [tag for tag in result if tag['tag'] in ['name', 'hello', 'blah']]
+    self.assertEquals(len(tagList), 3)
+    self.assertEquals(tagList[0]['tag'], 'blah')
+    self.assertEquals(tagList[1]['tag'], 'hello')
+    self.assertEquals(tagList[2]['tag'], 'name')
+
+    # get filtered list of tags
+    result = db.list_tags(filter='hello|bla')
+    tagList = [tag for tag in result if tag['tag'] in ['name', 'hello', 'blah']]
+    self.assertEquals(len(tagList), 2)
+    self.assertEquals(tagList[0]['tag'], 'blah')
+    self.assertEquals(tagList[1]['tag'], 'hello')
+
+    # get list of values
+    result = db.list_values('hello')
+    valueList = [value for value in result if value['value'] in ['tiger', 'lion']]
+    self.assertEquals(len(valueList), 2)
+    self.assertEquals(valueList[0]['value'], 'lion')
+    self.assertEquals(valueList[1]['value'], 'tiger')
+
+    # get filtered list of values (match)
+    result = db.list_values('hello', filter='tig')
+    valueList = [value for value in result if value['value'] in ['tiger', 'lion']]
+    self.assertEquals(len(valueList), 1)
+    self.assertEquals(valueList[0]['value'], 'tiger')
+
+    # get filtered list of values (no match)
+    result = db.list_values('hello', filter='tigr')
+    valueList = [value for value in result if value['value'] in ['tiger', 'lion']]
+    self.assertEquals(len(valueList), 0)
 
     # basic find
     result = db.find_series(['hello=tiger'])


### PR DESCRIPTION
This PR adds support for a `/tags/findSeries` endpoint that can be used to look up series via the same logic as `seriesByTag`, and adds support for passing a `filter` parameter to `/tags` and `/tags/<tag>` to filter the returned tags & tag values respectively.  It also adds support for a `pretty` parameter to return formatted json from those endpoints.