### PR TITLE
Use prefetch logic for sub-requests

### DIFF
--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -1,18 +1,32 @@
 import re
+from time import time
+
+from django.conf import settings
+from graphite.logger import log
 from graphite.render.grammar import grammar
-from graphite.render.datalib import fetchData, TimeSeries
+from graphite.render.datalib import fetchData, TimeSeries, prefetchRemoteData
 
+def evaluateTarget(requestContext, *targets):
+  if settings.REMOTE_PREFETCH_DATA and not requestContext.get('localOnly'):
+    prefetchRemoteData(requestContext, targets)
 
-def evaluateTarget(requestContext, target):
-  tokens = grammar.parseString(target)
-  result = evaluateTokens(requestContext, tokens)
+  seriesList = []
 
-  if type(result) is TimeSeries:
-    return [result] #we have to return a list of TimeSeries objects
+  for target in targets:
+    if isinstance(target, basestring):
+      if not target.strip():
+        continue
+      target = grammar.parseString(target)
 
-  else:
-    return result
+    result = evaluateTokens(requestContext, target)
 
+    # we have to return a list of TimeSeries objects
+    if isinstance(result, TimeSeries):
+      seriesList.append(result)
+    elif result:
+      seriesList.extend(result)
+
+  return seriesList
 
 def evaluateTokens(requestContext, tokens, replacements=None, pipedArg=None):
   if tokens.template:

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -1,8 +1,6 @@
 import re
-from time import time
 
 from django.conf import settings
-from graphite.logger import log
 from graphite.render.grammar import grammar
 from graphite.render.datalib import fetchData, TimeSeries, prefetchRemoteData
 

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -6,8 +6,11 @@ from graphite.logger import log
 from graphite.render.grammar import grammar
 from graphite.render.datalib import fetchData, TimeSeries, prefetchRemoteData
 
