### PR TITLE
Render view refactor & maxDataPoints=1

### DIFF
--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -404,7 +404,7 @@ class RenderTest(TestCase):
             (4, [ [30, 5], [55, 10], [80, 15], [39, 20] ]),
             (3, [ [63, 7], [112, 14], [20, 21] ]),
             (2, [ [135, 10], [39, 20] ]),
-            (1, [ [39, 20] ]),
+            (1, [ [210, 1] ]),
         ]
 
         self.verify_maxDataPoints(data, tests)
@@ -435,7 +435,7 @@ class RenderTest(TestCase):
             (4, [ [30, 5], [55, 10], [80, 15], [82, 20] ]),
             (3, [ [63, 7], [112, 14], [63, 21] ]),
             (2, [ [135, 10], [82, 20] ]),
-            (1, [ [82, 20] ]),
+            (1, [ [250, 3] ]),
         ]
 
         self.verify_maxDataPoints(data, tests)
@@ -466,7 +466,7 @@ class RenderTest(TestCase):
             (4, [ [55, 10], [80, 15], [105, 20], [24, 25] ]),
             (3, [ [63, 7], [112, 14], [110, 21] ]),
             (2, [ [135, 10], [129, 20] ]),
-            (1, [ [129, 20] ]),
+            (1, [ [290, 5] ]),
         ]
 
         self.verify_maxDataPoints(data, tests)
@@ -497,7 +497,7 @@ class RenderTest(TestCase):
             (4, [ [30, 5], [55, 10], [80, 15], [None, 20] ]),
             (3, [ [63, 7], [112, 14], [None, 21] ]),
             (2, [ [135, 10], [None, 20] ]),
-            (1, [ [None, 20] ]),
+            (1, [ [210, 1] ]),
         ]
 
         self.verify_maxDataPoints(data, tests)
@@ -528,7 +528,7 @@ class RenderTest(TestCase):
             (4, [ [30, 5], [55, 10], [80, 15], [None, 20] ]),
             (3, [ [63, 7], [112, 14], [None, 21] ]),
             (2, [ [135, 10], [None, 20] ]),
-            (1, [ [None, 20] ]),
+            (1, [ [250, 3] ]),
         ]
 
         self.verify_maxDataPoints(data, tests)
@@ -559,7 +559,7 @@ class RenderTest(TestCase):
             (4, [ [55, 10], [80, 15], [105, 20], [None, 25] ]),
             (3, [ [63, 7], [112, 14], [None, 21] ]),
             (2, [ [135, 10], [None, 20] ]),
-            (1, [ [None, 20] ]),
+            (1, [ [290, 5] ]),
         ]
 
         self.verify_maxDataPoints(data, tests)
@@ -590,7 +590,7 @@ class RenderTest(TestCase):
             (4, [ [80, 15], [105, 20], [130, 25], [None, 30] ]),
             (3, [ [112, 14], [161, 21], [None, 28] ]),
             (2, [ [235, 20], [None, 30] ]),
-            (1, [ [None, 20] ]),
+            (1, [ [410, 11] ]),
         ]
 
         self.verify_maxDataPoints(data, tests)

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import copy
 import json
 import os
 import time
@@ -6,8 +7,15 @@ import math
 import logging
 import shutil
 
+try:
+  import cPickle as pickle
+except ImportError:
+  import pickle
+
+from graphite.render.datalib import TimeSeries
 from graphite.render.hashing import ConsistentHashRing, hashRequest, hashData
 from graphite.render.utils import extractPathExpressions
+from graphite.render.views import renderViewJson
 import whisper
 
 from django.conf import settings
@@ -28,13 +36,15 @@ if hasattr(logging, "NullHandler"):
 
 class RenderTest(TestCase):
     db = os.path.join(settings.WHISPER_DIR, 'test.wsp')
+    db2 = os.path.join(settings.WHISPER_DIR, 'test2.wsp')
     hostcpu = os.path.join(settings.WHISPER_DIR, 'hosts/hostname/cpu.wsp')
 
     def wipe_whisper(self):
-        try:
-            os.remove(self.db)
-        except OSError:
-            pass
+        for path in [self.db, self.db2]:
+            try:
+                os.remove(path)
+            except OSError:
+                pass
 
     def create_whisper_hosts(self):
         worker1 = self.hostcpu.replace('hostname', 'worker1')
@@ -102,32 +112,212 @@ class RenderTest(TestCase):
         whisper.update(self.db, float('-inf'), ts - 1)
         whisper.update(self.db, float('nan'), ts)
 
