### PR TITLE
TagDB refactor

### DIFF
--- a/webapp/graphite/finders/remote.py
+++ b/webapp/graphite/finders/remote.py
@@ -24,7 +24,6 @@ from graphite.worker_pool.pool import get_pool, pool_apply
 
 class RemoteFinder(BaseFinder):
     local = False
-    disabled = False
 
     def __init__(self, hosts=None):
         if hosts is None:

--- a/webapp/graphite/finders/remote.py
+++ b/webapp/graphite/finders/remote.py
@@ -24,6 +24,7 @@ from graphite.worker_pool.pool import get_pool, pool_apply
 
 class RemoteFinder(BaseFinder):
     local = False
+    disabled = False
 
     def __init__(self, hosts=None):
         if hosts is None:
@@ -36,6 +37,7 @@ class RemoteFinder(BaseFinder):
             remote_hosts.append(host)
 
         self.remote_stores = [RemoteStore(self, host) for host in remote_hosts]
+        self.disabled = len(self.remote_stores) < 1
 
     def worker_pool(self):
         # The number of workers should increase linear with the number of

--- a/webapp/graphite/finders/utils.py
+++ b/webapp/graphite/finders/utils.py
@@ -39,8 +39,10 @@ class FindQuery(object):
 class BaseFinder(object):
     __metaclass__ = abc.ABCMeta
 
-    # Set to 'False' if this is a remote finder.
+    # Set to False if this is a remote finder.
     local = True
+    # set to True if this finder shouldn't be used
+    disabled = False
 
     def __init__(self):
         """Initialize the finder."""

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -316,6 +316,11 @@ def prefetchRemoteData(requestContext, targets):
   each time evaluateTarget() needs to fetch a path. All the prefetched
   data is stored in the requestContext, to be accessed later by datalib.
   """
+  # only prefetch if there is at least one remote finder
+  # this is to avoid the overhead of tagdb lookups in extractPathExpressions
+  if len([finder for finder in STORE.finders if not getattr(finder, 'local', True) and not getattr(finder, 'disabled')]) < 1:
+    return
+
   pathExpressions = extractPathExpressions(targets)
   log.rendering("Prefetching remote data for [%s]" % (', '.join(pathExpressions)))
 

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -316,7 +316,7 @@ def prefetchRemoteData(requestContext, targets):
   each time evaluateTarget() needs to fetch a path. All the prefetched
   data is stored in the requestContext, to be accessed later by datalib.
   """
-  # only prefetch if there is at least one remote finder
+  # only prefetch if there is at least one active remote finder
   # this is to avoid the overhead of tagdb lookups in extractPathExpressions
   if len([finder for finder in STORE.finders if not getattr(finder, 'local', True) and not getattr(finder, 'disabled')]) < 1:
     return

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -56,7 +56,7 @@ class Store(object):
         results = []
         for finder in self.finders:
             is_local = getattr(finder, 'local', True)
