### PR TITLE
support sending logs to stderr

### DIFF
--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -37,6 +37,12 @@
 #LOG_RENDERING_PERFORMANCE = True
 #LOG_CACHE_PERFORMANCE = True
 
+# Filenames for log output, set to '-' to log to stderr
+#LOG_FILE_INFO = 'info.log'
+#LOG_FILE_EXCEPTION = 'exception.log'
+#LOG_FILE_CACHE = 'cache.log'
+#LOG_FILE_RENDERING = 'rendering.log'
+
 # Enable full debug page display on exceptions (Internal Server Error pages)
 #DEBUG = True
 

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -95,6 +95,11 @@ LOG_CACHE_PERFORMANCE = False
 LOG_ROTATION = True
 LOG_ROTATION_COUNT = 1
 
+LOG_FILE_INFO = 'info.log'
+LOG_FILE_EXCEPTION = 'exception.log'
+LOG_FILE_CACHE = 'cache.log'
+LOG_FILE_RENDERING = 'rendering.log'
+
 MAX_FETCH_RETRIES = 2
 
 # This settings limit metrics find to prevent from too large query


### PR DESCRIPTION
This PR adds 4 new config settings for the names of the 4 files that graphite-web logs to, and adds code to send these logs to `stderr` instead if those filenames are specified as `-`.

When sending logs to `stderr` the format is modified to make them easier to distinguish, and to support that it removes the (bogus) custom level names that were breaking formatting of warning messages, and updates the rendering and cache loggers to use `INFO` level.