### PR TITLE
support "pipe" function chaining syntax

### DIFF
--- a/docs/render_api.rst
+++ b/docs/render_api.rst
@@ -89,7 +89,18 @@ Paths also support the following wildcards, which allows you to identify more th
   All wildcards apply only within a single path element.  In other words, they do not include or cross dots (``.``).
   Therefore, ``servers.*`` will not match ``servers.ix02ehssvc04v.cpu.total.user``, while ``servers.*.*.*.*`` will.
 
-  
+Tagged Series
+^^^^^^^^^^^^^
+
+When querying tagged series, we start with the `seriesByTag <functions.html#graphite.render.functions.seriesByTag>`_ function:
+
+.. code-block:: none
+
+    # find all series that have tag1 set to value1
+    seriesByTag('tag1=value1')
+
+See :ref:`querying tagged series <querying-tagged-series>` for more detail on using `seriesByTag <functions.html#graphite.render.functions.seriesByTag>`_.
+
 Examples
 ^^^^^^^^
 
@@ -122,6 +133,16 @@ You can also run any number of :doc:`functions </functions>` on the various metr
 
   &target=averageSeries(company.server*.applicationInstance.requestsHandled)
   (draws 1 aggregate line)
+
+Multiple function calls can be chained together either by nesting them or by piping the result into another function (it will be passed to the piped function as its first parameter):
+
+.. code-block:: none
+
+  &target=movingAverage(aliasByNode(company.server*.applicationInstance.requestsHandled,1),"5min")
+  &target=aliasByNode(company.server*.applicationInstance.requestsHandled,1)|movingAverage("5min")
+  &target=company.server*.applicationInstance.requestsHandled|aliasByNode(1)|movingAverage("5min")
+  &target=movingAverage(company.server*.applicationInstance.requestsHandled|aliasByNode(1),"5min")
+  (these are all equivalent)
 
 The target param can also be repeated to graph multiple related metrics.
 

--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -13,6 +13,8 @@ To enter tagged series into Graphite, they should be passed to Carbon by appendi
 
 Carbon will automatically decode the tags, normalize the tag order, and register the series in the tag database.
 
+.. _querying-tagged-series:
+
 Querying
 --------
 
@@ -28,7 +30,7 @@ This function returns a `seriesList` that can then be used by any other Graphite
 .. code-block:: none
 
     # find all series that have tag1 set to value1, sorted by total
-    sortByTotal(seriesByTag('tag1=value1'))
+    seriesByTag('tag1=value1') | sortByTotal()
 
 The `seriesByTag <functions.html#graphite.render.functions.seriesByTag>`_ function supports specifying any number of tag expressions to refine the list of matches.  When multiple tag expressions are specified, only series that match all the expressions will be returned.
 
@@ -57,7 +59,7 @@ Once you have selected a seriesList, it is possible to group series together usi
 .. code-block:: none
 
     # get a list of disk space used per datacenter for all webheads
-    groupByTags(seriesByTag('name=disk.used', 'server=~web.*'), 'sumSeries', 'datacenter')
+    seriesByTag('name=disk.used', 'server=~web.*') | groupByTags('sumSeries', 'datacenter')
 
     # given series like:
     # disk.used;datacenter=dc1;rack=a1;server=web01
