### PR TITLE
HTTP(S) TagDB

### DIFF
--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -94,6 +94,33 @@ As Whisper and other storage backends are designed to hold simple time-series da
 
   Tag support requires Graphite webapp & carbon version 1.1.0 or newer.
 
+Local Database TagDB
+^^^^^^^^^^^^^^^^^^^^
+
+The Local TagDB stores tag information in tables inside the graphite-web database.  It supports SQLite, MySQL and Postgres, and is enabled by default.
+
+Redis TagDB
+^^^^^^^^^^^
+
+The Redis TagDB will store the tag information on a Redis server, and is selected by setting ``TAGDB='graphite.tags.redis.RedisTagDB'`` in `local_settings.py`.  There are 3 additional config settings for the Redis TagDB::
+
+    TAGDB_REDIS_HOST = 'localhost'
+    TAGDB_REDIS_PORT = 6379
+    TAGDB_REDIS_DB = 0
+
+The default settings (above) will connect to a local Redis server on the default port, and use the default database.
+
+HTTP(S) TagDB
+^^^^^^^^^^^^^
+
+The HTTP(S) TagDB is used to delegate all tag operations to an external server that implements the Graphite tagging HTTP API.  It can be used in clustered graphite scenarios, or with custom data stores.  It is selected by setting ``TAGDB='graphite.tags.http.HttpTagDB'`` in `local_settings.py`.  There are 3 additional config settings for the HTTP(S) TagDB::
+
+    TAGDB_HTTP_URL = 'https://another.server'
+    TAGDB_HTTP_USER = ''
+    TAGDB_HTTP_PASSWORD = ''
+
+The ``TAGDB_HTTP_URL`` is required. ``TAGDB_HTTP_USER`` and ``TAGDB_HTTP_PASSWORD`` are optional and if specified will be used to send a Basic Authorization header in all requests.
+
 Adding Series to the TagDB
 --------------------------
 Normally `carbon` will take care of this, it submits all new series to the TagDB, and periodically re-submits all series to ensure that the TagDB is kept up to date.  There are 2 `carbon` configuration settings related to tagging; the `GRAPHITE_URL` setting specifies the url of your graphite-web installation (default `http://127.0.0.1:8000`), and the `TAG_UPDATE_INTERVAL` setting specifies how often each series should be re-submitted to the TagDB (default is every 100th update).

--- a/webapp/graphite/readers/remote.py
+++ b/webapp/graphite/readers/remote.py
@@ -172,7 +172,7 @@ class RemoteReader(BaseReader):
 
             if result.status != 200:
                 self.store.fail()
-                self.log_error("ReadResult:: Error response %d from %s" % url_full)
+                self.log_error("ReadResult:: Error response %d from %s" % (result.status, url_full))
                 data = []
             else:
                 data = unpickle.loads(result.data)

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -117,9 +117,15 @@ STORAGE_FINDERS = (
     'graphite.finders.standard.StandardFinder',
 )
 TAGDB = 'graphite.tags.localdatabase.LocalDatabaseTagDB'
-TAGDB_REDIS_HOST='localhost'
-TAGDB_REDIS_PORT=6379
-TAGDB_REDIS_DB=0
+
+TAGDB_REDIS_HOST = 'localhost'
+TAGDB_REDIS_PORT = 6379
+TAGDB_REDIS_DB = 0
+
+TAGDB_HTTP_URL = ''
+TAGDB_HTTP_USER = ''
+TAGDB_HTTP_PASSWORD = ''
+
 MIDDLEWARE = ()
 if DJANGO_VERSION < (1, 10):
     MIDDLEWARE_CLASSES = MIDDLEWARE

--- a/webapp/graphite/tags/http.py
+++ b/webapp/graphite/tags/http.py
@@ -13,7 +13,13 @@ class HttpTagDB(BaseTagDB):
   """
   Stores tag information using an external http service that implements the graphite tags API.
   """
-  def request(self, method, url, fields={}, headers={}):
+  @staticmethod
+  def request(method, url, fields=None, headers=None):
+    if not fields:
+      fields = {}
+    if not headers:
+      headers = {}
+
     if 'Authorization' not in headers and settings.TAGDB_HTTP_USER and settings.TAGDB_HTTP_PASSWORD:
       headers['Authorization'] = 'Basic ' + ('%s:%s' % (settings.TAGDB_HTTP_USER, settings.TAGDB_HTTP_PASSWORD)).encode('base64')
 

--- a/webapp/graphite/tags/http.py
+++ b/webapp/graphite/tags/http.py
@@ -39,7 +39,7 @@ class HttpTagDB(BaseTagDB):
 
     seriesList = self.find_series([('%s=%s' % (tag, parsed.tags[tag])) for tag in parsed.tags])
 