-        response = self.client.get(url, {'target': 'test', 'format': 'raw'})
+        whisper.create(self.db2, [(1, 60)])
+
+        ts = int(time.time())
+        whisper.update(self.db2, 1, ts - 5)
+        whisper.update(self.db2, 2, ts - 4)
+        whisper.update(self.db2, 3, ts - 3)
+        whisper.update(self.db2, 4, ts - 2)
+        whisper.update(self.db2, 5, ts - 1)
+        whisper.update(self.db2, 6, ts)
+
+        response = self.client.get(url, {'target': 'test', 'format': 'csv'})
+        csv_response = ""
+        for i in range(ts-59, ts-5):
+            csv_response += "test," + datetime.fromtimestamp(i).strftime("%Y-%m-%d %H:%M:%S") + ",\r\n"
+        csv_response += (
+            "test," + datetime.fromtimestamp(ts-5).strftime("%Y-%m-%d %H:%M:%S") + ",0.12345678901234568\r\n"
+            "test," + datetime.fromtimestamp(ts-4).strftime("%Y-%m-%d %H:%M:%S") + ",0.4\r\n"
+            "test," + datetime.fromtimestamp(ts-3).strftime("%Y-%m-%d %H:%M:%S") + ",0.6\r\n"
+            "test," + datetime.fromtimestamp(ts-2).strftime("%Y-%m-%d %H:%M:%S") + ",inf\r\n"
+            "test," + datetime.fromtimestamp(ts-1).strftime("%Y-%m-%d %H:%M:%S") + ",-inf\r\n"
+            "test," + datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S") + ",nan\r\n"
+        )
+        self.assertEqual(response['content-type'], 'text/csv')
+        self.assertEqual(sorted(response['cache-control'].split(', ')), ['max-age=60'])
+        self.assertEqual(response.content, csv_response)
+
+        # test noCache flag
+        response = self.client.get(url, {'target': 'test', 'format': 'csv', 'noCache': 1})
+        self.assertEqual(response['content-type'], 'text/csv')
+        self.assertEqual(sorted(response['cache-control'].split(', ')), ['max-age=0', 'must-revalidate', 'no-cache', 'no-store'])
+        self.assertEqual(response.content, csv_response)
+
+        # test cacheTimeout=0 flag
+        response = self.client.get(url, {'target': 'test', 'format': 'csv', 'cacheTimeout': 0})
+        self.assertEqual(response['content-type'], 'text/csv')
+        self.assertEqual(sorted(response['cache-control'].split(', ')), ['max-age=0', 'must-revalidate', 'no-cache', 'no-store'])
+        self.assertEqual(response.content, csv_response)
+
+        # test alternative target syntax
+        response = self.client.get(url, {'target[]': 'test', 'format': 'csv'})
+        self.assertEqual(response['content-type'], 'text/csv')
+        self.assertEqual(sorted(response['cache-control'].split(', ')), ['max-age=60'])
+        self.assertEqual(response.content, csv_response)
+
+        # test multiple targets & empty targets
+        csv_response = ""
+        for i in range(ts-49, ts-5):
+            csv_response += "test," + datetime.fromtimestamp(i).strftime("%Y-%m-%d %H:%M:%S") + ",\r\n"
+        csv_response += (
+            "test," + datetime.fromtimestamp(ts-5).strftime("%Y-%m-%d %H:%M:%S") + ",0.12345678901234568\r\n"
+            "test," + datetime.fromtimestamp(ts-4).strftime("%Y-%m-%d %H:%M:%S") + ",0.4\r\n"
+            "test," + datetime.fromtimestamp(ts-3).strftime("%Y-%m-%d %H:%M:%S") + ",0.6\r\n"
+            "test," + datetime.fromtimestamp(ts-2).strftime("%Y-%m-%d %H:%M:%S") + ",inf\r\n"
+            "test," + datetime.fromtimestamp(ts-1).strftime("%Y-%m-%d %H:%M:%S") + ",-inf\r\n"
+            "test," + datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S") + ",nan\r\n"
+        )
+        for i in range(ts-49, ts-5):
+            csv_response += "test2," + datetime.fromtimestamp(i).strftime("%Y-%m-%d %H:%M:%S") + ",\r\n"
+        csv_response += (
+            "test2," + datetime.fromtimestamp(ts-5).strftime("%Y-%m-%d %H:%M:%S") + ",1.0\r\n"
+            "test2," + datetime.fromtimestamp(ts-4).strftime("%Y-%m-%d %H:%M:%S") + ",2.0\r\n"
+            "test2," + datetime.fromtimestamp(ts-3).strftime("%Y-%m-%d %H:%M:%S") + ",3.0\r\n"
+            "test2," + datetime.fromtimestamp(ts-2).strftime("%Y-%m-%d %H:%M:%S") + ",4.0\r\n"
+            "test2," + datetime.fromtimestamp(ts-1).strftime("%Y-%m-%d %H:%M:%S") + ",5.0\r\n"
+            "test2," + datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S") + ",6.0\r\n"
+        )
+
+        response = self.client.get(url + '?target=test&target=%20test2&target=%20&format=csv&from=' + str(ts - 50) + '&now=' + str(ts))
+        self.assertEqual(response['content-type'], 'text/csv')
+        self.assertEqual(sorted(response['cache-control'].split(', ')), ['max-age=60'])
+        self.assertEqual(response.content.split("\r\n"), csv_response.split("\r\n"))
+        self.assertEqual(response.content, csv_response)
+
+        response = self.client.get(url + '?target[]=test&target[]=%20test2&target[]=%20&format=csv&from=' + str(ts - 50) + '&now=' + str(ts))
+        self.assertEqual(response['content-type'], 'text/csv')
+        self.assertEqual(sorted(response['cache-control'].split(', ')), ['max-age=60'])
+        self.assertEqual(response.content.split("\r\n"), csv_response.split("\r\n"))
+        self.assertEqual(response.content, csv_response)
+
+        # test no targets
+        response = self.client.get(url + '?format=csv')
+        self.assertEqual(response['content-type'], 'text/csv')
+        self.assertEqual(sorted(response['cache-control'].split(', ')), ['max-age=60'])
+        self.assertEqual(response.content, '')
+
+        # test raw format
         raw_data = ("None,None,None,None,None,None,None,None,None,None,None,"
                     "None,None,None,None,None,None,None,None,None,None,None,"
                     "None,None,None,None,None,None,None,None,None,None,None,"
                     "None,None,None,None,None,None,None,None,None,None,None,"
-                    "None,None,None,None,None,None,None,None,None,None,"
                     "0.12345678901234568,0.4,0.6,inf,-inf,nan")
