### PR TITLE
Support using tags in functions that accept nodes

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -914,16 +914,15 @@ def weightedAverage(requestContext, seriesListAvg, seriesListWeight, *nodes):
   """
   Takes a series of average values and a series of weights and
   produces a weighted average for all values.
-  The corresponding values should share one or more zero-indexed nodes.
+  The corresponding values should share one or more zero-indexed nodes and/or tags.
 
   Example:
 
   .. code-block:: none
 
     &target=weightedAverage(*.transactions.mean,*.transactions.count,0)
-    &target=weightedAverage(*.transactions.mean,*.transactions.count,1,3,4)
 
-
+  Each node may be an integer referencing a node in the series name or a string identifying a tag.
   """
   sortedSeries={}
 

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -267,6 +267,9 @@ def aggregate(requestContext, seriesList, func, xFilesFactor=None):
   tags = seriesList[0].tags
   for series in seriesList:
     tags = {tag: tags[tag] for tag in tags if tag in series.tags and tags[tag] == series.tags[tag]}
+  if 'name' not in tags:
+    tags['name'] = name
+  tags['aggregatedBy'] = func
   series = TimeSeries(name, start, end, step, values, xFilesFactor=xFilesFactor, tags=tags)
 
   return [series]
@@ -4277,9 +4280,6 @@ def groupByTags(requestContext, seriesList, callback, *tags):
   This function can be used with all aggregation functions supported by
   :py:func:`aggregate <aggregate>`: ``average``, ``median``, ``sum``, ``min``, ``max``, ``diff``,
   ``stddev``, ``range`` & ``multiply``.
-
-  This is very similar to :py:func:`groupByNodes <groupByNodes>`, except that the generated series
-  names are formatted with tags.
   """
   if STORE.tagdb is None:
     log.info('groupByTags called but no TagDB configured')

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -1408,6 +1408,32 @@ class FunctionsTest(TestCase):
         result = functions.weightedAverage({}, seriesList, seriesList2, 1)
         self.assertEqual(result, expectedResult)
 
+    def test_weightedAverage_empty_productlist(self):
+        seriesList = self._gen_series_list_with_data(
+            key=[
+                'collectd.test-db1.load.value',
+            ],
+            end=1,
+            data=[
+                [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20],
+            ]
+        )
+
+        seriesList2 = self._gen_series_list_with_data(
+            key=[
+                'collectd.test-db2.load.value',
+            ],
+            end=1,
+            data=[
+                [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20],
+            ]
+        )
+
+        expectedResult = []
+
+        result = functions.weightedAverage({}, seriesList, seriesList2, 1)
+        self.assertEqual(result, expectedResult)
+
     def test_scaleToSeconds(self):
         seriesList = self._gen_series_list_with_data(
             key=[


### PR DESCRIPTION
This PR defines a new standardized function `aggKey()` for taking a list of nodes and/or tags and producing an identifier for a given series.

This function is used by `aggregate()`, `asPercent()`, `weightedAverage()`, `aliasByNode()`, `mapSeries()`, `groupByNode()`, `groupByNodes()` & `aliasByTags()`, all of which now support specifying nodes and/or tags interchangeably.

After this change, `aliasByTags()` and `aliasByNode()` are identical, though `groupByTags()` still differs from `groupByNodes()` because it return series using "tagged" names rather than flattening them into dot-delimited names.  For that reason it also does not support integer node ids.

There are a few functions that have not been updated because they use node numbers in different ways;  the `*WithWildcards()` functions, `applyByNode()` & `reduceSeries()`.