### PR TITLE
Whisper reader updates

### DIFF
--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -150,8 +150,10 @@ class TimeSeries(list):
     )
 
 
-@logtime()
-def _fetchData(pathExpr, startTime, endTime, now, requestContext, seriesList):
+@logtime(custom_msg=True)
+def _fetchData(pathExpr, startTime, endTime, now, requestContext, seriesList, msg_setter=None):
+  msg_setter("retrieval of \"%s\" took" % str(pathExpr))
+
   result_queue = []
   remote_done = False
 
@@ -269,8 +271,10 @@ def _merge_results(pathExpr, startTime, endTime, result_queue, seriesList, reque
 
 
 # Data retrieval API
-@logtime()
-def fetchData(requestContext, pathExpr):
+@logtime(custom_msg=True)
+def fetchData(requestContext, pathExpr, msg_setter=None):
+  msg_setter("retrieval of \"%s\" took" % str(pathExpr))
+
   seriesList = {}
   (startTime, endTime, now) = timebounds(requestContext)
 

--- a/webapp/tests/test_readers_whisper.py
+++ b/webapp/tests/test_readers_whisper.py
@@ -76,10 +76,11 @@ class WhisperReadersTests(TestCase):
         self.addCleanup(self.wipe_whisper_hosts)
 
         reader = GzippedWhisperReader(self.worker4, 'hosts.worker4.cpu')
+        ts = int(time.time())
         intervals = reader.get_intervals()
         for interval in intervals:
-          self.assertEqual(int(interval.start), self.start_ts-60)
-          self.assertEqual(int(interval.end), self.start_ts)
+          self.assertEqual(int(interval.start), ts-60)
+          self.assertEqual(int(interval.end), ts)
 
     # Confirm fetch works.
     def test_GzippedWhisperReader_fetch(self):
@@ -110,10 +111,11 @@ class WhisperReadersTests(TestCase):
         self.addCleanup(self.wipe_whisper_hosts)
 
         reader = WhisperReader(self.worker1, 'hosts.worker1.cpu')
+        ts = int(time.time())
         intervals = reader.get_intervals()
         for interval in intervals:
-          self.assertEqual(int(interval.start), self.start_ts-60)
-          self.assertEqual(int(interval.end), self.start_ts)
+          self.assertEqual(int(interval.start),ts-60)
+          self.assertEqual(int(interval.end), ts)
 
     # Confirm fetch works.
     def test_WhisperReader_fetch(self):


### PR DESCRIPTION
This PR is the result of looking into why the whisper reader tests were failing fairly regularly.

In the first commit I changed the timestamps used when testing `get_intervals()` to account for the situation where it takes more than 1s to create the whisper files.

Once I started looking at the reader itself I noticed that the regular reader can read the meta info twice if you call `get_intervals()` and `fetch()`, but it only uses data that isn't going to change so it should be caching that data and only reading it once.  I also noticed that the gzipped whisper reader didn't handle carbonlink.  The second commit fixes both of those issues, and shares more code between the 2 readers.

The 3rd commit adds coverage for the case when the info is cached, and tests the code path for `fetch()` against a missing whisper file.

The 4th commit just tweaks the log format for `fetchData` and `_fetchData` in `render.datalib` so that you can see which metrics they are fetching.

On review I'm not sure if the behavior in `get_intervals()` is actually correct, since it uses `end = max(stat(self.fs_path).st_mtime, start)` while whisper never uses the mtime of the file.  It may make more sense to update whisper to use mtime (see https://github.com/graphite-project/whisper/issues/160) rather than wall clock time as the starting point when reading whisper files.