-def evaluateTarget(requestContext, *targets):
-  if settings.REMOTE_PREFETCH_DATA and not requestContext.get('localOnly'):
+def evaluateTarget(requestContext, targets, noPrefetch=False):
+  if not isinstance(targets, list):
+    targets = [targets]
+
+  if settings.REMOTE_PREFETCH_DATA and not requestContext.get('localOnly') and not noPrefetch:
     prefetchRemoteData(requestContext, targets)
 
   seriesList = []

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1018,7 +1018,7 @@ def movingWindow(requestContext, seriesList, windowSize, func='average', xFilesF
   # data from earlier is needed to calculate the early results
   newContext = requestContext.copy()
   newContext['startTime'] = requestContext['startTime'] -  timedelta(seconds=previewSeconds)
-  previewList = evaluateTokens(newContext, requestContext['args'][0])
+  previewList = evaluateTarget(newContext, requestContext['args'][0])
   result = []
 
   tagName = 'moving' + func.capitalize()
@@ -1089,7 +1089,7 @@ def exponentialMovingAverage(requestContext, seriesList, windowSize):
   # data from earlier is needed to calculate the early results
   newContext = requestContext.copy()
   newContext['startTime'] = requestContext['startTime'] -  timedelta(seconds=previewSeconds)
-  previewList = evaluateTokens(newContext, requestContext['args'][0])
+  previewList = evaluateTarget(newContext, requestContext['args'][0])
   result = []
 
   for series in previewList:
@@ -2948,7 +2948,7 @@ def holtWintersForecast(requestContext, seriesList, bootstrapInterval='7d'):
   # ignore original data and pull new, including our preview
   newContext = requestContext.copy()
   newContext['startTime'] = requestContext['startTime'] -  timedelta(seconds=previewSeconds)
-  previewList = evaluateTokens(newContext, requestContext['args'][0])
+  previewList = evaluateTarget(newContext, requestContext['args'][0])
   results = []
   for series in previewList:
     analysis = holtWintersAnalysis(series)
@@ -2973,7 +2973,7 @@ def holtWintersConfidenceBands(requestContext, seriesList, delta=3, bootstrapInt
   # ignore original data and pull new, including our preview
   newContext = requestContext.copy()
   newContext['startTime'] = requestContext['startTime'] -  timedelta(seconds=previewSeconds)
-  previewList = evaluateTokens(newContext, requestContext['args'][0])
+  previewList = evaluateTarget(newContext, requestContext['args'][0])
   results = []
   for series in previewList:
     analysis = holtWintersAnalysis(series)
@@ -3103,7 +3103,7 @@ def linearRegression(requestContext, seriesList, startSourceAt=None, endSourceAt
   if startSourceAt is not None: sourceContext['startTime'] = parseATTime(startSourceAt)
   if endSourceAt is not None: sourceContext['endTime'] = parseATTime(endSourceAt)
 
-  sourceList = evaluateTokens(sourceContext, requestContext['args'][0])
+  sourceList = evaluateTarget(sourceContext, requestContext['args'][0])
 
   for source,series in zip(sourceList, seriesList):
     series.tags['linearRegressions'] = '%s, %s' % (
@@ -3231,16 +3231,14 @@ def timeStack(requestContext, seriesList, timeShiftUnit, timeShiftStart, timeShi
     innerDelta = delta * shft
     myContext['startTime'] = requestContext['startTime'] + innerDelta
     myContext['endTime'] = requestContext['endTime'] + innerDelta
-    shiftedSeriesList = evaluateTokens(myContext, requestContext['args'][0])
-    if isinstance(shiftedSeriesList, list):
-      for shiftedSeries in shiftedSeriesList:
-        shiftedSeries.tags['timeShiftUnit'] = timeShiftUnit
-        shiftedSeries.tags['timeShift'] = shft
-        shiftedSeries.name = 'timeShift(%s, %s, %s)' % (shiftedSeries.name, timeShiftUnit,shft)
-        shiftedSeries.pathExpression = shiftedSeries.name
-        shiftedSeries.start = series.start
-        shiftedSeries.end = series.end
-        results.append(shiftedSeries)
+    for shiftedSeries in evaluateTarget(myContext, requestContext['args'][0]):
+      shiftedSeries.tags['timeShiftUnit'] = timeShiftUnit
+      shiftedSeries.tags['timeShift'] = shft
+      shiftedSeries.name = 'timeShift(%s, %s, %s)' % (shiftedSeries.name, timeShiftUnit,shft)
+      shiftedSeries.pathExpression = shiftedSeries.name
+      shiftedSeries.start = series.start
+      shiftedSeries.end = series.end
+      results.append(shiftedSeries)
 
   return results
 
@@ -3308,17 +3306,15 @@ def timeShift(requestContext, seriesList, timeShift, resetEnd=True, alignDST=Fal
     return []
   series = seriesList[0]
 
-  shiftedSeriesList = evaluateTokens(myContext, requestContext['args'][0])
-  if isinstance(shiftedSeriesList, list):
-    for shiftedSeries in shiftedSeriesList:
-      shiftedSeries.tags['timeShift'] = timeShift
-      shiftedSeries.name = 'timeShift(%s, "%s")' % (shiftedSeries.name, timeShift)
-      if resetEnd:
-        shiftedSeries.end = series.end
-      else:
-        shiftedSeries.end = shiftedSeries.end - shiftedSeries.start + series.start
-      shiftedSeries.start = series.start
-      results.append(shiftedSeries)
+  for shiftedSeries in evaluateTarget(myContext, requestContext['args'][0]):
+    shiftedSeries.tags['timeShift'] = timeShift
+    shiftedSeries.name = 'timeShift(%s, "%s")' % (shiftedSeries.name, timeShift)
+    if resetEnd:
+      shiftedSeries.end = series.end
+    else:
+      shiftedSeries.end = shiftedSeries.end - shiftedSeries.start + series.start
+    shiftedSeries.start = series.start
+    results.append(shiftedSeries)
 
   return results
 
@@ -3899,7 +3895,7 @@ def smartSummarize(requestContext, seriesList, intervalString, func='sum', align
         requestContext['startTime'] = datetime(s.year, s.month, s.day, s.hour, s.minute, s.second, tzinfo = s.tzinfo)
 
       # Ignore the originally fetched data and pull new using the modified requestContext
-      seriesList = evaluateTokens(requestContext, requestContext['args'][0])
+      seriesList = evaluateTarget(requestContext, requestContext['args'][0])
 
   results = []
   delta = parseTimeOffset(intervalString)
@@ -4054,7 +4050,7 @@ def hitcount(requestContext, seriesList, intervalString, alignToInterval = False
 
     # Ignore the originally fetched data and pull new using
     # the modified requestContext.
-    seriesList = evaluateTokens(requestContext, requestContext['args'][0])
+    seriesList = evaluateTarget(requestContext, requestContext['args'][0])
     for series in seriesList:
       intervalCount = int((series.end - series.start) // interval)
       series.end = series.start + (intervalCount * interval) + interval
@@ -4612,4 +4608,4 @@ SeriesFunctions = {
 
 # Avoid import circularity
 if not environ.get('READTHEDOCS'):
-  from graphite.render.evaluator import evaluateTarget, evaluateTokens
+  from graphite.render.evaluator import evaluateTarget

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -4278,7 +4278,7 @@ def seriesByTag(requestContext, *tagExpressions):
 
   log.debug('taggedSeriesQuery %s' % taggedSeriesQuery)
 
-  seriesList = evaluateTarget(requestContext, taggedSeriesQuery)
+  seriesList = evaluateTarget(requestContext, taggedSeriesQuery, noPrefetch=True)
 
   log.debug('seriesByTag found [%s]' % ', '.join([series.pathExpression for series in seriesList]))
 

--- a/webapp/graphite/render/utils.py
+++ b/webapp/graphite/render/utils.py
@@ -9,7 +9,10 @@ def extractPathExpressions(targets):
 
   def extractPathExpression(tokens):
     if tokens.expression:
-      return extractPathExpression(tokens.expression)
+      extractPathExpression(tokens.expression)
+      if tokens.expression.pipedCalls:
+        for token in tokens.expression.pipedCalls:
+          extractPathExpression(token)
     elif tokens.pathExpression:
       pathExpressions.add(tokens.pathExpression)
     elif tokens.call:
@@ -23,7 +26,10 @@ def extractPathExpressions(targets):
           extractPathExpression(a)
 
   for target in targets:
-    tokens = grammar.parseString(target)
-    extractPathExpression(tokens)
+    if isinstance(target, basestring):
+      if not target.strip():
+        continue
+      target = grammar.parseString(target)
+    extractPathExpression(target)
 
   return list(pathExpressions)

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -39,7 +39,6 @@ from graphite.render.attime import parseATTime
 from graphite.render.functions import PieFunctions
 from graphite.render.hashing import hashRequest, hashData
 from graphite.render.glyph import GraphTypes
-from graphite.render.datalib import prefetchRemoteData
 from graphite.tags.models import Series, Tag, TagValue, SeriesTag  # noqa # pylint: disable=unused-import
 
 from django.http import HttpResponseServerError, HttpResponseRedirect
@@ -118,16 +117,8 @@ def renderView(request):
       requestContext['data'] = data = cachedData
     else: # Have to actually retrieve the data now
       targets = requestOptions['targets']
-      if settings.REMOTE_PREFETCH_DATA and not requestOptions.get('localOnly'):
-        prefetchRemoteData(requestContext, targets)
 
-      for target in targets:
-        if not target.strip():
-          continue
-        t = time()
-        seriesList = evaluateTarget(requestContext, target)
-        log.rendering("Retrieval of %s took %.6f" % (target, time() - t))
-        data.extend(seriesList)
+      data.extend(evaluateTarget(requestContext, *targets))
 
       if useCache:
         cache.add(dataKey, data, cacheTimeout)

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -118,7 +118,7 @@ def renderView(request):
     else: # Have to actually retrieve the data now
       targets = requestOptions['targets']
 
-      data.extend(evaluateTarget(requestContext, *targets))
+      data.extend(evaluateTarget(requestContext, targets))
 
       if useCache:
         cache.add(dataKey, data, cacheTimeout)

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -3706,6 +3706,21 @@ class FunctionsTest(TestCase):
 
         self.assertEqual(results, expectedResults)
 
+    def test_timeStack_emptySeries(self):
+        # Input of an empty series will result in no timeshifting attempted
+        results = functions.timeStack(
+            self._build_requestContext(
+                startTime=datetime(1970, 1, 1, 0, 10, 0, 0, pytz.timezone(settings.TIME_ZONE)),
+                endTime=datetime(1970, 1, 1, 0, 20, 0, 0, pytz.timezone(settings.TIME_ZONE))
+            ),
+            [ ],
+            "-10minutes",
+            0,
+            3
+        )
+        expectedResult = [ ]
+        self.assertEqual(results, expectedResult)
+
     def test_timeShift(self):
         seriesList = self._gen_series_list_with_data(
             key=['test.value'],
@@ -4064,7 +4079,7 @@ class FunctionsTest(TestCase):
                 data=range(10, 25)
             )
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             with self.assertRaisesRegexp(Exception, '^Unsupported window function: invalid$'):
                 functions.movingWindow(request_context, seriesList, 5, 'invalid')
 
@@ -4088,7 +4103,7 @@ class FunctionsTest(TestCase):
             TimeSeries('movingAverage(collectd.test-db0.load.value,10)', 20, 30, 1, [None, None, None, None, None, 2.0, 2.5, 3.0, 3.5, 4.0])
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingWindow(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4122,7 +4137,7 @@ class FunctionsTest(TestCase):
             TimeSeries('movingMedian(collectd.test-db0.load.value,10)', 20, 25, 1, [None, None, None, None, None])
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingMedian(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4152,7 +4167,7 @@ class FunctionsTest(TestCase):
             TimeSeries('movingMedian(collectd.test-db0.load.value,10)', 20, 30, 1, [None, 0, 1, 1, 2, 2, 3, 3, 4, 4])
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingMedian(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4175,7 +4190,7 @@ class FunctionsTest(TestCase):
 
         expectedResults = []
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingMedian(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4205,7 +4220,7 @@ class FunctionsTest(TestCase):
             TimeSeries('movingMedian(collectd.test-db0.load.value,60)', 660, 700, 1, range(30, 70)),
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingMedian(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4235,7 +4250,7 @@ class FunctionsTest(TestCase):
             TimeSeries('movingMedian(collectd.test-db0.load.value,"-1min")', 660, 700, 1, range(30, 70)),
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingMedian(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4268,7 +4283,7 @@ class FunctionsTest(TestCase):
             TimeSeries('movingAverage(collectd.test-db0.load.value,10)', 20, 25, 1, [None, None, None, None, None])
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingAverage(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4298,7 +4313,7 @@ class FunctionsTest(TestCase):
             TimeSeries('movingAverage(collectd.test-db0.load.value,10)', 20, 30, 1, [None, 0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0])
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingAverage(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4322,7 +4337,7 @@ class FunctionsTest(TestCase):
 
         expectedResults = []
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingAverage(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4356,7 +4371,7 @@ class FunctionsTest(TestCase):
             TimeSeries('movingAverage(collectd.test-db0.load.value,60)', 660, 700, 1, frange(29.5, 69.5, 1)),
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingAverage(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4391,7 +4406,7 @@ class FunctionsTest(TestCase):
             TimeSeries('movingAverage(collectd.test-db0.load.value,"-1min")', 660, 700, 1, frange(29.5, 69.5, 1)),
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingAverage(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4426,7 +4441,7 @@ class FunctionsTest(TestCase):
             TimeSeries('movingMin(collectd.test-db0.load.value,10)', 20, 25, 1, [None, None, None, None, None])
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingMin(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4456,7 +4471,7 @@ class FunctionsTest(TestCase):
             TimeSeries('movingMin(collectd.test-db0.load.value,10)', 20, 30, 1, [None, 2, 1, 1, 1, 1, 1, 1, 1, 1] )
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingMin(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4479,7 +4494,7 @@ class FunctionsTest(TestCase):
 
         expectedResults = []
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingMin(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4509,7 +4524,7 @@ class FunctionsTest(TestCase):
             TimeSeries('movingMin(collectd.test-db0.load.value,10)', 20, 30, 1, [None, 10] + [1] * 8)
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingMin(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4539,7 +4554,7 @@ class FunctionsTest(TestCase):
             TimeSeries('movingMin(collectd.test-db0.load.value,"-1min")', 660, 700, 1, [1]*40),
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingMin(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4574,7 +4589,7 @@ class FunctionsTest(TestCase):
             TimeSeries('movingMax(collectd.test-db0.load.value,10)', 20, 25, 1, [None, None, None, None, None])
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingMax(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4604,7 +4619,7 @@ class FunctionsTest(TestCase):
             TimeSeries('movingMax(collectd.test-db0.load.value,10)', 20, 30, 1, [None, 1, 2, 2, 2, 2, 2, 2, 2, 2])
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingMax(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4627,7 +4642,7 @@ class FunctionsTest(TestCase):
 
         expectedResults = []
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingMax(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4657,7 +4672,7 @@ class FunctionsTest(TestCase):
             TimeSeries('movingMax(collectd.test-db0.load.value,10)', 20, 30, 1, [None, 1, 2, 2, 2, 2, 2, 2, 2, 2])
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingMax(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4687,7 +4702,7 @@ class FunctionsTest(TestCase):
             TimeSeries('movingMax(collectd.test-db0.load.value,"-1min")', 660, 700, 1, [10] * 40),
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingMax(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4735,7 +4750,7 @@ class FunctionsTest(TestCase):
             TimeSeries('movingSum(collectd.test-db0.load.value,10)', 20, 25, 1, [None, None, None, None, None])
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingSum(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4765,7 +4780,7 @@ class FunctionsTest(TestCase):
             TimeSeries('movingSum(collectd.test-db0.load.value,10)', 20, 30, 1, [None, 0.0, 1.0, 3.0, 6.0, 10.0, 15.0, 21.0, 28.0, 36.0])
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingSum(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4788,7 +4803,7 @@ class FunctionsTest(TestCase):
 
         expectedResults = []
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingSum(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4813,7 +4828,7 @@ class FunctionsTest(TestCase):
             TimeSeries('movingSum(collectd.test-db0.load.value,60)', 660, 700, 1, [60.0]*40)
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingSum(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4838,7 +4853,7 @@ class FunctionsTest(TestCase):
             TimeSeries('movingSum(collectd.test-db0.load.value,"-1min")', 660, 700, 1, [60.0]*40),
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.movingSum(
                 self._build_requestContext(
                     startTime=datetime(1970, 1, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4866,7 +4881,7 @@ class FunctionsTest(TestCase):
             TimeSeries('holtWintersForecast(collectd.test-db0.load.value)', 605400, 700, 1, [])
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.holtWintersForecast(
                 self._build_requestContext(
                     startTime=datetime(1970, 2, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4905,7 +4920,7 @@ class FunctionsTest(TestCase):
             TimeSeries('holtWintersConfidenceUpper(collectd.test-db0.load.value)', start_time, start_time+(points*step), step, [8.424944558327624, 9.409422251880809, 10.607070189221787, 10.288439865038768, 9.491556863132963, 9.474595784593738, 8.572310478053845, 8.897670449095346, 8.941566968508148, 9.409728797779282])
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.holtWintersConfidenceBands(
                 self._build_requestContext(
                     startTime=datetime(1970, 2, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4946,7 +4961,7 @@ class FunctionsTest(TestCase):
         expectedResults[0].options = {'invisible': True, 'stacked': True}
         expectedResults[1].options = {'stacked': True}
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.holtWintersConfidenceArea(
                 self._build_requestContext(
                     startTime=datetime(1970, 2, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -4984,7 +4999,7 @@ class FunctionsTest(TestCase):
             TimeSeries('holtWintersAberration(collectd.test-db0.load.value)', start_time, start_time+(points*step), step, [-0.2841206166091448, -0.05810270987744115, 0, 0, 0, 0, 0, 0, 0, 0])
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.holtWintersAberration(
                 self._build_requestContext(
                     startTime=datetime(1970, 2, 1, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -5296,7 +5311,7 @@ class FunctionsTest(TestCase):
         bucketSize = '1hour'
         alignTo = True
 
-        with patch('graphite.render.functions.evaluateTokens', lambda *_: []):
+        with patch('graphite.render.evaluator.evaluateTokens', lambda *_: []):
             request_context = self._build_requestContext(start_time, end_time)
             with self.assertRaises(TypeError):
                 functions.smartSummarize(request_context, None, bucketSize, 'max', alignTo)
@@ -5318,7 +5333,7 @@ class FunctionsTest(TestCase):
             TimeSeries('hitcount(servers.s2.disk.bytes_free, "1d", true)', 0, 172800, 86400, [62164800, None])
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', lambda *_: seriesList):
+        with patch('graphite.render.evaluator.evaluateTokens', lambda *_: seriesList):
             result = functions.hitcount(
                 self._build_requestContext(endTime=datetime(1970, 1, 2, 0, 0, 0, 0, pytz.timezone(settings.TIME_ZONE))),
                 seriesList, "1d", True)
@@ -5341,7 +5356,7 @@ class FunctionsTest(TestCase):
             TimeSeries('hitcount(servers.s2.disk.bytes_free, "1hour", true)', 0, 18000, 3600, [12956400, 38876400, 64796400, 90716400, None])
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', lambda *_: seriesList):
+        with patch('graphite.render.evaluator.evaluateTokens', lambda *_: seriesList):
             result = functions.hitcount(
                 self._build_requestContext(endTime=datetime(1970, 1, 1, 0, 4, 0, 0, pytz.timezone(settings.TIME_ZONE))),
                 seriesList,
@@ -5365,7 +5380,7 @@ class FunctionsTest(TestCase):
             TimeSeries('hitcount(servers.s2.disk.bytes_free, "1minute", true)', 0, 300, 60, [3540, 10740, 17940, 25140, None])
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', lambda *_: seriesList):
+        with patch('graphite.render.evaluator.evaluateTokens', lambda *_: seriesList):
             result = functions.hitcount(
                 self._build_requestContext(endTime=datetime(1970, 1, 1, 0, 4, 0, 0, pytz.timezone(settings.TIME_ZONE))),
                 seriesList,
@@ -5389,7 +5404,7 @@ class FunctionsTest(TestCase):
             TimeSeries('hitcount(servers.s2.disk.bytes_free, "1minute")', 0, 240, 60, [3540, 10740, 17940, 25140])
         ]
 
-        with patch('graphite.render.functions.evaluateTokens', lambda *_: seriesList):
+        with patch('graphite.render.evaluator.evaluateTokens', lambda *_: seriesList):
             result = functions.hitcount(
                 self._build_requestContext(endTime=datetime(1970, 1, 1, 0, 4, 0, 0, pytz.timezone(settings.TIME_ZONE))),
                 seriesList,
@@ -5547,7 +5562,7 @@ class FunctionsTest(TestCase):
         def mock_evaluateTokens(reqCtx, tokens, replacements=None):
             return seriesList
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.exponentialMovingAverage(self._build_requestContext(), seriesList, 30)
 
         self.assertEqual(list(result[0]), list(expectedResults[0]))
@@ -5565,7 +5580,7 @@ class FunctionsTest(TestCase):
         def mock_evaluateTokens(reqCtx, tokens, replacements=None):
             return seriesList
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.exponentialMovingAverage(self._build_requestContext(), seriesList, "-30s")
 
         self.assertEqual(list(result[0]), list(expectedResults[0]))
@@ -5578,7 +5593,7 @@ class FunctionsTest(TestCase):
         def mock_evaluateTokens(reqCtx, tokens, replacements=None):
             return []
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.exponentialMovingAverage(self._build_requestContext(endTime=datetime(1970, 1, 1, 0, 9, 0, 0, pytz.timezone(settings.TIME_ZONE))), seriesList, 60)
 
         self.assertEqual(result, expectedResults)
@@ -5596,7 +5611,7 @@ class FunctionsTest(TestCase):
         def mock_evaluateTokens(reqCtx, tokens, replacements=None):
             return self._gen_series_list_with_data(key='collectd.test-db0.load.value',start=10, end=30, data=([None] * 10 + range(0, 5) + [None] + range(5, 9)))
 
-        with patch('graphite.render.functions.evaluateTokens', mock_evaluateTokens):
+        with patch('graphite.render.evaluator.evaluateTokens', mock_evaluateTokens):
             result = functions.exponentialMovingAverage(self._build_requestContext(endTime=datetime(1970, 1, 1, 0, 9, 0, 0, pytz.timezone(settings.TIME_ZONE))), seriesList, 10)
 
         self.assertEqual(list(result[0]), list(expectedResults[0]))
@@ -5697,7 +5712,7 @@ class FunctionsTest(TestCase):
         return seriesList
 
     def _assert_smartsummarize(self, start_time, end_time, step, bucketSize, alignTo, expectedResults):
-        with patch('graphite.render.functions.evaluateTokens', lambda ctx, _: self._gen_smart_summarize_series_list(ctx['startTime'], end_time, step)):
+        with patch('graphite.render.evaluator.evaluateTokens', lambda ctx, _: self._gen_smart_summarize_series_list(ctx['startTime'], end_time, step)):
             for func in expectedResults:
                 request_context = self._build_requestContext(start_time, end_time)
                 result = functions.smartSummarize(request_context, None, bucketSize, func, alignTo)


### PR DESCRIPTION
When functions need to perform sub-requests to get data for a time range that's different from the main query (eg `moving*`, `timeShift`, etc) they currently always go through the regular find/read pipeline and can't use the faster prefetch mechanism to optimize those requests (instead potentially making a large number of small requests to the backend servers).

This PR moves the triggering of the prefetch mechanism from `views.py` into `evaluateTarget` and updates it to be able to accept pre-tokenized input, a raw string, or a list of tokens/strings.  All functions now use `evaluateTarget` instead of `evaluateTokens` so that they can take advantage of prefetching.

The special case here is `seriesByTag` which explicitly disables prefetching because the series will already have been prefetched by code in `extractPathExpression` that handles `seriesByTag` to be able to grab the matching series in the initial prefetch and not require a second prefetch cycle.