-    if path in seriesList:
+    if parsed.path in seriesList:
       return parsed
 
   def list_tags(self, tagFilter=None):

--- a/webapp/graphite/tags/http.py
+++ b/webapp/graphite/tags/http.py
@@ -13,19 +13,22 @@ class HttpTagDB(BaseTagDB):
   """
   Stores tag information using an external http service that implements the graphite tags API.
   """
-  @staticmethod
-  def request(method, url, fields=None, headers=None):
+  def __init__(self):
+    self.base_url = settings.TAGDB_HTTP_URL
+    self.username = settings.TAGDB_HTTP_USER
+    self.password = settings.TAGDB_HTTP_PASSWORD
+
+  def request(self, method, url, fields=None):
     if not fields:
       fields = {}
-    if not headers:
-      headers = {}
 
-    if 'Authorization' not in headers and settings.TAGDB_HTTP_USER and settings.TAGDB_HTTP_PASSWORD:
-      headers['Authorization'] = 'Basic ' + ('%s:%s' % (settings.TAGDB_HTTP_USER, settings.TAGDB_HTTP_PASSWORD)).encode('base64')
+    headers = {}
+    if 'Authorization' not in headers and self.username and self.password:
+      headers['Authorization'] = 'Basic ' + ('%s:%s' % (self.username, self.password)).encode('base64')
 
     result = http.request(
       method,
-      settings.TAGDB_HTTP_URL + url,
+      self.base_url + url,
       fields={field: value for (field, value) in fields.items() if value is not None},
       headers=headers,
       timeout=settings.REMOTE_FIND_TIMEOUT,

--- a/webapp/graphite/tags/http.py
+++ b/webapp/graphite/tags/http.py
@@ -1,0 +1,63 @@
+from __future__ import absolute_import
+
+from urllib import quote
+import json
+
+from django.conf import settings
+from graphite.util import logtime
+from graphite.http_pool import http
+
+from graphite.tags.utils import BaseTagDB
+
+class HttpTagDB(BaseTagDB):
+  """
+  Stores tag information using an external http service that implements the graphite tags API.
+  """
+  def request(self, method, url, fields=None, headers={}):
+    if 'Authorization' not in headers and settings.TAGDB_HTTP_USER and settings.TAGDB_HTTP_PASSWORD:
+      headers['Authorization'] = 'Basic ' + ('%s:%s' % (settings.TAGDB_HTTP_USER, settings.TAGDB_HTTP_PASSWORD)).encode('base64')
+
+    result = http.request(
+      method,
+      settings.TAGDB_HTTP_URL + url,
+      fields={field: value for (field, value) in fields.items() if value is not None},
+      headers=headers,
+      timeout=settings.REMOTE_FIND_TIMEOUT,
+    )
+
+    if result.status != 200:
+      raise Exception('HTTP Error from remote tagdb: %s' % result.status)
+
+    return json.loads(result.data.decode('utf-8'))
+
+  @logtime()
+  def find_series(self, tags):
+    print tags
+    return self.request('POST', '/tags/findSeries?' + '&'.join([('expr=%s' % quote(tag)) for tag in tags]))
+
+  def get_series(self, path):
+    parsed = self.parse(path)
+
+    seriesList = self.find_series([('%s=%s' % (tag, parsed.tags[tag])) for tag in parsed.tags])
+
+    if path in seriesList:
+      return parsed
+
+  def list_tags(self, tagFilter=None):
+    return self.request('GET', '/tags', {'filter': tagFilter})
+
+  def get_tag(self, tag, valueFilter=None):
+    return self.request('GET', '/tags/' + tag, {'filter': valueFilter})
+
+  def list_values(self, tag, valueFilter=None):
+    tagInfo = self.get_tag(tag, valueFilter)
+    if not tagInfo:
+      return []
+
+    return tagInfo['values']
+
+  def tag_series(self, series):
+    return self.request('POST', '/tags/tagSeries', {'path': series})
+
+  def del_series(self, series):
+    return self.request('POST', '/tags/delSeries', {'path': series})

--- a/webapp/graphite/tags/http.py
+++ b/webapp/graphite/tags/http.py
@@ -13,7 +13,7 @@ class HttpTagDB(BaseTagDB):
   """
   Stores tag information using an external http service that implements the graphite tags API.
   """
-  def request(self, method, url, fields=None, headers={}):
+  def request(self, method, url, fields={}, headers={}):
     if 'Authorization' not in headers and settings.TAGDB_HTTP_USER and settings.TAGDB_HTTP_PASSWORD:
       headers['Authorization'] = 'Basic ' + ('%s:%s' % (settings.TAGDB_HTTP_USER, settings.TAGDB_HTTP_PASSWORD)).encode('base64')
 
@@ -32,7 +32,6 @@ class HttpTagDB(BaseTagDB):
 
   @logtime()
   def find_series(self, tags):
-    print tags
     return self.request('POST', '/tags/findSeries?' + '&'.join([('expr=%s' % quote(tag)) for tag in tags]))
 
   def get_series(self, path):

--- a/webapp/tests/test_tags.py
+++ b/webapp/tests/test_tags.py
@@ -103,7 +103,7 @@ class TagsTest(TestCase):
     self.assertEquals(valueList[0]['value'], 'tiger')
 
     # get tag & filtered list of values (no match)
-    result = db.get_tag('hello', valueFilter='tigr')
+    result = db.get_tag('hello', valueFilter='^tigr')
     self.assertEquals(result['tag'], 'hello')
     valueList = [value for value in result['values'] if value['value'] in ['tiger', 'lion']]
     self.assertEquals(len(valueList), 0)
@@ -113,7 +113,7 @@ class TagsTest(TestCase):
     self.assertEqual(result, ['test.a;blah=blah;hello=tiger'])
 
     # find with regex
-    result = db.find_series(['blah=~b.*', 'hello=~tiger', 'test=~.*'])
+    result = db.find_series(['blah=~b.*', 'hello=~^tiger', 'test=~.*'])
     self.assertEqual(result, ['test.a;blah=blah;hello=tiger'])
 
     # find with not regex

--- a/webapp/tests/test_tags.py
+++ b/webapp/tests/test_tags.py
@@ -5,8 +5,11 @@ try:
 except ImportError:  # Django < 1.10
   from django.core.urlresolvers import reverse
 
+from mock import patch
+
 from graphite.tags.localdatabase import LocalDatabaseTagDB
 from graphite.tags.redis import RedisTagDB
+from graphite.tags.http import HttpTagDB
 from graphite.tags.utils import TaggedSeries
 from graphite.util import json
 
@@ -166,6 +169,58 @@ class TagsTest(TestCase):
 
   def test_redis_tagdb(self):
     return self._test_tagdb(RedisTagDB())
+
+  def test_http_tagdb(self):
+    # test http tagdb using django client
+    db = HttpTagDB()
+    db.base_url = reverse('tagList').replace('/tags', '')
+    db.username = ''
+    db.password = ''
+
+    # helper class to mock urllib3 response object
+    class mockResponse(object):
+      def __init__(self, status, data):
+        self.status = status
+        self.data = data
+
+    # mock http request that forwards requests using django client
+    def mockRequest(method, url, fields=None, headers=None, timeout=None):
+      if db.username and db.password:
+        self.assertEqual(headers, {'Authorization': 'Basic dGVzdDp0ZXN0\n'})
+      else:
+        self.assertEqual(headers, {})
+
+      if method == 'POST':
+        result = self.client.post(url, fields)
+      elif method == 'GET':
+        result = self.client.get(url, fields)
+      else:
+        raise Exception('Invalid HTTP method %s' % method)
+
+      return mockResponse(result.status_code, result.content)
+
+    # use mockRequest to send http requests to live django running configured tagdb
+    with patch('graphite.http_pool.http.request', mockRequest):
+      self._test_tagdb(db)
+
+      with self.assertRaisesRegexp(Exception, 'HTTP Error from remote tagdb: 405'):
+        db.get_tag('delSeries')
+
+      db.username = 'test'
+      db.password = 'test'
+
+      result = db.tag_series('test.a;hello=tiger;blah=blah')
+      self.assertEquals(result, 'test.a;blah=blah;hello=tiger')
+
+      result = db.list_values('hello')
+      valueList = [value for value in result if value['value'] in ['tiger', 'lion']]
+      self.assertEquals(len(valueList), 1)
+      self.assertEquals(valueList[0]['value'], 'tiger')
+
+      result = db.list_values('notarealtag')
+      self.assertEquals(result, [])
+
+      self.assertTrue(db.del_series('test.a;blah=blah;hello=tiger'))
 
   def test_tag_views(self):
     url = reverse('tagList')


### PR DESCRIPTION
This PR adds a TagDB that forwards all tag-related operations to an HTTP(S) server that implements the graphite-web tagging API.

It's designed to be used as a standard way to integrate with outboard tag databases, or with clustered graphite configurations.

I'm not sure what the best way is to go about writing tests for this, since you really need to have 2 graphite installations running for it to work.  Any suggestions appreciated!

I also fixed a minor bug in the remote reader, which wasn't properly formatting the error log entry if the remote returned a non-200 status code.