### PR TITLE
support matching series by node in asPercent

### DIFF
--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -83,6 +83,9 @@ def evaluateTokens(requestContext, tokens, replacements=None, pipedArg=None):
   elif tokens.boolean:
     return tokens.boolean[0] == 'true'
 
+  elif tokens.none:
+    return None
+
   else:
     raise ValueError("unknown token in target evaluator")
 

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -594,7 +594,30 @@ def asPercent(requestContext, seriesList, total=None, *nodes):
     # cpu stats for each server as a percentage of its total
     &target=asPercent(Server*.cpu.*.jiffies, None, 0)
 
-  .. note:: When `total` is a seriesList, specifying `nodes` to match series with the corresponding total series will increase reliability.
+  When using `nodes`, any series or totals that can't be matched will create output series with
+  names like ``asPercent(someSeries,MISSING)`` or ``asPercent(MISSING,someTotalSeries)`` and all
+  values set to None. If desired these series can be filtered out by piping the result through
+  ``|exclude("MISSING")`` as shown below:
+
+  .. code-block:: none
+
+    &target=asPercent(Server{1,2}.memory.used,Server{1,3}.memory.total,0)
+
+    # will produce 3 output series:
+    # asPercent(Server1.memory.used,Server1.memory.total) [values will be as expected]
+    # asPercent(Server2.memory.used,MISSING) [all values will be None]
+    # asPercent(MISSING,Server3.memory.total) [all values will be None]
+
+    &target=asPercent(Server{1,2}.memory.used,Server{1,3}.memory.total,0)|exclude("MISSING")
+
+    # will produce 1 output series:
+    # asPercent(Server1.memory.used,Server1.memory.total) [values will be as expected]
+
+  .. note::
+
+    When `total` is a seriesList, specifying `nodes` to match series with the corresponding total
+    series will increase reliability.
+
   """
   normalize([seriesList])
 

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -563,19 +563,39 @@ def asPercent(requestContext, seriesList, total=None, *nodes):
   each series will be calculated as a percentage of that total. If `total` is not specified,
   the sum of all points in the wildcard series will be used instead.
 
-  The `total` parameter may be a single series, reference the same number of series as `seriesList` or a numeric value.
+  A list of nodes can optionally be provided, if so they will be used to match series with their
+  corresponding totals following the same logic as :py:func:`groupByNodes <groupByNodes>`.
+
+  When passing `nodes` the `total` parameter may be a series list or `None`.  If it is `None` then
+  for each series in `seriesList` the percentage of the sum of series in that group will be returned.
+
+  When not passing `nodes`, the `total` parameter may be a single series, reference the same number
+  of series as `seriesList` or be a numeric value.
 
   Example:
 
   .. code-block:: none
 
+    # Server01 connections failed and succeeded as a percentage of Server01 connections attempted
     &target=asPercent(Server01.connections.{failed,succeeded}, Server01.connections.attempted)
-    &target=asPercent(Server*.connections.{failed,succeeded}, Server*.connections.attempted)
+
+    # For each server, its connections failed as a percentage of its connections attempted
+    &target=asPercent(Server*.connections.failed, Server*.connections.attempted)
+
+    # For each server, its connections failed and succeeded as a percentage of its connections attemped
+    &target=asPercent(Server*.connections.{failed,succeeded}, Server*.connections.attempted, 0)
+
+    # apache01.threads.busy as a percentage of 1500
     &target=asPercent(apache01.threads.busy,1500)
+
+    # Server01 cpu stats as a percentage of its total
     &target=asPercent(Server01.cpu.*.jiffies)
 
-  """
+    # cpu stats for each server as a percentage of its total
+    &target=asPercent(Server*.cpu.*.jiffies, None, 0)
 
