### PR TITLE
implement xFilesFactor support, add aggregate function

### DIFF
--- a/docs/render_api.rst
+++ b/docs/render_api.rst
@@ -903,6 +903,8 @@ Set the maximum numbers of datapoints returned when using json content.
 
 If the number of datapoints in a selected range exceeds the maxDataPoints value then the datapoints over the whole period are consolidated.
 
+The function used to consolidate points can be set using the `consolidateBy <functions.html#graphite.render.functions.consolidateBy>`_ function.
+
 .. _param-minorGridLineColor:
 
 minorGridLineColor
@@ -1003,6 +1005,14 @@ One of:
   The maximum of non-null points in the series
 ``minimum``
   THe minimum of non-null points in the series
+
+.. _param-pretty:
+
+pretty
+------
+*Default: <unset>*
+
+If set to 1 and combined with ``format=json``, outputs human-friendly json.
 
 .. _param-rightColor:
 
@@ -1167,6 +1177,19 @@ Example:
 .. code-block:: none
 
   &width=650&height=250
+
+.. _param-xFilesFactor:
+
+xFilesFactor
+------------
+*Default: DEFAULT_XFILES_FACTOR specified in local_settings.py or 0*
+
+Sets the default `xFilesFactor` value used when performing runtime aggregation across multiple
+series and/or intervals.
+
+See the `xFilesFactor <functions.html#graphite.render.functions.setXFilesFactor>`_ function for
+more information on the `xFilesFactor` value and how the default can be overridden for specific
+targets or series.
 
 .. _param-xFormat:
 

--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -65,12 +65,14 @@
 #                        (21600, 180)] # >= 6 hour queries are cached 3 minutes
 #MEMCACHE_KEY_PREFIX = 'graphite'
 
-
 # This lists the memcached options. Default is an empty dict.
 # Accepted options depend on the Memcached implementation and the Django version. 
 # Until Django 1.10, options are used only for pylibmc. 
 # Starting from 1.11, options are used for both python-memcached and pylibmc.
 #MEMCACHE_OPTIONS = { 'socket_timeout': 0.5 }
+
+# this setting controls the default xFilesFactor used for query-time aggregration
+DEFAULT_XFILES_FACTOR = 0
 
 # Set URL_PREFIX when deploying graphite-web to a non-root location
 #URL_PREFIX = '/graphite'

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -39,7 +39,7 @@ class TimeSeries(list):
     self.valuesPerPoint = 1
     self.options = {}
     self.pathExpression = name
-    self.xFilesFactor = xFilesFactor if xFilesFactor is not None else 0
+    self.xFilesFactor = xFilesFactor if xFilesFactor is not None else settings.DEFAULT_XFILES_FACTOR
 
     if tags:
       self.tags = tags
@@ -175,10 +175,10 @@ def _fetchData(pathExpr, startTime, endTime, now, requestContext, seriesList):
     result_queue.append(
       (node.path, node.fetch(startTime, endTime, now, requestContext)))
 
-  return _merge_results(pathExpr, startTime, endTime, result_queue, seriesList)
+  return _merge_results(pathExpr, startTime, endTime, result_queue, seriesList, requestContext)
 
 
-def _merge_results(pathExpr, startTime, endTime, result_queue, seriesList):
+def _merge_results(pathExpr, startTime, endTime, result_queue, seriesList, requestContext):
   log.debug("render.datalib.fetchData :: starting to merge")
   for path, results in result_queue:
     results = wait_for_result(results)
@@ -193,7 +193,7 @@ def _merge_results(pathExpr, startTime, endTime, result_queue, seriesList):
       raise Exception("could not parse timeInfo/values from metric '%s': %s" % (path, e))
     (start, end, step) = timeInfo
 
-    series = TimeSeries(path, start, end, step, values)
+    series = TimeSeries(path, start, end, step, values, xFilesFactor=requestContext.get('xFilesFactor'))
 
     # hack to pass expressions through to render functions
     series.pathExpression = pathExpr

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -238,7 +238,11 @@ def aggregate(requestContext, seriesList, func, xFilesFactor=None):
   else:
     raise Exception('Unsupported aggregation function: %s' % (rawFunc))
 
