### PR TITLE
Fix consolidation

### DIFF
--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -107,7 +107,7 @@ class TimeSeries(list):
           yield None
     if buf:
       yield cf(buf)
-    else:
+    elif valcnt > 0:
       yield None
     raise StopIteration
 

--- a/webapp/tests/test_render_datalib.py
+++ b/webapp/tests/test_render_datalib.py
@@ -50,8 +50,10 @@ class TimeSeriesTest(TestCase):
 
     def test_TimeSeries_consolidate(self):
       values = range(0,100)
+
       series = TimeSeries("collectd.test-db.load.value", 0, len(values)/2, 1, values)
       self.assertEqual(series.valuesPerPoint, 1)
+
       series.consolidate(2)
       self.assertEqual(series.valuesPerPoint, 2)
 
@@ -63,8 +65,10 @@ class TimeSeriesTest(TestCase):
 
     def test_TimeSeries_iterate_valuesPerPoint_2_none_values(self):
       values = [None, None, None, None, None]
+
       series = TimeSeries("collectd.test-db.load.value", 0, len(values)/2, 1, values)
       self.assertEqual(series.valuesPerPoint, 1)
+
       series.consolidate(2)
       self.assertEqual(series.valuesPerPoint, 2)
       expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, [None, None, None])
@@ -72,65 +76,108 @@ class TimeSeriesTest(TestCase):
 
     def test_TimeSeries_iterate_valuesPerPoint_2_avg(self):
       values = range(0,100)
+
       series = TimeSeries("collectd.test-db.load.value", 0, len(values)/2, 1, values)
       self.assertEqual(series.valuesPerPoint, 1)
+
       series.consolidate(2)
       self.assertEqual(series.valuesPerPoint, 2)
-      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, [0.5, 2.5, 4.5, 6.5, 8.5, 10.5, 12.5, 14.5, 16.5, 18.5, 20.5, 22.5, 24.5, 26.5, 28.5, 30.5, 32.5, 34.5, 36.5, 38.5, 40.5, 42.5, 44.5, 46.5, 48.5, 50.5, 52.5, 54.5, 56.5, 58.5, 60.5, 62.5, 64.5, 66.5, 68.5, 70.5, 72.5, 74.5, 76.5, 78.5, 80.5, 82.5, 84.5, 86.5, 88.5, 90.5, 92.5, 94.5, 96.5, 98.5, None])
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, [0.5, 2.5, 4.5, 6.5, 8.5, 10.5, 12.5, 14.5, 16.5, 18.5, 20.5, 22.5, 24.5, 26.5, 28.5, 30.5, 32.5, 34.5, 36.5, 38.5, 40.5, 42.5, 44.5, 46.5, 48.5, 50.5, 52.5, 54.5, 56.5, 58.5, 60.5, 62.5, 64.5, 66.5, 68.5, 70.5, 72.5, 74.5, 76.5, 78.5, 80.5, 82.5, 84.5, 86.5, 88.5, 90.5, 92.5, 94.5, 96.5, 98.5])
+      self.assertEqual(list(series), list(expected))
+
+      series.consolidate(3)
+      self.assertEqual(series.valuesPerPoint, 3)
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, map(float, range(1, 100, 3) + [99]))
       self.assertEqual(list(series), list(expected))
 
     def test_TimeSeries_iterate_valuesPerPoint_2_sum(self):
       values = range(0,100)
+
       series = TimeSeries("collectd.test-db.load.value", 0, 5, 1, values, consolidate='sum')
       self.assertEqual(series.valuesPerPoint, 1)
+
       series.consolidate(2)
       self.assertEqual(series.valuesPerPoint, 2)
-      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(1,200,4)+[None])
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(1,200,4))
+      self.assertEqual(list(series), list(expected))
+
+      series.consolidate(3)
+      self.assertEqual(series.valuesPerPoint, 3)
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(3,300,9) + [99])
       self.assertEqual(list(series), list(expected))
 
     def test_TimeSeries_iterate_valuesPerPoint_2_max(self):
       values = range(0,100)
+
       series = TimeSeries("collectd.test-db.load.value", 0, 5, 1, values, consolidate='max')
       self.assertEqual(series.valuesPerPoint, 1)
+
       series.consolidate(2)
       self.assertEqual(series.valuesPerPoint, 2)
-      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(1,100,2)+[None])
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(1,100,2))
+      self.assertEqual(list(series), list(expected))
+
+      series.consolidate(3)
+      self.assertEqual(series.valuesPerPoint, 3)
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(2,100,3) + [99])
       self.assertEqual(list(series), list(expected))
 
     def test_TimeSeries_iterate_valuesPerPoint_2_min(self):
       values = range(0,100)
+
       series = TimeSeries("collectd.test-db.load.value", 0, 5, 1, values, consolidate='min')
       self.assertEqual(series.valuesPerPoint, 1)
+
       series.consolidate(2)
       self.assertEqual(series.valuesPerPoint, 2)
-      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(0,100,2)+[None])
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(0,100,2))
+      self.assertEqual(list(series), list(expected))
+
+      series.consolidate(3)
+      self.assertEqual(series.valuesPerPoint, 3)
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(0,100,3))
       self.assertEqual(list(series), list(expected))
 
     def test_TimeSeries_iterate_valuesPerPoint_2_first(self):
       values = range(0,100)
+
       series = TimeSeries("collectd.test-db.load.value", 0, 5, 1, values, consolidate='first')
       self.assertEqual(series.valuesPerPoint, 1)
+
       series.consolidate(2)
       self.assertEqual(series.valuesPerPoint, 2)
-      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(0,100,2)+[None])
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(0,100,2))
+      self.assertEqual(list(series), list(expected))
+
+      series.consolidate(3)
+      self.assertEqual(series.valuesPerPoint, 3)
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(0,100,3))
       self.assertEqual(list(series), list(expected))
 
     def test_TimeSeries_iterate_valuesPerPoint_2_last(self):
       values = range(0,100)
+
       series = TimeSeries("collectd.test-db.load.value", 0, 5, 1, values, consolidate='last')
       self.assertEqual(series.valuesPerPoint, 1)
+
       series.consolidate(2)
       self.assertEqual(series.valuesPerPoint, 2)
-      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(1,100,2)+[None])
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(1,100,2))
+      self.assertEqual(list(series), list(expected))
+
+      series.consolidate(3)
+      self.assertEqual(series.valuesPerPoint, 3)
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(2,100,3) + [99])
       self.assertEqual(list(series), list(expected))
 
     def test_TimeSeries_iterate_valuesPerPoint_2_invalid(self):
       values = range(0,100)
+
       series = TimeSeries("collectd.test-db.load.value", 0, 5, 1, values, consolidate='bogus')
       self.assertEqual(series.valuesPerPoint, 1)
+
       series.consolidate(2)
       self.assertEqual(series.valuesPerPoint, 2)
-      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(0,100,2)+[None])
       with self.assertRaisesRegexp(Exception, "Invalid consolidation function: 'bogus'"):
         result = list(series)
 


### PR DESCRIPTION
This PR updates the code in #771 and incorporates updates from #2051 

In addition, it fixes an issue where consolidating a series by an interval that divides evenly into the number of points in the series results in a None value being appended to the result.

The new tests do highlight the need for support for `xFilesFactor` here, since the final value for some aggregations can be quite nonsensical when there aren't enough points in the interval.