+  .. note:: When `total` is a seriesList, specifying `nodes` to match series with the corresponding total series will increase reliability.
+  """
   normalize([seriesList])
 
   # if nodes are specified, use them to match series & total

--- a/webapp/graphite/render/grammar.py
+++ b/webapp/graphite/render/grammar.py
@@ -34,6 +34,10 @@ boolean = Group(
   CaselessKeyword("false")
 )('boolean')
 
+none = Group(
+  CaselessKeyword('none')
+)('none')
+
 argname = Word(alphas + '_', alphanums + '_')('argname')
 funcname = Word(alphas + '_', alphanums + '_')('funcname')
 
@@ -58,6 +62,7 @@ symbols = '''(){},.'"\\|'''
 arg = Group(
   boolean |
   number |
+  none |
   aString |
   expression
 )('args*')

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -986,6 +986,8 @@ class FunctionsTest(TestCase):
             TimeSeries('asPercent(collectd.test-db4.load.value,collectd.test-db4.load.total)',0,1,1,[100.0, 100.0, 100.0, 100.0, None, 100.0, None, None, 100.0, 100.0, 100.0, None, 100.0, None, None, None, None, 100.0, 100.0, 100.0]),
             TimeSeries('asPercent(collectd.test-db4.load.avg,collectd.test-db4.load.total)',0,1,1,[100.0, 100.0, 100.0, 100.0, None, 100.0, None, None, 100.0, 100.0, 100.0, None, 100.0, None, None, None, None, 100.0, 100.0, 100.0]),
             TimeSeries('asPercent(collectd.test-db5.load.value,sumSeries(collectd.test-db5.load.total,collectd.test-db5.load.total2))',0,1,1,[50.0, 50.0, None, None, None, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, None, None]),
+            TimeSeries('asPercent(collectd.test-db6.load.avg,MISSING)',0,1,1,[None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None]),
+            TimeSeries('asPercent(MISSING,collectd.test-db7.load.total)',0,1,1,[None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None]),
         ]
 
         result = functions.asPercent({}, seriesList, seriesList2, 1)

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -923,6 +923,80 @@ class FunctionsTest(TestCase):
 
         self.assertEqual(result, expectedResult)
 
+    def test_asPercent_seriesList2_nodes(self):
+        self.maxDiff = None
+
+        seriesList = self._gen_series_list_with_data(
+            key=[
+                'collectd.test-db1.load.value',
+                'collectd.test-db2.load.value',
+                'collectd.test-db3.load.value',
+                'collectd.test-db4.load.value',
+                'collectd.test-db5.load.value',
+                'collectd.test-db1.load.avg',
+                'collectd.test-db2.load.avg',
+                'collectd.test-db3.load.avg',
+                'collectd.test-db4.load.avg',
+                'collectd.test-db6.load.avg',
+            ],
+            end=1,
+            data=[
+                [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20],
+                [None,2,None,4,None,6,None,8,None,10,None,12,None,14,None,16,None,18,None,20],
+                [1,2,None,None,None,6,7,8,9,10,11,12,13,14,15,16,17,None,None,None],
+                [1,2,3,4,None,6,None,None,9,10,11,None,13,None,None,None,None,18,19,20],
+                [1,2,None,None,None,6,7,8,9,10,11,12,13,14,15,16,17,18,None,None],
+                [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20],
+                [None,2,None,4,None,6,None,8,None,10,None,12,None,14,None,16,None,18,None,20],
+                [1,2,None,None,None,6,7,8,9,10,11,12,13,14,15,16,17,None,None,None],
+                [1,2,3,4,None,6,None,None,9,10,11,None,13,None,None,None,None,18,19,20],
+                [1,2,None,None,None,6,7,8,9,10,11,12,13,14,15,16,17,18,None,None],
+            ]
+        )
+
+        seriesList2 = self._gen_series_list_with_data(
+            key=[
+                'collectd.test-db1.load.total',
+                'collectd.test-db2.load.total',
+                'collectd.test-db3.load.total',
+                'collectd.test-db4.load.total',
+                'collectd.test-db5.load.total',
+                'collectd.test-db7.load.total',
+            ],
+            end=1,
+            data=[
+                [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20],
+                [None,2,None,4,None,6,None,8,None,10,None,12,None,14,None,16,None,18,None,20],
+                [1,2,None,None,None,6,7,8,9,10,11,12,13,14,15,16,17,None,None,None],
+                [1,2,3,4,None,6,None,None,9,10,11,None,13,None,None,None,None,18,19,20],
+                [1,2,None,None,None,6,7,8,9,10,11,12,13,14,15,16,17,18,None,None],
+                [1,2,None,None,None,6,7,8,9,10,11,12,13,14,15,16,17,18,None,None],
+            ]
+        )
+
+        expectedResult = [
+            TimeSeries('asPercent(collectd.test-db1.load.value,collectd.test-db1.load.total)',0,1,1,[100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0]),
+            TimeSeries('asPercent(collectd.test-db1.load.avg,collectd.test-db1.load.total)',0,1,1,[100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0]),
+            TimeSeries('asPercent(collectd.test-db2.load.value,collectd.test-db2.load.total)',0,1,1,[None, 100.0, None, 100.0, None, 100.0, None, 100.0, None, 100.0, None, 100.0, None, 100.0, None, 100.0, None, 100.0, None, 100.0]),
+            TimeSeries('asPercent(collectd.test-db2.load.avg,collectd.test-db2.load.total)',0,1,1,[None, 100.0, None, 100.0, None, 100.0, None, 100.0, None, 100.0, None, 100.0, None, 100.0, None, 100.0, None, 100.0, None, 100.0]),
+            TimeSeries('asPercent(collectd.test-db3.load.value,collectd.test-db3.load.total)',0,1,1,[100.0, 100.0, None, None, None, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, None, None, None]),
+            TimeSeries('asPercent(collectd.test-db3.load.avg,collectd.test-db3.load.total)',0,1,1,[100.0, 100.0, None, None, None, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, None, None, None]),
+            TimeSeries('asPercent(collectd.test-db4.load.value,collectd.test-db4.load.total)',0,1,1,[100.0, 100.0, 100.0, 100.0, None, 100.0, None, None, 100.0, 100.0, 100.0, None, 100.0, None, None, None, None, 100.0, 100.0, 100.0]),
+            TimeSeries('asPercent(collectd.test-db4.load.avg,collectd.test-db4.load.total)',0,1,1,[100.0, 100.0, 100.0, 100.0, None, 100.0, None, None, 100.0, 100.0, 100.0, None, 100.0, None, None, None, None, 100.0, 100.0, 100.0]),
+            TimeSeries('asPercent(collectd.test-db5.load.value,collectd.test-db5.load.total)',0,1,1,[100.0, 100.0, None, None, None, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, None, None]),
+            TimeSeries('asPercent(collectd.test-db6.load.avg,MISSING)',0,1,1,[None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None]),
+            TimeSeries('asPercent(MISSING,collectd.test-db7.load.total)',0,1,1,[None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None]),
+        ]
+
+        result = functions.asPercent({}, seriesList, seriesList2, 1)
+
+        for i, series in enumerate(result):
+          for k, v in enumerate(series):
+            if type(v) is float:
+              series[k] = round(v,2)
+
+        self.assertEqual(result, expectedResult)
+
     def test_divideSeries_error(self):
         seriesList = self._gen_series_list_with_data(
             key=[

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -923,7 +923,7 @@ class FunctionsTest(TestCase):
 
         self.assertEqual(result, expectedResult)
 
-    def test_asPercent_seriesList2_nodes(self):
+    def test_asPercent_seriesList2_nodes_total(self):
         self.maxDiff = None
 
         seriesList = self._gen_series_list_with_data(
@@ -984,11 +984,62 @@ class FunctionsTest(TestCase):
             TimeSeries('asPercent(collectd.test-db4.load.value,collectd.test-db4.load.total)',0,1,1,[100.0, 100.0, 100.0, 100.0, None, 100.0, None, None, 100.0, 100.0, 100.0, None, 100.0, None, None, None, None, 100.0, 100.0, 100.0]),
             TimeSeries('asPercent(collectd.test-db4.load.avg,collectd.test-db4.load.total)',0,1,1,[100.0, 100.0, 100.0, 100.0, None, 100.0, None, None, 100.0, 100.0, 100.0, None, 100.0, None, None, None, None, 100.0, 100.0, 100.0]),
             TimeSeries('asPercent(collectd.test-db5.load.value,collectd.test-db5.load.total)',0,1,1,[100.0, 100.0, None, None, None, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, None, None]),
-            TimeSeries('asPercent(collectd.test-db6.load.avg,MISSING)',0,1,1,[None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None]),
-            TimeSeries('asPercent(MISSING,collectd.test-db7.load.total)',0,1,1,[None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None]),
         ]
 
         result = functions.asPercent({}, seriesList, seriesList2, 1)
+
+        for i, series in enumerate(result):
+          for k, v in enumerate(series):
+            if type(v) is float:
+              series[k] = round(v,2)
+
+        self.assertEqual(result, expectedResult)
+
+    def test_asPercent_seriesList2_nodes_no_total(self):
+        self.maxDiff = None
+
+        seriesList = self._gen_series_list_with_data(
+            key=[
+                'collectd.test-db1.load.value',
+                'collectd.test-db2.load.value',
+                'collectd.test-db3.load.value',
+                'collectd.test-db4.load.value',
+                'collectd.test-db5.load.value',
+                'collectd.test-db1.load.avg',
+                'collectd.test-db2.load.avg',
+                'collectd.test-db3.load.avg',
+                'collectd.test-db4.load.avg',
+                'collectd.test-db6.load.avg',
+            ],
+            end=1,
+            data=[
+                [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20],
+                [None,2,None,4,None,6,None,8,None,10,None,12,None,14,None,16,None,18,None,20],
+                [1,2,None,None,None,6,7,8,9,10,11,12,13,14,15,16,17,None,None,None],
+                [1,2,3,4,None,6,None,None,9,10,11,None,13,None,None,None,None,18,19,20],
+                [1,2,None,None,None,6,7,8,9,10,11,12,13,14,15,16,17,18,None,None],
+                [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20],
+                [None,2,None,4,None,6,None,8,None,10,None,12,None,14,None,16,None,18,None,20],
+                [1,2,None,None,None,6,7,8,9,10,11,12,13,14,15,16,17,None,None,None],
+                [1,2,3,4,None,6,None,None,9,10,11,None,13,None,None,None,None,18,19,20],
+                [1,2,None,None,None,6,7,8,9,10,11,12,13,14,15,16,17,18,None,None],
+            ]
+        )
+
+        expectedResult = [
+            TimeSeries('asPercent(collectd.test-db1.load.value,sumSeries(collectd.test-db1.load.value,collectd.test-db1.load.avg))',0,1,1,[50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0]),
+            TimeSeries('asPercent(collectd.test-db1.load.avg,sumSeries(collectd.test-db1.load.value,collectd.test-db1.load.avg))',0,1,1,[50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0]),
+            TimeSeries('asPercent(collectd.test-db2.load.value,sumSeries(collectd.test-db2.load.value,collectd.test-db2.load.avg))',0,1,1,[None, 50.0, None, 50.0, None, 50.0, None, 50.0, None, 50.0, None, 50.0, None, 50.0, None, 50.0, None, 50.0, None, 50.0]),
+            TimeSeries('asPercent(collectd.test-db2.load.avg,sumSeries(collectd.test-db2.load.value,collectd.test-db2.load.avg))',0,1,1,[None, 50.0, None, 50.0, None, 50.0, None, 50.0, None, 50.0, None, 50.0, None, 50.0, None, 50.0, None, 50.0, None, 50.0]),
+            TimeSeries('asPercent(collectd.test-db3.load.value,sumSeries(collectd.test-db3.load.value,collectd.test-db3.load.avg))',0,1,1,[50.0, 50.0, None, None, None, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, None, None, None]),
+            TimeSeries('asPercent(collectd.test-db3.load.avg,sumSeries(collectd.test-db3.load.value,collectd.test-db3.load.avg))',0,1,1,[50.0, 50.0, None, None, None, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, None, None, None]),
+            TimeSeries('asPercent(collectd.test-db4.load.value,sumSeries(collectd.test-db4.load.value,collectd.test-db4.load.avg))',0,1,1,[50.0, 50.0, 50.0, 50.0, None, 50.0, None, None, 50.0, 50.0, 50.0, None, 50.0, None, None, None, None, 50.0, 50.0, 50.0]),
+            TimeSeries('asPercent(collectd.test-db4.load.avg,sumSeries(collectd.test-db4.load.value,collectd.test-db4.load.avg))',0,1,1,[50.0, 50.0, 50.0, 50.0, None, 50.0, None, None, 50.0, 50.0, 50.0, None, 50.0, None, None, None, None, 50.0, 50.0, 50.0]),
+            TimeSeries('asPercent(collectd.test-db5.load.value,collectd.test-db5.load.value)',0,1,1,[100.0, 100.0, None, None, None, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, None, None]),
+            TimeSeries('asPercent(collectd.test-db6.load.avg,collectd.test-db6.load.avg)',0,1,1,[100.0, 100.0, None, None, None, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, None, None]),
+        ]
+
+        result = functions.asPercent({}, seriesList, None, 1)
 
         for i, series in enumerate(result):
           for k, v in enumerate(series):


### PR DESCRIPTION
This PR adds support for specifying nodes to be used to match value and total series in calls to `asPercent` using the same logic as in `groupByNodes`.  This allows it to work much more reliably with glob expressions, and doesn't rely on the lists being the same length.  It also makes it much easier to calculate things like disk percentage free/used from raw values.

Usage description and examples are in the updated docblock.  I opted to add the extra params to `asPercent` rather than creating a separate `asPercentByNodes` function both to avoid further bloating the function list, and because I suspect that it will become the preferred way to use `asPercent` when dealing with multiple series.

In order to support the usage where nodes are specified without a `total` series, support has been added for passing `None` in function calls, which previously would have been passed through to the finders as a path expression.