-  # if seriesLists is actually a single series then wrap it for normalize
+  # if seriesList is empty then just short-circuit
+  if not seriesList:
+    return []
+
+  # if seriesList is a single series then wrap it for normalize
   if isinstance(seriesList[0], TimeSeries):
     seriesList = [seriesList]
 

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -4251,6 +4251,7 @@ def groupByTags(requestContext, seriesList, callback, *tags):
     names = set([series.tags['name'] for series in seriesList])
     name = list(names)[0] if len(names) == 1 else callback
 
+  keys = []
   metaSeries = {}
   for series in seriesList:
     # key is the metric path for the new series
@@ -4261,10 +4262,11 @@ def groupByTags(requestContext, seriesList, callback, *tags):
 
     if key not in metaSeries:
       metaSeries[key] = [series]
+      keys.append(key)
     else:
       metaSeries[key].append(series)
 
-  for key in metaSeries.keys():
+  for key in keys:
     if callback in SeriesFunctions:
       metaSeries[key] = SeriesFunctions[callback](requestContext, metaSeries[key])[0]
     else:
@@ -4273,7 +4275,7 @@ def groupByTags(requestContext, seriesList, callback, *tags):
     metaSeries[key].pathExpression = key
     metaSeries[key].tags = STORE.tagdb.parse(key).tags
 
