### PR TITLE
default value for getattr disabled

### DIFF
--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -339,7 +339,7 @@ def prefetchRemoteData(requestContext, targets):
   """
   # only prefetch if there is at least one active remote finder
   # this is to avoid the overhead of tagdb lookups in extractPathExpressions
-  if len([finder for finder in STORE.finders if not getattr(finder, 'local', True) and not getattr(finder, 'disabled')]) < 1:
+  if len([finder for finder in STORE.finders if not getattr(finder, 'local', True) and not getattr(finder, 'disabled', False)]) < 1:
     return
 
   pathExpressions = extractPathExpressions(targets)

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -56,7 +56,7 @@ class Store(object):
         results = []
         for finder in self.finders:
             is_local = getattr(finder, 'local', True)
-            if is_local or getattr(finder, 'disabled'):
+            if is_local or getattr(finder, 'disabled', False):
                 continue
 
             result = finder.fetch(
@@ -105,7 +105,7 @@ class Store(object):
             is_local = not hasattr(finder, 'local') or finder.local
             if query.local and not is_local:
                 continue
-            if getattr(finder, 'disabled'):
+            if getattr(finder, 'disabled', False):
                 continue
             jobs.append((finder.find_nodes, query))
 


### PR DESCRIPTION
The new `disabled` flag for finders won't be defined by custom finders that don't extend `BaseFinder`, so we need to provide a default value for `getattr` calls that reference it.