-        raw_response = "test,%d,%d,1|%s\n" % (ts-59, ts+1, raw_data)
+        raw_response = "test,%d,%d,1|%s\n" % (ts-49, ts+1, raw_data)
+        response = self.client.get(url, {'target': 'test', 'format': 'raw', 'from': ts-50})
         self.assertEqual(response.content, raw_response)
 
-        response = self.client.get(url, {'target': 'test', 'format': 'json'})
+        response = self.client.get(url, {'target': 'test', 'format': 'raw', 'from': ts-50, 'until': ts})
+        self.assertEqual(response.content, raw_response)
+
+        response = self.client.get(url, {'target': 'test', 'rawData': 1, 'from': ts-50})
+        self.assertEqual(response.content, raw_response)
+
+        # test pickle format
+        expected = [
+            {
+                'name': u'test',
+                'pathExpression': u'test',
+                'start': ts - 49,
+                'end': ts + 1,
+                'step': 1,
+                'valuesPerPoint': 1,
+                'consolidationFunc': 'average',
+                'xFilesFactor': 0.0,
+                'values': [None] * 44 + [0.12345678901234568, 0.4, 0.6, float('inf'), float('-inf'), 'NaN'],
+            }
+        ]
+        self.maxDiff = None
+
+        response = self.client.get(url, {'target': 'test', 'format': 'pickle', 'from': ts-50, 'now': ts})
+        self.assertEqual(response['content-type'], 'application/pickle')
+        unpickled = pickle.loads(response.content)
+        # special handling for NaN value, otherwise assertEqual fails
+        self.assertTrue(math.isnan(unpickled[0]['values'][-1]))
+        unpickled[0]['values'][-1] = 'NaN'
+        self.assertEqual(unpickled, expected)
+
+        response = self.client.get(url, {'target': 'test', 'pickle': 1, 'from': ts-50, 'now': ts})
+        self.assertEqual(response['content-type'], 'application/pickle')
+        unpickled = pickle.loads(response.content)
+        # special handling for NaN value, otherwise assertEqual fails
+        self.assertTrue(math.isnan(unpickled[0]['values'][-1]))
+        unpickled[0]['values'][-1] = 'NaN'
+        self.assertEqual(unpickled, expected)
+
+        # test json format
+        response = self.client.get(url, {'target': 'test', 'format': 'json', 'from': ts-50, 'now': ts})
+        self.assertEqual(response['content-type'], 'application/json')
         self.assertIn('[1e9999, ' + str(ts - 2) + ']', response.content)
         self.assertIn('[-1e9999, ' + str(ts - 1) + ']', response.content)
         self.assertIn('[null, ' + str(ts) + ']', response.content)
         data = json.loads(response.content)