-  return metaSeries.values()
+  return [metaSeries[key] for key in keys]
 
 def aliasByTags(requestContext, seriesList, *tags):
   """

--- a/webapp/graphite/render/hashing.py
+++ b/webapp/graphite/render/hashing.py
@@ -46,11 +46,11 @@ def hashRequest(request):
   return compactHash(normalizedParams)
 
 
-def hashData(targets, startTime, endTime):
+def hashData(targets, startTime, endTime, xFilesFactor):
   targetsString = ','.join(sorted(targets))
   startTimeString = startTime.strftime("%Y%m%d_%H%M")
   endTimeString = endTime.strftime("%Y%m%d_%H%M")
-  myHash = targetsString + '@' + startTimeString + ':' + endTimeString
+  myHash = targetsString + '@' + startTimeString + ':' + endTimeString + ':' + str(xFilesFactor)
   return compactHash(myHash)
 
 

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -66,6 +66,7 @@ def renderView(request):
     'forwardHeaders': extractForwardHeaders(request),
     'data' : [],
     'prefetched' : {},
+    'xFilesFactor' : requestOptions['xFilesFactor'],
   }
   data = requestContext['data']
 
@@ -103,7 +104,7 @@ def renderView(request):
       targets = requestOptions['targets']
       startTime = requestOptions['startTime']
       endTime = requestOptions['endTime']
-      dataKey = hashData(targets, startTime, endTime)
+      dataKey = hashData(targets, startTime, endTime, requestOptions['xFilesFactor'])
       cachedData = cache.get(dataKey)
       if cachedData:
         log.cache("Data-Cache hit [%s]" % dataKey)
@@ -421,6 +422,8 @@ def parseOptions(request):
   if cacheTimeout == 0:
     requestOptions['noCache'] = True
   requestOptions['cacheTimeout'] = cacheTimeout
+
+  requestOptions['xFilesFactor'] = float( queryParams.get('xFilesFactor', settings.DEFAULT_XFILES_FACTOR) )
 
   return (graphOptions, requestOptions)
 

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -85,6 +85,9 @@ FIND_TOLERANCE = 2 * FIND_CACHE_DURATION
 DEFAULT_CACHE_DURATION = 60 #metric data and graphs are cached for one minute by default
 DEFAULT_CACHE_POLICY = []
 
+# this setting controls the default xFilesFactor used for query-time aggregration
+DEFAULT_XFILES_FACTOR = 0
+
 # These can also be configured using:
 # https://docs.djangoproject.com/en/1.11/topics/logging/
 LOG_RENDERING_PERFORMANCE = False

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -591,6 +591,10 @@ class FunctionsTest(TestCase):
         with self.assertRaisesRegexp(Exception, "Unsupported aggregation function: blahSeries"):
             functions.aggregate({}, [], 'blahSeries')
 
+    def test_aggregate_emptySeries(self):
+        result = functions.aggregate({}, [], 'sum')
+        self.assertEqual(result, [])
+
     def test_averageSeries(self):
         seriesList = self._generate_series_list()
         data = range(0,101)

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -2533,11 +2533,11 @@ class FunctionsTest(TestCase):
     def test_groupByNodes(self):
         seriesList, inputList = self._generate_mr_series()
 
-        def verify_groupByNodes(expectedResult, *nodes):
+        def verify_groupByNodes(expectedResult, func, *nodes):
             if isinstance(nodes, int):
                 node_number = [nodes]
 
-            results = functions.groupByNodes({}, copy.deepcopy(seriesList), "keepLastValue", *nodes)
+            results = functions.groupByNodes({}, copy.deepcopy(seriesList), func, *nodes)
 
             self.assertEqual(results, expectedResult)
 
@@ -2545,7 +2545,7 @@ class FunctionsTest(TestCase):
             TimeSeries('server1',0,1,1,[None]),
             TimeSeries('server2',0,1,1,[None]),
         ]
-        verify_groupByNodes(expectedResult, 1)
+        verify_groupByNodes(expectedResult, "keepLastValue", 1)
 
         expectedResult = [
             TimeSeries('server1.metric1',0,1,1,[None]),
@@ -2553,13 +2553,19 @@ class FunctionsTest(TestCase):
             TimeSeries('server2.metric1',0,1,1,[None]),
             TimeSeries('server2.metric2',0,1,1,[None]),
         ]
-        verify_groupByNodes(expectedResult, 1, 2)
+        verify_groupByNodes(expectedResult, "keepLastValue", 1, 2)
 
         expectedResult = [
             TimeSeries('server1.group',0,1,1,[None]),
             TimeSeries('server2.group',0,1,1,[None]),
         ]
-        verify_groupByNodes(expectedResult, 1, 0)
+        verify_groupByNodes(expectedResult, "keepLastValue", 1, 0)
+
+        expectedResult = [
+            TimeSeries('server1.group',0,1,1,[None]),
+            TimeSeries('server2.group',0,1,1,[None]),
+        ]
+        verify_groupByNodes(expectedResult, "range",  1, 0)
 
     def test_exclude(self):
         seriesList = self._gen_series_list_with_data(

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -203,8 +203,9 @@ class RenderTest(TestCase):
         targets = ['foo=1', 'bar=2']
         start_time = datetime.fromtimestamp(0)
         end_time = datetime.fromtimestamp(1000)
-        self.assertEqual(hashData(targets, start_time, end_time),
-                        hashData(reversed(targets), start_time, end_time))
+        xFilesFactor = 1
+        self.assertEqual(hashData(targets, start_time, end_time, xFilesFactor), '1b3f369c2473cd151fd450d953f41d2a')
+        self.assertEqual(hashData(reversed(targets), start_time, end_time, xFilesFactor), '1b3f369c2473cd151fd450d953f41d2a')
 
     def test_correct_timezone(self):
         url = reverse('render')


### PR DESCRIPTION
This PR adds support for setting the `xFilesFactor` value used when performing consolidations across series or across intervals.

Setting the `xFilesFactor` is accomplished using the new `xFilesFactor()` function which sets the `xFilesFactor` on the series it operates on as well as updating the new `xFilesFactor` setting in the request context (which is used by functions that have to process multiple series, so that they can just use the current setting rather than having to worry about resolving differences in xFilesFactor across the series passed to them).

As part of this update, the handling for all functions that aggregate across series (`sumSeries` & friends) is centralized into a new `aggregate` function which mirrors the previously-added `movingWindow` function used for aggregating across intervals.  This greatly cuts down the amount of duplicated code needed for all these functions.

In the same vein, a new `copy` method is added to `TimeSeries` which simplifies making new series that mirror an existing one, only needing to pass in new attributes and cutting down on repetition.  This is also the mechanism used to propagate the `xFilesFactor` setting through functions that create modified versions of series.

All existing tests pass, the only change being to add `valuesPerPoint`, `consolidationFunc` & `xFilesFactor` to the `TimeSeries.getInfo` test.  Additional tests have been added to cover all new code.
