### PR TITLE
Fix time series consolidation

### DIFF
--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -80,15 +80,18 @@ class TimeSeries(list):
 
   __consolidation_functions = {
     'sum': sum,
-    'average': lambda usable: float(sum(usable) / len(usable)),
+    'average': lambda buf: float(sum(buf)) / len(buf),
     'max': max,
     'min': min,
+    'first': lambda buf: buf[0],
+    'last': lambda buf: buf[-1],
   }
+
   def __consolidatingGenerator(self, gen):
     try:
       cf = self.__consolidation_functions[self.consolidationFunc]
     except KeyError:
-      raise Exception, "Invalid consolidation function!"
+      raise Exception("Invalid consolidation function: '%s'" % self.consolidationFunc)
     buf = []    # only the not-None values
     valcnt = 0
     for x in gen:

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -78,39 +78,35 @@ class TimeSeries(list):
     self.valuesPerPoint = int(valuesPerPoint)
 
 
+  __consolidation_functions = {
+    'sum': sum,
+    'average': lambda usable: float(sum(usable) / len(usable)),
+    'max': max,
+    'min': min,
+  }
   def __consolidatingGenerator(self, gen):
-    buf = []
+    try:
+      cf = self.__consolidation_functions[self.consolidationFunc]
+    except KeyError:
+      raise Exception, "Invalid consolidation function!"
+    buf = []    # only the not-None values
+    valcnt = 0
     for x in gen:
-      buf.append(x)
-      if len(buf) == self.valuesPerPoint:
-        while None in buf: buf.remove(None)
+      valcnt += 1
+      if x is not None:
+        buf.append(x)
+      if valcnt == self.valuesPerPoint:
+        valcnt = 0
         if buf:
-          yield self.__consolidate(buf)
+          yield cf(buf)
           buf = []
         else:
           yield None
-    while None in buf: buf.remove(None)
-    if buf: yield self.__consolidate(buf)
-    else: yield None
+    if buf:
+      yield cf(buf)
+    else:
+      yield None
     raise StopIteration
-
-
-  def __consolidate(self, values):
-    usable = [v for v in values if v is not None]
-    if not usable: return None
-    if self.consolidationFunc == 'sum':
-      return sum(usable)
-    if self.consolidationFunc == 'average':
-      return float(sum(usable)) / len(usable)
-    if self.consolidationFunc == 'max':
-      return max(usable)
-    if self.consolidationFunc == 'min':
-      return min(usable)
-    if self.consolidationFunc == 'first':
-      return usable[0]
-    if self.consolidationFunc == 'last':
-      return usable[-1]
-    raise Exception("Invalid consolidation function: '%s'" % self.consolidationFunc)
 
 
   def __repr__(self):

--- a/webapp/tests/test_render_datalib.py
+++ b/webapp/tests/test_render_datalib.py
@@ -106,13 +106,13 @@ class TimeSeriesTest(TestCase):
       expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(0,100,2)+[None])
       self.assertEqual(list(series), list(expected))
 
-    def test_TimeSeries_iterate_valuesPerPoint_2_first(self):
+    def test_TimeSeries_iterate_valuesPerPoint_3_first(self):
       values = range(0,100)
       series = TimeSeries("collectd.test-db.load.value", 0, 5, 1, values, consolidate='first')
       self.assertEqual(series.valuesPerPoint, 1)
-      series.consolidate(2)
-      self.assertEqual(series.valuesPerPoint, 2)
-      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(0,100,2)+[None])
+      series.consolidate(3)
+      self.assertEqual(series.valuesPerPoint, 3)
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(0,100,3))
       self.assertEqual(list(series), list(expected))
 
     def test_TimeSeries_iterate_valuesPerPoint_2_last(self):


### PR DESCRIPTION
A time series having a lot of None values would previously lead to O(n²) time complexity and thus very slow rendering when consolidating values.

This fix is mostly the work of @powo with two new consolidation functions, an added fix for the broken "average" consolidation function and deprecated exception syntax by myself.