### PR TITLE
Handle no data with graphType=pie

### DIFF
--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1769,6 +1769,14 @@ class PieGraph(Graph):
     self.pieLabels = params.get('pieLabels', 'horizontal')
     self.total = sum( [t[1] for t in self.data] )
 
+    if not self.data:
+      x = self.width / 2
+      y = self.height / 2
+      self.setColor('red')
+      self.setFont(size=math.log(self.width * self.height) )
+      self.drawText("No Data", x, y, align='center')
+      return
+
     if self.params.get('areaAlpha'):
       try:
         self.alpha = float(self.params['areaAlpha'])

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1797,7 +1797,8 @@ class PieGraph(Graph):
 
     if not params.get('hideLegend',False):
       elements = [ (slice['name'],slice['color'],None) for slice in self.slices ]
-      self.drawLegend(elements)
+      if len(elements) > 0:
+        self.drawLegend(elements)
 
     self.drawSlices()
 

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -81,18 +81,35 @@ class RenderTest(TestCase):
     def test_render_view(self):
         url = reverse('render')
 
+        # Very very basic tests of the render view responding to input params
+        # The test target does not exist, so there is no data to return
+        # These do not check any graphs are drawn properly.
+
+        # Raw format
         response = self.client.get(url, {'target': 'test', 'format': 'raw'})
         self.assertEqual(response.content, "")
         self.assertEqual(response['Content-Type'], 'text/plain')
 
+        # json format
         response = self.client.get(url, {'target': 'test', 'format': 'json'})
         self.assertEqual(json.loads(response.content), [])
         self.assertTrue(response.has_header('Expires'))
 
+        # no format returns image/png
         response = self.client.get(url, {'target': 'test'})
         self.assertEqual(response['Content-Type'], 'image/png')
         self.assertTrue(response.has_header('Expires'))
 
+        # Verify graphType=pie returns
+        response = self.client.get(url, {'target': 'a:50', 'graphType': 'pie'})
+        self.assertEqual(response['Content-Type'], 'image/png')
+        self.assertTrue(response.has_header('Expires'))
+
+        response = self.client.get(url, {'target': 'test', 'graphType': 'pie'})
+        self.assertEqual(response['Content-Type'], 'image/png')
+        self.assertTrue(response.has_header('Expires'))
+
+        # dygraph format
         response = self.client.get(url, {'target': 'test', 'format': 'dygraph'})
         self.assertEqual(json.loads(response.content), {})
         self.assertTrue(response.has_header('Expires'))
@@ -101,6 +118,7 @@ class RenderTest(TestCase):
         self.assertEqual(json.loads(response.content), [])
         self.assertTrue(response.has_header('Expires'))
 
+        # More invasive tests
         self.addCleanup(self.wipe_whisper)
         whisper.create(self.db, [(1, 60)])
 

--- a/webapp/tests/test_render_glyph.py
+++ b/webapp/tests/test_render_glyph.py
@@ -782,6 +782,10 @@ class LogAxisTicsTest(TestCase):
       with self.assertRaises(glyph.GraphError):
           glyph._LogAxisTics(0.0, float('inf'), unitSystem='binary')
 
+    def test_LogAxisTics_invalid_base_value(self):
+      with self.assertRaises(glyph.GraphError):
+          glyph._LogAxisTics(0.0, 100.0, base=1.0, unitSystem='binary')
+
     #
     # Testing _LogAxisTics.applySettings()
     #


### PR DESCRIPTION
Display 'No Data' graphs for graphType=pie when there's no data.  Current situation is a failure case.

Also, perform the same defensive tests before attempting to draw a legend with no elements that happens in LineGraph's drawGraph.

Added a few tests to cover this.