-        end = data[0]['datapoints'][-7:]
-        self.assertEqual(
-            end, [[None, ts - 6],
-                  [0.12345678901234568, ts - 5],
-                  [0.4, ts - 4],
-                  [0.6, ts - 3],
-                  [float('inf'), ts - 2],
-                  [float('-inf'), ts - 1],
-                  [None, ts]])
+        expected = [
+            {
+                'datapoints': [
+                    [None, i] for i in range(ts-49, ts-6)
+                ] + [
+                    [None, ts - 6],
+                    [0.12345678901234568, ts - 5],
+                    [0.4, ts - 4],
+                    [0.6, ts - 3],
+                    [float('inf'), ts - 2],
+                    [float('-inf'), ts - 1],
+                    [None, ts]
+                ],
+                'target': 'test',
+                'tags': {
+                    'name': 'test',
+                },
+            }
+        ]
+        self.assertEqual(data, expected)
 
-        response = self.client.get(url, {'target': 'test', 'format': 'dygraph'})
+        # test jsonp
+        responsejsonp = self.client.get(url, {'target': 'test', 'format': 'json', 'jsonp': 'test', 'from': ts-50, 'now': ts})
+        self.assertEqual(responsejsonp['content-type'], 'text/javascript')
+        self.assertEqual(responsejsonp.content, 'test(' + response.content + ')')
+
+        # test noNullPoints
+        response = self.client.get(url, {'target': 'test', 'format': 'json', 'noNullPoints': 1, 'now': ts})
+        self.assertEqual(response['content-type'], 'application/json')
+        self.assertIn('[1e9999, ' + str(ts - 2) + ']', response.content)
+        self.assertIn('[-1e9999, ' + str(ts - 1) + ']', response.content)
+        self.assertNotIn('[null, ' + str(ts) + ']', response.content)
+        data = json.loads(response.content)
+        expected = [
+            {
+                'datapoints': [
+                    [0.12345678901234568, ts - 5],
+                    [0.4, ts - 4],
+                    [0.6, ts - 3],
+                    [float('inf'), ts - 2],
+                    [float('-inf'), ts - 1],
+                ],
+                'target': 'test',
+                'tags': {
+                    'name': 'test',
+                },
+            }
+        ]
+        self.assertEqual(data, expected)
+
+        # test noNullPoints excludes series with only None values altogether
+        response = self.client.get(url, {'target': 'test', 'format': 'json', 'noNullPoints': 1, 'until': ts-10})
+        self.assertEqual(response['content-type'], 'application/json')
+        data = json.loads(response.content)
+        expected = []
+        self.assertEqual(data, expected)
+
+        # test maxDataPoints is respected, testing the returned values is done in test_maxDataPoints
+        response = self.client.get(url, {'target': 'test', 'format': 'json', 'maxDataPoints': 10, 'until': ts-10})
+        self.assertEqual(response['content-type'], 'application/json')
+        data = json.loads(response.content)
+        self.assertEqual(len(data[0]['datapoints']), 10)
+
+        # test dygraph
+        response = self.client.get(url, {'target': 'test', 'format': 'dygraph', 'now': ts})
+        self.assertEqual(response['content-type'], 'application/json')
         self.assertIn('[' + str((ts - 2) * 1000) + ', Infinity]', response.content)
         self.assertIn('[' + str((ts - 1) * 1000) + ', -Infinity]', response.content)
         data = json.loads(response.content)
@@ -141,7 +331,13 @@ class RenderTest(TestCase):
             [(ts - 1) * 1000, float('-inf')],
             [ts * 1000, None]])
 
