### PR TITLE
add aggregateWithWildcards function, minor refactor for movingWindow

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -276,9 +276,6 @@ def aggregateWithWildcards(requestContext, seriesList, callback, *positions):
   :py:func:`minSeries <minSeries>`, :py:func:`maxSeries <maxSeries>` &
   :py:func:`rangeOfSeries <rangeOfSeries>`.
   """
-  if isinstance(positions, int):
-    positions = [positions]
-
   metaSeries = {}
   keys = []
   for series in seriesList:
@@ -723,10 +720,6 @@ def weightedAverage(requestContext, seriesListAvg, seriesListWeight, *nodes):
 
 
   """
-
-  if isinstance(nodes, int):
-    nodes=[nodes]
-
   sortedSeries={}
 
   for seriesAvg, seriesWeight in izip(seriesListAvg , seriesListWeight):
@@ -1782,8 +1775,6 @@ def aliasByNode(requestContext, seriesList, *nodes):
     &target=aliasByNode(ganglia.*.cpu.load5,1)
 
   """
-  if isinstance(nodes, int):
-    nodes=[nodes]
   for series in seriesList:
     pathExpression = _getFirstPathExpression(series.name)
     metric_pieces = pathExpression.split('.')
@@ -3553,9 +3544,6 @@ def groupByNodes(requestContext, seriesList, callback, *nodes):
     sumSeries(ganglia.server1.*.cpu.load5),sumSeries(ganglia.server1.*.cpu.load10),sumSeries(ganglia.server1.*.cpu.load15),sumSeries(ganglia.server2.*.cpu.load5),sumSeries(ganglia.server2.*.cpu.load10),sumSeries(ganglia.server2.*.cpu.load15),...
 
   """
-  if isinstance(nodes, int):
-    nodes = [nodes]
-
   metaSeries = {}
   keys = []
   for series in seriesList:

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -214,8 +214,12 @@ def sumSeriesWithWildcards(requestContext, seriesList, *position): #XXX
     &target=sumSeriesWithWildcards(host.cpu-[0-7].cpu-{user,system}.value, 1)
 
   This would be the equivalent of
-  ``target=sumSeries(host.cpu-[0-7].cpu-user.value)&target=sumSeries(host.cpu-[0-7].cpu-system.value)``
 
+  .. code-block:: none
+
+    &target=sumSeries(host.cpu-[0-7].cpu-user.value)&target=sumSeries(host.cpu-[0-7].cpu-system.value)
+
+  This is an alias for :py:func:`aggregateWithWildcards <aggregateWithWildcards>` with callback :py:func:`sumSeries <sumSeries>`.
   """
   return aggregateWithWildcards(requestContext, seriesList, 'sumSeries', *position)
 
@@ -230,8 +234,12 @@ def averageSeriesWithWildcards(requestContext, seriesList, *position): #XXX
     &target=averageSeriesWithWildcards(host.cpu-[0-7].cpu-{user,system}.value, 1)
 
   This would be the equivalent of
-  ``target=averageSeries(host.*.cpu-user.value)&target=averageSeries(host.*.cpu-system.value)``
 
+  .. code-block:: none
+
+    &target=averageSeries(host.*.cpu-user.value)&target=averageSeries(host.*.cpu-system.value)
+
+  This is an alias for :py:func:`aggregateWithWildcards <aggregateWithWildcards>` with callback :py:func:`averageSeries <averageSeries>`.
   """
   return aggregateWithWildcards(requestContext, seriesList, 'averageSeries', *position)
 
@@ -251,6 +259,7 @@ def multiplySeriesWithWildcards(requestContext, seriesList, *position): #XXX
 
     &target=multiplySeries(web.host-0.{avg-response,total-request}.value)&target=multiplySeries(web.host-1.{avg-response,total-request}.value)...
 
+  This is an alias for :py:func:`aggregateWithWildcards <aggregateWithWildcards>` with callback :py:func:`multiplySeries <multiplySeries>`.
   """
   return aggregateWithWildcards(requestContext, seriesList, 'multiplySeries', *position)
 
@@ -275,6 +284,8 @@ def aggregateWithWildcards(requestContext, seriesList, callback, *positions):
   :py:func:`diffSeries <diffSeries>`, :py:func:`stddevSeries <stddevSeries>`,
   :py:func:`minSeries <minSeries>`, :py:func:`maxSeries <maxSeries>` &
   :py:func:`rangeOfSeries <rangeOfSeries>`.
+
+  This complements :py:func:`groupByNodes <groupByNodes>` which takes a list of nodes that must match in each group.
   """
   metaSeries = {}
   keys = []
@@ -3525,6 +3536,7 @@ def groupByNode(requestContext, seriesList, nodeNum, callback):
 
     sumSeries(ganglia.by-function.server1.*.cpu.load5),sumSeries(ganglia.by-function.server2.*.cpu.load5),...
 
+  This is an alias for using :py:func:`groupByNodes <groupByNodes>` with a single node.
   """
   return groupByNodes(requestContext, seriesList, callback, nodeNum)
 
@@ -3543,6 +3555,13 @@ def groupByNodes(requestContext, seriesList, callback, *nodes):
 
     sumSeries(ganglia.server1.*.cpu.load5),sumSeries(ganglia.server1.*.cpu.load10),sumSeries(ganglia.server1.*.cpu.load15),sumSeries(ganglia.server2.*.cpu.load5),sumSeries(ganglia.server2.*.cpu.load10),sumSeries(ganglia.server2.*.cpu.load15),...
 
+  This function can be used with :py:func:`sumSeries <sumSeries>`,
+  :py:func:`averageSeries <averageSeries>`, :py:func:`multiplySeries <multiplySeries>`,
+  :py:func:`diffSeries <diffSeries>`, :py:func:`stddevSeries <stddevSeries>`,
+  :py:func:`minSeries <minSeries>`, :py:func:`maxSeries <maxSeries>` &
+  :py:func:`rangeOfSeries <rangeOfSeries>`.
+
+  This complements :py:func:`aggregateWithWildcards <aggregateWithWildcards>` which takes a list of wildcard nodes.
   """
   metaSeries = {}
   keys = []

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -816,11 +816,11 @@ def movingWindow(requestContext, seriesList, windowSize, func='average', xFilesF
   elif func == 'median':
     consolidateFunc = lambda nonNull: sorted(nonNull)[len(nonNull) // 2]
   elif func == 'sum':
-    consolidateFunc = lambda nonNull: sum(nonNull)
+    consolidateFunc = sum
   elif func == 'min':
-    consolidateFunc = lambda nonNull: min(nonNull)
+    consolidateFunc = min
   elif func == 'max':
-    consolidateFunc = lambda nonNull: max(nonNull)
+    consolidateFunc = max
   else:
     raise Exception('Unsupported window function: %s' % (func))
 


### PR DESCRIPTION
In much the same way that `movingWindow` provides a centralized implementation for the various `moving*` functions and added support for additional aggregation methods, this PR defines a new `aggregateWithWildcards` function that provides a single implementation for all `*SeriesWithWildcards` functions and adds support for using all defined series aggregator function with wildcards (full list is in the docs).

It also includes a minor refactor for `movingWindow` to take the block that defines the aggregation func outside the loop.