### PR TITLE
Improve parseATTime

### DIFF
--- a/webapp/graphite/render/attime.py
+++ b/webapp/graphite/render/attime.py
@@ -14,7 +14,6 @@ limitations under the License."""
 
 import pytz
 from datetime import datetime, timedelta, datetime as datetimetype
-from time import daylight
 from django.conf import settings
 
 months = ['jan','feb','mar','apr','may','jun','jul','aug','sep','oct','nov','dec']
@@ -42,8 +41,6 @@ def parseATTime(s, tzinfo=None, now=None):
       pass #Fall back because its not a timestamp, its YYYYMMDD form
     else:
       return datetime.fromtimestamp(int(s),tzinfo)
-  elif ':' in s and len(s) == 13:
-    return tzinfo.localize(datetime.strptime(s,'%H:%M%Y%m%d'), daylight)
   if '+' in s:
     ref,offset = s.split('+',1)
     offset = '+' + offset

--- a/webapp/graphite/render/attime.py
+++ b/webapp/graphite/render/attime.py
@@ -72,10 +72,10 @@ def parseTimeReference(ref, tzinfo=None, now=None):
 
   # Time-of-day reference
   i = ref.find(':')
-  hour,min = 0,0
+  hour,minute = 0,0
   if 0 < i < 3:
     hour = int( ref[:i] )
-    min = int( ref[i+1:i+3] )
+    minute = int( ref[i+1:i+3] )
     ref = ref[i+3:]
     if ref[:2] == 'am':
       ref = ref[2:]
@@ -96,16 +96,16 @@ def parseTimeReference(ref, tzinfo=None, now=None):
     ref = ref[i+2:]
 
   if ref.startswith('noon'):
-    hour,min = 12,0
+    hour,minute = 12,0
     ref = ref[4:]
   elif ref.startswith('midnight'):
-    hour,min = 0,0
+    hour,minute = 0,0
     ref = ref[8:]
   elif ref.startswith('teatime'):
-    hour,min = 16,0
+    hour,minute = 16,0
     ref = ref[7:]
 
-  refDate = now.replace(hour=hour,minute=min,second=0,microsecond=0,tzinfo=None)
+  refDate = now.replace(hour=hour,minute=minute,second=0,microsecond=0,tzinfo=None)
 
   # Day reference
   if ref in ('yesterday','today','tomorrow'): # yesterday, today, tomorrow
@@ -118,10 +118,10 @@ def parseTimeReference(ref, tzinfo=None, now=None):
     m,d,y = map(int,ref.split('/'))
     if y < 1900: y += 1900
     if y < 1970: y += 100
-    refDate = datetime(year=y,month=m,day=d,hour=hour,minute=min)
+    refDate = datetime(year=y,month=m,day=d,hour=hour,minute=minute)
 
   elif len(ref) == 8 and ref.isdigit(): # YYYYMMDD
-    refDate = datetime(year=int(ref[:4]),month=int(ref[4:6]),day=int(ref[6:8]),hour=hour,minute=min)
+    refDate = datetime(year=int(ref[:4]),month=int(ref[4:6]),day=int(ref[6:8]),hour=hour,minute=minute)
 
   elif ref[:3] in months: # MonthName DayOfMonth
     d = None
@@ -131,7 +131,7 @@ def parseTimeReference(ref, tzinfo=None, now=None):
       d = int(ref[-1:])
     else:
       raise Exception("Day of month required after month name")
-    refDate = datetime(year=refDate.year,month=months.index(ref[:3]) + 1,day=d,hour=hour,minute=min)
+    refDate = datetime(year=refDate.year,month=months.index(ref[:3]) + 1,day=d,hour=hour,minute=minute)
 
   elif ref[:3] in weekdays: # DayOfWeek (Monday, etc)
     todayDayName = refDate.strftime("%a").lower()[:3]

--- a/webapp/graphite/render/attime.py
+++ b/webapp/graphite/render/attime.py
@@ -71,10 +71,12 @@ def parseTimeReference(ref, tzinfo=None, now=None):
 
   if not ref or ref == 'now': return now
 
+  rawRef = ref
+
   # Time-of-day reference
   i = ref.find(':')
   hour,min = 0,0
-  if i != -1:
+  if 0 < i < 3:
     hour = int( ref[:i] )
     min = int( ref[i+1:i+3] )
     ref = ref[i+3:]
@@ -83,6 +85,19 @@ def parseTimeReference(ref, tzinfo=None, now=None):
     elif ref[:2] == 'pm':
       hour = (hour + 12) % 24
       ref = ref[2:]
+
+  # Xam or XXam
+  i = ref.find('am')
+  if 0 < i < 3:
+    hour = int( ref[:i] )
+    ref = ref[i+2:]
+
+  # Xpm or XXpm
+  i = ref.find('pm')
+  if 0 < i < 3:
+    hour = (int( ref[:i] ) + 12) % 24
+    ref = ref[i+2:]
+
   if ref.startswith('noon'):
     hour,min = 12,0
     ref = ref[4:]
@@ -130,7 +145,7 @@ def parseTimeReference(ref, tzinfo=None, now=None):
     refDate -= timedelta(days=dayOffset)
 
   elif ref:
-    raise Exception("Unknown day reference")
+    raise ValueError("Unknown day reference: %s" % rawRef)
 
   return tzinfo.localize(refDate)
 

--- a/webapp/tests/test_attime.py
+++ b/webapp/tests/test_attime.py
@@ -126,7 +126,7 @@ class parseTimeReferenceTest(TestCase):
 
     def test_parse_random_string_raise_Exception(self):
         with self.assertRaises(Exception):
-            time_ref = parseTimeReference("random")
+            parseTimeReference("random")
 
     def test_parse_now_return_now(self):
         time_ref = parseTimeReference("now")
@@ -134,7 +134,7 @@ class parseTimeReferenceTest(TestCase):
 
     def test_parse_colon_raises_ValueError(self):
         with self.assertRaises(ValueError):
-            time_ref = parseTimeReference(":")
+            parseTimeReference(":")
 
     def test_parse_naive_datetime(self):
         time_ref = parseTimeReference(datetime(self.MOCK_DATE.year, self.MOCK_DATE.month, self.MOCK_DATE.day, 8, 50))
@@ -228,11 +228,11 @@ class parseTimeReferenceTest(TestCase):
 
     def test_parse_MonthName_DayOfMonth_threedigits_raise_ValueError(self):
         with self.assertRaises(ValueError):
-            time_ref = parseTimeReference("january800")
+            parseTimeReference("january800")
 
     def test_parse_MonthName_without_DayOfMonth_raise_Exception(self):
         with self.assertRaises(Exception):
-            time_ref = parseTimeReference("january")
+            parseTimeReference("january")
 
     def test_parse_monday_return_monday_before_now(self):
         time_ref = parseTimeReference("monday")
@@ -264,23 +264,23 @@ class parseTimeOffsetTest(TestCase):
 
     def test_parse_integer_raises_TypeError(self):
         with self.assertRaises(TypeError):
-            time_ref = parseTimeOffset(1)
+            parseTimeOffset(1)
 
     def test_parse_string_starting_neither_with_minus_nor_digit_raises_KeyError(self):
         with self.assertRaises(KeyError):
-            time_ref = parseTimeOffset("Something")
+            parseTimeOffset("Something")
 
     def test_parse_m_as_unit_raises_Exception(self):
         with self.assertRaises(Exception):
-            time_ref = parseTimeOffset("1m")
+            parseTimeOffset("1m")
 
     def test_parse_digits_only_raises_exception(self):
         with self.assertRaises(Exception):
-            time_ref = parseTimeOffset("10")
+            parseTimeOffset("10")
 
     def test_parse_alpha_only_raises_KeyError(self):
         with self.assertRaises(KeyError):
-            time_ref = parseTimeOffset("month")
+            parseTimeOffset("month")
 
     def test_parse_minus_only_returns_zero(self):
         time_ref = parseTimeOffset("-")
@@ -555,7 +555,7 @@ class parseTimeReferenceTestNow(TestCase):
 
     def test_parse_random_string_raise_Exception(self):
         with self.assertRaises(Exception):
-            time_ref = parseTimeReference("random", now=self.now)
+            parseTimeReference("random", now=self.now)
 
     def test_parse_now_return_now(self):
         time_ref = parseTimeReference("now", now=self.now)
@@ -563,7 +563,7 @@ class parseTimeReferenceTestNow(TestCase):
 
     def test_parse_colon_raises_ValueError(self):
         with self.assertRaises(ValueError):
-            time_ref = parseTimeReference(":", now=self.now)
+            parseTimeReference(":", now=self.now)
 
     def test_parse_naive_datetime(self):
         time_ref = parseTimeReference(datetime(self.MOCK_DATE.year, self.MOCK_DATE.month, self.MOCK_DATE.day, 8, 50), now=self.now)
@@ -657,11 +657,11 @@ class parseTimeReferenceTestNow(TestCase):
 
     def test_parse_MonthName_DayOfMonth_threedigits_raise_ValueError(self):
         with self.assertRaises(ValueError):
-            time_ref = parseTimeReference("january800", now=self.now)
+            parseTimeReference("january800", now=self.now)
 
     def test_parse_MonthName_without_DayOfMonth_raise_Exception(self):
         with self.assertRaises(Exception):
-            time_ref = parseTimeReference("january", now=self.now)
+            parseTimeReference("january", now=self.now)
 
     def test_parse_monday_return_monday_before_now(self):
         time_ref = parseTimeReference("monday", now=self.now)

--- a/webapp/tests/test_attime.py
+++ b/webapp/tests/test_attime.py
@@ -149,6 +149,16 @@ class parseTimeReferenceTest(TestCase):
         expected = self.zone.localize(datetime(self.MOCK_DATE.year, self.MOCK_DATE.month, self.MOCK_DATE.day, 20, 50))
         self.assertEquals(time_ref, expected)
 
+    def test_parse_hour_only_am(self):
+        time_ref = parseTimeReference("8am")
+        expected = self.zone.localize(datetime(self.MOCK_DATE.year, self.MOCK_DATE.month, self.MOCK_DATE.day, 8, 0))
+        self.assertEquals(time_ref, expected)
+
+    def test_parse_hour_only_pm(self):
+        time_ref = parseTimeReference("10pm")
+        expected = self.zone.localize(datetime(self.MOCK_DATE.year, self.MOCK_DATE.month, self.MOCK_DATE.day, 22, 0))
+        self.assertEquals(time_ref, expected)
+
     def test_parse_noon(self):
         time_ref = parseTimeReference("noon")
         expected = self.zone.localize(datetime(self.MOCK_DATE.year, self.MOCK_DATE.month, self.MOCK_DATE.day, 12, 0))
@@ -554,6 +564,16 @@ class parseTimeReferenceTestNow(TestCase):
     def test_parse_hour_pm(self):
         time_ref = parseTimeReference("8:50pm", now=self.now)
         expected = self.zone.localize(datetime(self.MOCK_DATE.year, self.MOCK_DATE.month, self.MOCK_DATE.day, 20, 50))
+        self.assertEquals(time_ref, expected)
+
+    def test_parse_hour_only_am(self):
+        time_ref = parseTimeReference("8am", now=self.now)
+        expected = self.zone.localize(datetime(self.MOCK_DATE.year, self.MOCK_DATE.month, self.MOCK_DATE.day, 8, 0))
+        self.assertEquals(time_ref, expected)
+
+    def test_parse_hour_only_pm(self):
+        time_ref = parseTimeReference("10pm", now=self.now)
+        expected = self.zone.localize(datetime(self.MOCK_DATE.year, self.MOCK_DATE.month, self.MOCK_DATE.day, 22, 0))
         self.assertEquals(time_ref, expected)
 
     def test_parse_noon(self):

--- a/webapp/tests/test_attime.py
+++ b/webapp/tests/test_attime.py
@@ -11,16 +11,21 @@ from .base import TestCase
 import pytz
 import mock
 
-class MockedDateTime(datetime):
-    def __new__(cls, *args, **kwargs):
-        return datetime.__new__(datetime, *args, **kwargs)
-    @classmethod
-    def now(cls, tzinfo=None):
-        if tzinfo:
-          return tzinfo.localize(cls(2015, 3, 8, 12, 0, 0))
-        return cls(2015, 3, 8, 12, 0, 0)
 
-@mock.patch('graphite.render.attime.datetime', MockedDateTime)
+def mockDateTime(year, month, day, hour, minute, second):
+  class MockedDateTime(datetime):
+      def __new__(cls, *args, **kwargs):
+          return datetime.__new__(datetime, *args, **kwargs)
+      @classmethod
+      def now(cls, tzinfo=None):
+          if tzinfo:
+            return tzinfo.localize(cls(year, month, day, hour, minute, second))
+          return cls(year, month, day, hour, minute, second)
+
+  return MockedDateTime
+
+
+@mock.patch('graphite.render.attime.datetime', mockDateTime(2015, 3, 8, 12, 0, 0))
 class ATTimeTimezoneTests(TestCase):
     default_tz = timezone.get_current_timezone()
     specified_tz = pytz.timezone("America/Los_Angeles")
@@ -82,15 +87,8 @@ class ATTimeTimezoneTests(TestCase):
         actual_time = parseATTime("midnight+3h", self.specified_tz)
         self.assertEqual(actual_time, expected_time)
 
-class AnotherMockedDateTime(datetime):
-    def __new__(cls, *args, **kwargs):
-        return datetime.__new__(datetime, *args, **kwargs)
-    @classmethod
-    def now(cls, tzinfo=None):
-        return cls(2015, 1, 1, 11, 0, 0, tzinfo=tzinfo)
 
-
-@mock.patch('graphite.render.attime.datetime', AnotherMockedDateTime)
+@mock.patch('graphite.render.attime.datetime', mockDateTime(2015, 1, 1, 11, 0, 0))
 class parseTimeReferenceTest(TestCase):
 
     zone = pytz.utc
@@ -194,14 +192,8 @@ class parseTimeReferenceTest(TestCase):
         expected = self.zone.localize(datetime(2014, 12, 29, 0, 0))
         self.assertEquals(time_ref, expected)
 
-class Bug551771MockedDateTime(datetime):
-    def __new__(cls, *args, **kwargs):
-        return datetime.__new__(datetime, *args, **kwargs)
-    @classmethod
-    def now(cls, tzinfo=None):
-        return cls(2010, 3, 30, 00, 0, 0, tzinfo=tzinfo)
 
-@mock.patch('graphite.render.attime.datetime', Bug551771MockedDateTime)
+@mock.patch('graphite.render.attime.datetime', mockDateTime(2010, 3, 30, 00, 0, 0))
 class parseTimeReferenceTestBug551771(TestCase):
     zone = pytz.utc
 
@@ -214,6 +206,7 @@ class parseTimeReferenceTestBug551771(TestCase):
         time_ref = parseTimeReference("20100223")
         expected = self.zone.localize(datetime(2010, 2, 23, 0, 0))
         self.assertEquals(time_ref, expected)
+
 
 class parseTimeOffsetTest(TestCase):
 
@@ -365,14 +358,8 @@ class getUnitStringTest(TestCase):
         with self.assertRaises(Exception):
             result = getUnitString(1)
 
-class LeapYearMockedDateTime(datetime):
-    def __new__(cls, *args, **kwargs):
-        return datetime.__new__(datetime, *args, **kwargs)
-    @classmethod
-    def now(cls, tzinfo=None):
-        return cls(2016, 2, 29, 00, 0, 0, tzinfo=tzinfo)
 
-@mock.patch('graphite.render.attime.datetime', LeapYearMockedDateTime)
+@mock.patch('graphite.render.attime.datetime', mockDateTime(2016, 2, 29, 00, 0, 0))
 class parseATTimeTestLeapYear(TestCase):
     zone = pytz.utc
 
@@ -391,14 +378,8 @@ class parseATTimeTestLeapYear(TestCase):
         expected = self.zone.localize(datetime(2016, 1, 30, 0, 0))
         self.assertEquals(time_ref, expected)
 
-class LeapYearMockedDateTime2(datetime):
-    def __new__(cls, *args, **kwargs):
-        return datetime.__new__(datetime, *args, **kwargs)
-    @classmethod
-    def now(cls, tzinfo=None):
-        return cls(2013, 2, 28, 00, 0, 0, tzinfo=tzinfo)
 
-@mock.patch('graphite.render.attime.datetime', LeapYearMockedDateTime2)
+@mock.patch('graphite.render.attime.datetime',mockDateTime(2013, 2, 28, 00, 0, 0))
 class parseATTimeTestLeapYear2(TestCase):
     zone = pytz.utc
 
@@ -416,6 +397,7 @@ class parseATTimeTestLeapYear2(TestCase):
         time_ref = parseATTime("-1month")
         expected = self.zone.localize(datetime(2013, 1, 29, 0, 0))
         self.assertEquals(time_ref, expected)
+
 
 class parseATTimeTest(TestCase):
     zone = pytz.utc

--- a/webapp/tests/test_attime.py
+++ b/webapp/tests/test_attime.py
@@ -41,6 +41,18 @@ class ATTimeTimezoneTests(TestCase):
         actual_time = parseATTime(time_string, self.specified_tz)
         self.assertEqual(actual_time, expected_time)
 
+    def test_should_return_absolute_time_short(self):
+        time_string = '9:0020150308'
+        expected_time = self.default_tz.localize(datetime.strptime(time_string,'%H:%M%Y%m%d'))
+        actual_time = parseATTime(time_string)
+        self.assertEqual(actual_time, expected_time)
+
+    def test_absolute_time_should_respect_tz_short(self):
+        time_string = '9:0020150308'
+        expected_time = self.specified_tz.localize(datetime.strptime(time_string, '%H:%M%Y%m%d'))
+        actual_time = parseATTime(time_string, self.specified_tz)
+        self.assertEqual(actual_time, expected_time)
+
     def test_absolute_time_YYYYMMDD(self):
         time_string = '20150110'
         expected_time = self.specified_tz.localize(datetime.strptime(time_string, '%Y%m%d'))
@@ -459,6 +471,18 @@ class parseATTimeTestNow(TestCase):
 
     def test_absolute_time_should_respect_tz(self):
         time_string = '12:0020150308'
+        expected_time = self.specified_tz.localize(datetime.strptime(time_string, '%H:%M%Y%m%d'))
+        actual_time = parseATTime(time_string, self.specified_tz, now=self.now)
+        self.assertEqual(actual_time, expected_time)
+
+    def test_should_return_absolute_time_short(self):
+        time_string = '9:0020150308'
+        expected_time = self.default_tz.localize(datetime.strptime(time_string,'%H:%M%Y%m%d'))
+        actual_time = parseATTime(time_string, now=self.now)
+        self.assertEqual(actual_time, expected_time)
+
+    def test_absolute_time_should_respect_tz_short(self):
+        time_string = '9:0020150308'
         expected_time = self.specified_tz.localize(datetime.strptime(time_string, '%H:%M%Y%m%d'))
         actual_time = parseATTime(time_string, self.specified_tz, now=self.now)
         self.assertEqual(actual_time, expected_time)

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -311,7 +311,7 @@ class RenderTest(TestCase):
         self.assertEqual(data, expected)
 
         # test maxDataPoints is respected, testing the returned values is done in test_maxDataPoints
-        response = self.client.get(url, {'target': 'test', 'format': 'json', 'maxDataPoints': 10, 'until': ts-10})
+        response = self.client.get(url, {'target': 'test', 'format': 'json', 'maxDataPoints': 10, 'from': ts-50, 'until': ts-10})
         self.assertEqual(response['content-type'], 'application/json')
         data = json.loads(response.content)
         self.assertEqual(len(data[0]['datapoints']), 10)

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -317,7 +317,7 @@ class RenderTest(TestCase):
         self.assertEqual(len(data[0]['datapoints']), 10)
 
         # test dygraph
-        response = self.client.get(url, {'target': 'test', 'format': 'dygraph', 'now': ts})
+        response = self.client.get(url, {'target': 'test', 'format': 'dygraph', 'from': ts-50, 'now': ts})
         self.assertEqual(response['content-type'], 'application/json')
         self.assertIn('[' + str((ts - 2) * 1000) + ', Infinity]', response.content)
         self.assertIn('[' + str((ts - 1) * 1000) + ', -Infinity]', response.content)
@@ -332,12 +332,12 @@ class RenderTest(TestCase):
             [(ts - 1) * 1000, float('-inf')],
             [ts * 1000, None]])
 
-        responsejsonp = self.client.get(url, {'target': 'test', 'format': 'dygraph', 'jsonp': 'test', 'now': ts})
+        responsejsonp = self.client.get(url, {'target': 'test', 'format': 'dygraph', 'jsonp': 'test', 'from': ts-50, 'now': ts})
         self.assertEqual(responsejsonp['content-type'], 'text/javascript')
         self.assertEqual(responsejsonp.content, 'test(' + response.content + ')')
 
         # test rickshaw
-        response = self.client.get(url, {'target': 'test', 'format': 'rickshaw', 'now': ts})
+        response = self.client.get(url, {'target': 'test', 'format': 'rickshaw', 'from': ts-50, 'now': ts})
         self.assertEqual(response['content-type'], 'application/json')
         data = json.loads(response.content)
         end = data[0]['datapoints'][-7:-1]
@@ -353,7 +353,7 @@ class RenderTest(TestCase):
         self.assertEqual(last['x'], ts)
         self.assertTrue(math.isnan(last['y']))
 
-        responsejsonp = self.client.get(url, {'target': 'test', 'format': 'rickshaw', 'jsonp': 'test', 'now': ts})
+        responsejsonp = self.client.get(url, {'target': 'test', 'format': 'rickshaw', 'jsonp': 'test', 'from': ts-50, 'now': ts})
         self.assertEqual(responsejsonp['content-type'], 'text/javascript')
         self.assertEqual(responsejsonp.content, 'test(' + response.content + ')')
 


### PR DESCRIPTION
This patch corrects some issues in `parseATTime` when used with the `now` parameter, adds support for times formatted like `6pm` or `10am`, and handles dates like `H:mmYYYYMMDD` properly.

It also expands the test suite to catch a number of edge cases.

This supercedes #2064 and #2067