-            if is_local:
+            if is_local or getattr(finder, 'disabled'):
                 continue
 
             result = finder.fetch(
@@ -104,6 +104,8 @@ class Store(object):
             # Support legacy finders by defaulting to 'local = True'
             is_local = not hasattr(finder, 'local') or finder.local
             if query.local and not is_local:
+                continue
+            if getattr(finder, 'disabled'):
                 continue
             jobs.append((finder.find_nodes, query))
 

--- a/webapp/graphite/tags/localdatabase.py
+++ b/webapp/graphite/tags/localdatabase.py
@@ -7,6 +7,7 @@ from graphite.tags.utils import BaseTagDB, TaggedSeries
 
 class LocalDatabaseTagDB(BaseTagDB):
   def find_series_query(self, tags):
+    # sql will select series that match all tag expressions that don't match empty tags
     sql = 'SELECT s.path'
     sql += ' FROM tags_series AS s'
     params = []
@@ -16,6 +17,7 @@ class LocalDatabaseTagDB(BaseTagDB):
 
     all_match_empty = True
 
+    # expressions that do match empty tags will be used to filter the result
     filters = []
 
     i = 0

--- a/webapp/graphite/tags/localdatabase.py
+++ b/webapp/graphite/tags/localdatabase.py
@@ -16,6 +16,8 @@ class LocalDatabaseTagDB(BaseTagDB):
 
     all_match_empty = True
 
+    filters = []
+
     i = 0
     for tagspec in tags:
       (tag, operator, spec) = self.parse_tagspec(tagspec)
@@ -23,14 +25,12 @@ class LocalDatabaseTagDB(BaseTagDB):
       i += 1
       s = str(i)
 
-      sql += ' JOIN tags_tag AS t' + s + ' ON t' + s + '.tag=%s'
-      params.append(tag)
-
       if operator == '=':
         matches_empty = spec == ''
 
-        where.append('v' + s + '.value=%s')
-        whereparams.append(spec)
+        if not matches_empty:
+          where.append('v' + s + '.value=%s')
+          whereparams.append(spec)
 
       elif operator == '=~':
         # make sure regex is anchored
@@ -39,14 +39,16 @@ class LocalDatabaseTagDB(BaseTagDB):
 
         matches_empty = bool(re.match(spec, ''))
 
-        where.append('v' + s + '.value ' + self._regexp_operator(connection) + ' %s')
-        whereparams.append(spec)
+        if not matches_empty:
+          where.append('v' + s + '.value ' + self._regexp_operator(connection) + ' %s')
+          whereparams.append(spec)
 
       elif operator == '!=':
         matches_empty = spec != ''
 
-        where.append('v' + s + '.value<>%s')
-        whereparams.append(spec)
+        if not matches_empty:
+          where.append('v' + s + '.value<>%s')
+          whereparams.append(spec)
 
       elif operator == '!=~':
         # make sure regex is anchored
@@ -55,18 +57,18 @@ class LocalDatabaseTagDB(BaseTagDB):
 
         matches_empty = not re.match(spec, '')
 
-        where.append('v' + s + '.value ' + self._regexp_not_operator(connection) + ' %s')
-        whereparams.append(spec)
+        if not matches_empty:
+          where.append('v' + s + '.value ' + self._regexp_not_operator(connection) + ' %s')
+          whereparams.append(spec)
 
       else:
         raise ValueError("Invalid operator %s" % operator)
 
       if matches_empty:
-        sql += ' LEFT JOIN tags_seriestag AS st' + s + ' ON st' + s + '.series_id=s.id AND st' + s + '.tag_id=t' + s + '.id'
-        sql += ' LEFT JOIN tags_tagvalue AS v' + s + ' ON v' + s + '.id=st' + s + '.value_id'
-
-        where[-1] = '(' + where[-1] + ' OR v' + s + '.id IS NULL)'
+        filters.append((tag, operator, spec))
       else:
+        sql += ' JOIN tags_tag AS t' + s + ' ON t' + s + '.tag=%s'
+        params.append(tag)
         sql += ' JOIN tags_seriestag AS st' + s + ' ON st' + s + '.series_id=s.id AND st' + s + '.tag_id=t' + s + '.id'
         sql += ' JOIN tags_tagvalue AS v' + s + ' ON v' + s + '.id=st' + s + '.value_id'
 
@@ -81,15 +83,33 @@ class LocalDatabaseTagDB(BaseTagDB):
 
     sql += ' ORDER BY s.path'
 
-    return sql, params
+    return sql, params, filters
 
   def find_series(self, tags):
-    sql, params = self.find_series_query(tags)
+    sql, params, filters = self.find_series_query(tags)
+
+    def matches_filters(path):
+      if not filters:
+        return True
+
+      parsed = self.parse(path)
+
+      for (tag, operator, spec) in filters:
+        value = parsed.tags.get(tag, '')
+        if (
+          (operator == '=' and value != spec) or
+          (operator == '=~' and re.match(spec, value) is None) or
+          (operator == '!=' and value == spec) or
+          (operator == '!=~' and re.match(spec, value) is not None)
+        ):
+          return False
+
+      return True
 
     with connection.cursor() as cursor:
       cursor.execute(sql, params)
 
-      return [row[0] for row in cursor.fetchall()]
+      return [row[0] for row in cursor.fetchall() if matches_filters(row[0])]
 
   def get_series(self, path):
     with connection.cursor() as cursor:

--- a/webapp/graphite/tags/redis.py
+++ b/webapp/graphite/tags/redis.py
@@ -34,7 +34,7 @@ class RedisTagDB(BaseTagDB):
     selector_cnt = None
     filters = []
 
-    # loop through tagspecs, look for best = or =~ match
+    # loop through tagspecs, look for best spec to use as selector
     for tagspec in tags:
       (tag, operator, spec) = self.parse_tagspec(tagspec)
 

--- a/webapp/graphite/tags/redis.py
+++ b/webapp/graphite/tags/redis.py
@@ -4,7 +4,6 @@ import re
 
 from django.conf import settings
 from graphite.util import logtime
-from graphite.logger import log
 
 from graphite.tags.utils import BaseTagDB, TaggedSeries
 

--- a/webapp/tests/test_tags.py
+++ b/webapp/tests/test_tags.py
@@ -110,14 +110,14 @@ class TagsTest(TestCase):
     self.assertEqual(result, ['test.a;blah=blah;hello=tiger'])
 
     # find with regex
-    result = db.find_series(['blah=~b.*', 'hello=~tiger'])
+    result = db.find_series(['blah=~b.*', 'hello=~tiger', 'test=~.*'])
     self.assertEqual(result, ['test.a;blah=blah;hello=tiger'])
 
     # find with not regex
-    result = db.find_series(['blah!=~l.*', 'hello=tiger'])
+    result = db.find_series(['blah!=~$', 'hello=~tiger', 'test!=~.+'])
     self.assertEqual(result, ['test.a;blah=blah;hello=tiger'])
 
-    result = db.find_series(['hello=~lion', 'blah!=~l.*'])
+    result = db.find_series(['hello=~lion', 'blah!=~$'])
     self.assertEqual(result, ['test.a;blah=blah;hello=lion'])
 
     # find with not equal


### PR DESCRIPTION
This PR refactors the redis TagDB implementation to increase performance by evaluating a single "selector" expression and then treating any remaining expressions as filters on that set, rather than evaluating each expression separately and intersecting the results.  This makes a big difference in cases where previously a large number of values would have had to be read from redis and tested in Python (expressions using `!=`, `=~` or `!=~`).

It also refactors the local db implementation to use database joins only for expressions that don't match empty tags, and to use filtering to evaluate any remaining expressions.

It also adds an optimization in the prefetch code so that `extractPathExpressions` isn't called if there are no remote stores enabled.  In a future PR we'll want to add some caching to the TagDB lookups to avoid the duplicated TagDB lookups when using prefetch.