@@ -78,7 +80,7 @@ Finally, the `aliasByTags <functions.html#graphite.render.functions.aliasByTags>
     # disk.used;datacenter=dc1;rack=b2;server=web02
 
     # format series name using datacenter tag:
-    aliasByTags(seriesByTag('name=disk.used', 'datacenter=dc1'), 'server', 'name')
+    seriesByTag('name=disk.used','datacenter=dc1') | aliasByTags('server', 'name')
 
     # will return
     # web01.disk.used

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -27,6 +27,8 @@ def evaluateTokens(requestContext, tokens, replacements=None, pipedArg=None):
 
   elif tokens.expression:
     if tokens.expression.pipedCalls:
+      # when the expression has piped calls, we pop the right-most call and pass the remaining
+      # expression into it via pipedArg, to get the same result as a nested call
       rightMost = tokens.expression.pipedCalls.pop()
       return evaluateTokens(requestContext, rightMost, replacements, tokens)
 

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -3986,7 +3986,7 @@ def seriesByTag(requestContext, *tagExpressions):
 
   .. code-block:: none
 
-    &target=seriesByTag("tag1=value1", "tag2!=value2")
+    &target=seriesByTag("tag1=value1","tag2!=value2")
 
   Returns a seriesList of all series that have tag1 set to value1, AND do not have tag2 set to value2.
 
@@ -4004,6 +4004,8 @@ def seriesByTag(requestContext, *tagExpressions):
   At least one tag spec must require a non-empty value.
 
   Regular expression conditions are treated as being anchored at the start of the value.
+
+  See :ref:`querying tagged series <querying-tagged-series>` for more detail.
   """
 
   if STORE.tagdb is None:
@@ -4030,14 +4032,14 @@ def groupByTags(requestContext, seriesList, callback, *tags):
 
   .. code-block:: none
 
-    &target=groupByTags(seriesByTag("name=cpu"),"averageSeries", "dc")
+    &target=seriesByTag("name=cpu")|groupByTags("averageSeries","dc")
 
   Would return multiple series which are each the result of applying the "averageSeries" function
   to groups joined on the specified tags resulting in a list of targets like
 
   .. code-block :: none
 
-    averageSeries(seriesByTag("name=cpu", "dc=dc1")),averageSeries(seriesByTag("name=cpu", "dc=dc2")),...
+    averageSeries(seriesByTag("name=cpu","dc=dc1")),averageSeries(seriesByTag("name=cpu","dc=dc2")),...
 
   """
   if STORE.tagdb is None:
@@ -4081,7 +4083,7 @@ def aliasByTags(requestContext, seriesList, *tags):
 
   .. code-block:: none
 
-    &target=aliasByTags(seriesByTag('name=cpu'), 'server', 'name')
+    &target=seriesByTag("name=cpu")|aliasByTags("server","name")
 
   """
   for series in seriesList:

--- a/webapp/graphite/render/grammar.py
+++ b/webapp/graphite/render/grammar.py
@@ -2,7 +2,7 @@ from pyparsing import (
     Forward, Combine, Optional, Word, Literal, CaselessKeyword,
     CaselessLiteral, Group, FollowedBy, LineEnd, OneOrMore, ZeroOrMore,
     alphas, alphanums, printables, delimitedList, quotedString, Regex,
-    __version__,
+    __version__, Suppress
 )
 
 grammar = Forward()
@@ -54,7 +54,7 @@ comma = Literal(',').suppress()
 equal = Literal('=').suppress()
 backslash = Literal('\\').suppress()
 
-symbols = '''(){},.'"\\'''
+symbols = '''(){},.'"\\|'''
 arg = Group(
   boolean |
   number |
@@ -110,11 +110,18 @@ template = Group(
   rightParen
 )('template')
 
+pipeSep = ZeroOrMore(Literal(' ')) + Literal('|') + ZeroOrMore(Literal(' '))
+
+pipedExpression = Group(
+  (template | call | pathExpression) +
+  Group(ZeroOrMore(Suppress(pipeSep) + Group(call)('pipedCall')))('pipedCalls')
+)('expression')
+
 if __version__.startswith('1.'):
-    expression << Group(template | call | pathExpression)('expression')
+    expression << pipedExpression
     grammar << expression
 else:
-    expression <<= Group(template | call | pathExpression)('expression')
+    expression <<= pipedExpression
     grammar <<= expression
 
 

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -2218,12 +2218,12 @@ class FunctionsTest(TestCase):
         # Additiona tests
         seriesList = []
         names = [
-            "collectd.test-db:#|.load.value",
-            "sum(collectd.test-db:#|.load.value)",
-            "sum(sum(collectd.test-db:#|.load.value))",
-            "divide(collectd.test-db:#|.load.value, 5)",
+            "collectd.test-db1.load.value",
+            "sum(collectd.test-db1.load.value)",
+            "sum(sum(collectd.test-db1.load.value))",
+            "divide(collectd.test-db1.load.value, 5)",
         ]
-        expected = ["test-db:#|"] * len(names)
+        expected = ["test-db1"] * len(names)
         for name in names:
             series = TimeSeries(name, 0, 1, 1, [1])
             series.pathExpression = series.name


### PR DESCRIPTION
This PR adds support for chaining functions together by "piping" the output of each function into the next (as the first parameter), much like the way they're presented in the Grafana UI.

When dealing with deeply-nested queries this keeps the arguments for each function together, and can help increase readability vs the current "nested" syntax.

With this update the following query:
```
aliasByNode(movingAverage(sortByName(test.*),"5min"),1)
```
can be written as:
```
test.*|sortByName()|movingAverage("5min")|aliasByNode(1)
```
or:
```
sortByName(test.*)|movingAverage("5min")|aliasByNode(1)
```
Piping is supported within function arguments, so the same expression could also be written as
```
movingAverage(test.*|sortByName(),"5min")|aliasByNode(1)
```
A more useful example would be selecting series for the `total` parameter of `asPercent`:
```
test.*|sortByName()|asPercent(test.total|movingAverage("5min"))
```

The syntax is unwrapped in the parser and evaluator, so there is no difference in how the actual render functions are called, the evaluator walks through the piped calls from right to left, passing the chain up to that point into the function as the first parameter.

The one change I had to make that would affect existing syntax is that the pipe character `|` is added to the list of symbols that aren't allowed in pathExpressions, but I doubt that's widely used since it would make working with the whisper files painful.  If a user does have series with a pipe in the name they can still be selected but the pipe would need to be escaped with a backslash.