-        response = self.client.get(url, {'target': 'test', 'format': 'rickshaw'})
+        responsejsonp = self.client.get(url, {'target': 'test', 'format': 'dygraph', 'jsonp': 'test', 'now': ts})
+        self.assertEqual(responsejsonp['content-type'], 'text/javascript')
+        self.assertEqual(responsejsonp.content, 'test(' + response.content + ')')
+
+        # test rickshaw
+        response = self.client.get(url, {'target': 'test', 'format': 'rickshaw', 'now': ts})
+        self.assertEqual(response['content-type'], 'application/json')
         data = json.loads(response.content)
         end = data[0]['datapoints'][-7:-1]
         self.assertEqual(end,
@@ -155,6 +351,249 @@ class RenderTest(TestCase):
         last = data[0]['datapoints'][-1]
         self.assertEqual(last['x'], ts)
         self.assertTrue(math.isnan(last['y']))
+
+        responsejsonp = self.client.get(url, {'target': 'test', 'format': 'rickshaw', 'jsonp': 'test', 'now': ts})
+        self.assertEqual(responsejsonp['content-type'], 'text/javascript')
+        self.assertEqual(responsejsonp.content, 'test(' + response.content + ')')
+
+
+    def verify_maxDataPoints(self, data, tests):
+        requestOptions = {}
+        for (maxDataPoints, expectedData) in tests:
+            requestOptions['maxDataPoints'] = maxDataPoints
+            expected = [
+                {
+                    'datapoints': expectedData,
+                    'target': 'test',
+                    'tags': {
+                        'name': 'test',
+                    },
+                }
+            ]
+            response = renderViewJson(requestOptions, copy.deepcopy(data))
+            self.assertEqual(response['content-type'], 'application/json')
+            result = json.loads(response.content)
+            self.assertEqual(result[0]['datapoints'], expected[0]['datapoints'])
+            self.assertEqual(result, expected)
+
+
+    def test_maxDataPoints(self):
+        # regular consolidate
+        data = [
+            TimeSeries('test', 1, 21, 1, [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20], consolidate='sum')
+        ]
+
+        tests = [
+            (21, [ [1,  1], [2,  2], [3,  3], [4,  4], [5,  5], [6,  6], [7,  7], [8,  8], [9,  9], [10, 10], [11, 11], [12, 12], [13, 13], [14, 14], [15, 15], [16, 16], [17, 17], [18, 18], [19, 19], [20, 20] ]),
+            (20, [ [1,  1], [2,  2], [3,  3], [4,  4], [5,  5], [6,  6], [7,  7], [8,  8], [9,  9], [10, 10], [11, 11], [12, 12], [13, 13], [14, 14], [15, 15], [16, 16], [17, 17], [18, 18], [19, 19], [20, 20] ]),
+            (19, [ [3, 2], [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20] ]),
+            (18, [ [3, 2], [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20] ]),
+            (17, [ [3, 2], [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20] ]),
+            (16, [ [3, 2], [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20] ]),
+            (15, [ [3, 2], [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20] ]),
+            (14, [ [3, 2], [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20] ]),
+            (13, [ [3, 2], [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20] ]),
+            (12, [ [3, 2], [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20] ]),
+            (11, [ [3, 2], [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20] ]),
+            (10, [ [3, 2], [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20] ]),
+            (9, [ [9, 3], [18, 6], [27, 9], [36, 12], [45, 15], [54, 18], [20, 21] ]),
+            (8, [ [9, 3], [18, 6], [27, 9], [36, 12], [45, 15], [54, 18], [20, 21] ]),
+            (7, [ [9, 3], [18, 6], [27, 9], [36, 12], [45, 15], [54, 18], [20, 21] ]),
+            (6, [ [18, 4], [34, 8], [50, 12], [66, 16], [39, 20] ]),
+            (5, [ [18, 4], [34, 8], [50, 12], [66, 16], [39, 20] ]),
+            (4, [ [30, 5], [55, 10], [80, 15], [39, 20] ]),
+            (3, [ [63, 7], [112, 14], [20, 21] ]),
+            (2, [ [135, 10], [39, 20] ]),
+            (1, [ [39, 20] ]),
+        ]
+
+        self.verify_maxDataPoints(data, tests)
+
+        # advance time window 2 seconds
+        data = [
+            TimeSeries('test', 3, 23, 1, [3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22], consolidate='sum')
+        ]
+
+        tests = [
+            (21, [ [3,  3], [4,  4], [5,  5], [6,  6], [7,  7], [8,  8], [9,  9], [10, 10], [11, 11], [12, 12], [13, 13], [14, 14], [15, 15], [16, 16], [17, 17], [18, 18], [19, 19], [20, 20], [21,  21], [22,  22] ]),
+            (20, [ [3,  3], [4,  4], [5,  5], [6,  6], [7,  7], [8,  8], [9,  9], [10, 10], [11, 11], [12, 12], [13, 13], [14, 14], [15, 15], [16, 16], [17, 17], [18, 18], [19, 19], [20, 20], [21,  21], [22,  22] ]),
+            (19, [ [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22] ]),
+            (18, [ [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22] ]),
+            (17, [ [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22] ]),
+            (16, [ [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22] ]),
+            (15, [ [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22] ]),
+            (14, [ [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22] ]),
+            (13, [ [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22] ]),
+            (12, [ [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22] ]),
+            (11, [ [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22] ]),
+            (10, [ [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22] ]),
+            (9, [ [18, 6], [27, 9], [36, 12], [45, 15], [54, 18], [63, 21] ]),
+            (8, [ [18, 6], [27, 9], [36, 12], [45, 15], [54, 18], [63, 21] ]),
+            (7, [ [18, 6], [27, 9], [36, 12], [45, 15], [54, 18], [63, 21] ]),
+            (6, [ [18, 4], [34, 8], [50, 12], [66, 16], [82, 20] ]),
+            (5, [ [18, 4], [34, 8], [50, 12], [66, 16], [82, 20] ]),
+            (4, [ [30, 5], [55, 10], [80, 15], [82, 20] ]),
+            (3, [ [63, 7], [112, 14], [63, 21] ]),
+            (2, [ [135, 10], [82, 20] ]),
+            (1, [ [82, 20] ]),
+        ]
+
+        self.verify_maxDataPoints(data, tests)
+
+        # advance time window 4 seconds
+        data = [
+            TimeSeries('test', 5, 25, 1, [5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24], consolidate='sum')
+        ]
+
+        tests = [
+            (21, [ [5,  5], [6,  6], [7,  7], [8,  8], [9,  9], [10, 10], [11, 11], [12, 12], [13, 13], [14, 14], [15, 15], [16, 16], [17, 17], [18, 18], [19, 19], [20, 20], [21,  21], [22,  22], [23,  23], [24,  24] ]),
+            (20, [ [5,  5], [6,  6], [7,  7], [8,  8], [9,  9], [10, 10], [11, 11], [12, 12], [13, 13], [14, 14], [15, 15], [16, 16], [17, 17], [18, 18], [19, 19], [20, 20], [21,  21], [22,  22], [23,  23], [24,  24] ]),
+            (19, [ [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24] ]),
+            (18, [ [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24] ]),
+            (17, [ [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24] ]),
+            (16, [ [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24] ]),
+            (15, [ [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24] ]),
+            (14, [ [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24] ]),
+            (13, [ [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24] ]),
+            (12, [ [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24] ]),
+            (11, [ [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24] ]),
+            (10, [ [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24] ]),
+            (9, [ [18, 6], [27, 9], [36, 12], [45, 15], [54, 18], [63, 21], [47, 24] ]),
+            (8, [ [18, 6], [27, 9], [36, 12], [45, 15], [54, 18], [63, 21], [47, 24] ]),
+            (7, [ [18, 6], [27, 9], [36, 12], [45, 15], [54, 18], [63, 21], [47, 24] ]),
+            (6, [ [34, 8], [50, 12], [66, 16], [82, 20], [47, 24] ]),
+            (5, [ [34, 8], [50, 12], [66, 16], [82, 20], [47, 24] ]),
+            (4, [ [55, 10], [80, 15], [105, 20], [24, 25] ]),
+            (3, [ [63, 7], [112, 14], [110, 21] ]),
+            (2, [ [135, 10], [129, 20] ]),
+            (1, [ [129, 20] ]),
+        ]
+
+        self.verify_maxDataPoints(data, tests)
+
+        # xFilesFactor = 1
+        data = [
+            TimeSeries('test', 1, 21, 1, [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20], consolidate='sum', xFilesFactor=1)
+        ]
+
+        tests = [
+            (21, [ [1,  1], [2,  2], [3,  3], [4,  4], [5,  5], [6,  6], [7,  7], [8,  8], [9,  9], [10, 10], [11, 11], [12, 12], [13, 13], [14, 14], [15, 15], [16, 16], [17, 17], [18, 18], [19, 19], [20, 20] ]),
+            (20, [ [1,  1], [2,  2], [3,  3], [4,  4], [5,  5], [6,  6], [7,  7], [8,  8], [9,  9], [10, 10], [11, 11], [12, 12], [13, 13], [14, 14], [15, 15], [16, 16], [17, 17], [18, 18], [19, 19], [20, 20] ]),
+            (19, [ [3, 2], [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20] ]),
+            (18, [ [3, 2], [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20] ]),
+            (17, [ [3, 2], [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20] ]),
+            (16, [ [3, 2], [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20] ]),
+            (15, [ [3, 2], [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20] ]),
+            (14, [ [3, 2], [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20] ]),
+            (13, [ [3, 2], [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20] ]),
+            (12, [ [3, 2], [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20] ]),
+            (11, [ [3, 2], [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20] ]),
+            (10, [ [3, 2], [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20] ]),
+            (9, [ [9, 3], [18, 6], [27, 9], [36, 12], [45, 15], [54, 18], [None, 21] ]),
+            (8, [ [9, 3], [18, 6], [27, 9], [36, 12], [45, 15], [54, 18], [None, 21] ]),
+            (7, [ [9, 3], [18, 6], [27, 9], [36, 12], [45, 15], [54, 18], [None, 21] ]),
+            (6, [ [18, 4], [34, 8], [50, 12], [66, 16], [None, 20] ]),
+            (5, [ [18, 4], [34, 8], [50, 12], [66, 16], [None, 20] ]),
+            (4, [ [30, 5], [55, 10], [80, 15], [None, 20] ]),
+            (3, [ [63, 7], [112, 14], [None, 21] ]),
+            (2, [ [135, 10], [None, 20] ]),
+            (1, [ [None, 20] ]),
+        ]
+
+        self.verify_maxDataPoints(data, tests)
+
+        # advance time window 2 seconds
+        data = [
+            TimeSeries('test', 3, 23, 1, [3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22], consolidate='sum', xFilesFactor=1)
+        ]
+
+        tests = [
+            (21, [ [3,  3], [4,  4], [5,  5], [6,  6], [7,  7], [8,  8], [9,  9], [10, 10], [11, 11], [12, 12], [13, 13], [14, 14], [15, 15], [16, 16], [17, 17], [18, 18], [19, 19], [20, 20], [21,  21], [22,  22] ]),
+            (20, [ [3,  3], [4,  4], [5,  5], [6,  6], [7,  7], [8,  8], [9,  9], [10, 10], [11, 11], [12, 12], [13, 13], [14, 14], [15, 15], [16, 16], [17, 17], [18, 18], [19, 19], [20, 20], [21,  21], [22,  22] ]),
+            (19, [ [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22] ]),
+            (18, [ [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22] ]),
+            (17, [ [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22] ]),
+            (16, [ [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22] ]),
+            (15, [ [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22] ]),
+            (14, [ [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22] ]),
+            (13, [ [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22] ]),
+            (12, [ [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22] ]),
+            (11, [ [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22] ]),
+            (10, [ [7, 4], [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22] ]),
+            (9, [ [18, 6], [27, 9], [36, 12], [45, 15], [54, 18], [63, 21] ]),
+            (8, [ [18, 6], [27, 9], [36, 12], [45, 15], [54, 18], [63, 21] ]),
+            (7, [ [18, 6], [27, 9], [36, 12], [45, 15], [54, 18], [63, 21] ]),
+            (6, [ [18, 4], [34, 8], [50, 12], [66, 16], [82, 20] ]),
+            (5, [ [18, 4], [34, 8], [50, 12], [66, 16], [82, 20] ]),
+            (4, [ [30, 5], [55, 10], [80, 15], [None, 20] ]),
+            (3, [ [63, 7], [112, 14], [None, 21] ]),
+            (2, [ [135, 10], [None, 20] ]),
+            (1, [ [None, 20] ]),
+        ]
+
+        self.verify_maxDataPoints(data, tests)
+
+        # advance time window 4 seconds
+        data = [
+            TimeSeries('test', 5, 25, 1, [5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24], consolidate='sum', xFilesFactor=1)
+        ]
+
+        tests = [
+            (21, [ [5,  5], [6,  6], [7,  7], [8,  8], [9,  9], [10, 10], [11, 11], [12, 12], [13, 13], [14, 14], [15, 15], [16, 16], [17, 17], [18, 18], [19, 19], [20, 20], [21,  21], [22,  22], [23,  23], [24,  24] ]),
+            (20, [ [5,  5], [6,  6], [7,  7], [8,  8], [9,  9], [10, 10], [11, 11], [12, 12], [13, 13], [14, 14], [15, 15], [16, 16], [17, 17], [18, 18], [19, 19], [20, 20], [21,  21], [22,  22], [23,  23], [24,  24] ]),
+            (19, [ [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24] ]),
+            (18, [ [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24] ]),
+            (17, [ [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24] ]),
+            (16, [ [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24] ]),
+            (15, [ [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24] ]),
+            (14, [ [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24] ]),
+            (13, [ [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24] ]),
+            (12, [ [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24] ]),
+            (11, [ [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24] ]),
+            (10, [ [11, 6], [15, 8], [19, 10], [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24] ]),
+            (9, [ [18, 6], [27, 9], [36, 12], [45, 15], [54, 18], [63, 21], [None, 24] ]),
+            (8, [ [18, 6], [27, 9], [36, 12], [45, 15], [54, 18], [63, 21], [None, 24] ]),
+            (7, [ [18, 6], [27, 9], [36, 12], [45, 15], [54, 18], [63, 21], [None, 24] ]),
+            (6, [ [34, 8], [50, 12], [66, 16], [82, 20], [None, 24] ]),
+            (5, [ [34, 8], [50, 12], [66, 16], [82, 20], [None, 24] ]),
+            (4, [ [55, 10], [80, 15], [105, 20], [None, 25] ]),
+            (3, [ [63, 7], [112, 14], [None, 21] ]),
+            (2, [ [135, 10], [None, 20] ]),
+            (1, [ [None, 20] ]),
+        ]
+
+        self.verify_maxDataPoints(data, tests)
+
+        # advance time window 10 seconds
+        data = [
+            TimeSeries('test', 11, 31, 1, [11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30], consolidate='sum', xFilesFactor=1)
+        ]
+
+        tests = [
+            (21, [ [11, 11], [12, 12], [13, 13], [14, 14], [15, 15], [16, 16], [17, 17], [18, 18], [19, 19], [20, 20], [21,  21], [22,  22], [23,  23], [24,  24], [25, 25], [26, 26], [27, 27], [28, 28], [29, 29], [30, 30] ]),
+            (20, [ [11, 11], [12, 12], [13, 13], [14, 14], [15, 15], [16, 16], [17, 17], [18, 18], [19, 19], [20, 20], [21,  21], [22,  22], [23,  23], [24,  24], [25, 25], [26, 26], [27, 27], [28, 28], [29, 29], [30, 30] ]),
+            (19, [ [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24], [51, 26], [55, 28], [59, 30] ]),
+            (18, [ [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24], [51, 26], [55, 28], [59, 30] ]),
+            (17, [ [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24], [51, 26], [55, 28], [59, 30] ]),
+            (16, [ [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24], [51, 26], [55, 28], [59, 30] ]),
+            (15, [ [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24], [51, 26], [55, 28], [59, 30] ]),
+            (14, [ [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24], [51, 26], [55, 28], [59, 30] ]),
+            (13, [ [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24], [51, 26], [55, 28], [59, 30] ]),
+            (12, [ [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24], [51, 26], [55, 28], [59, 30] ]),
+            (11, [ [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24], [51, 26], [55, 28], [59, 30] ]),
+            (10, [ [23, 12], [27, 14], [31, 16], [35, 18], [39, 20], [43, 22], [47, 24], [51, 26], [55, 28], [59, 30] ]),
+            (9, [ [36, 12], [45, 15], [54, 18], [63, 21], [72, 24], [81, 27], [None, 30] ]),
+            (8, [ [36, 12], [45, 15], [54, 18], [63, 21], [72, 24], [81, 27], [None, 30] ]),
+            (7, [ [36, 12], [45, 15], [54, 18], [63, 21], [72, 24], [81, 27], [None, 30] ]),
+            (6, [ [50, 12], [66, 16], [82, 20], [98, 24], [114, 28] ]),
+            (5, [ [50, 12], [66, 16], [82, 20], [98, 24], [114, 28] ]),
+            (4, [ [80, 15], [105, 20], [130, 25], [None, 30] ]),
+            (3, [ [112, 14], [161, 21], [None, 28] ]),
+            (2, [ [235, 20], [None, 30] ]),
+            (1, [ [None, 20] ]),
+        ]
+
+        self.verify_maxDataPoints(data, tests)
 
 
     def test_hash_request(self):


### PR DESCRIPTION
This PR refactors `render/views.py` to break up the monolithic `renderView()` function into a set of helpers for each output format, and to unify handling of response caching and render logging.

It also expands the render test suite to increase coverage for the new helper functions to 100% and cover more of the available query parameters.

Finally, the second commit introduces a change to the consolidation behavior when `maxDataPoints=1` is specified.  Previously this path used the same "nudging" logic as other `maxDataPoints` values, but that would often produce nonsensical results because it would "nudge" out a large number of data points.  With this change there is no longer any "nudging" with `maxDataPoints=1` and all available points are simply consolidated.