### PR TITLE
Auto complete for tags

### DIFF
--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -148,10 +148,10 @@ To get a list of defined tags:
 
     [
       {
-        "tag": "name"
+        "tag": "datacenter"
       },
       {
-        "tag": "datacenter"
+        "tag": "name"
       },
       {
         "tag": "rack"
@@ -217,6 +217,82 @@ Finally, to search for series matching a set of tag expressions:
 
     [
       "disk.used;datacenter=dc1;rack=a1;server=web01"
+    ]
+
+Auto-complete Support
+---------------------
+The HTTP api provides 2 endpoints to support auto-completion of tags and values based on the series which match a provided set of tag expressions.
+
+Each of these endpoints accepts an optional list of tag expressions using the same syntax as the `/tags/findSeries` endpoint.
+
+The provided expressions are used to filter the results, so that the suggested list of tags will only include tags that occur in series matching the expressions.
+
+To get an auto-complete list of tags (results are limited to 100):
+
+.. code-block:: none
+
+    $ curl -s "http://graphite/tags/autoComplete/tags?pretty=1"
+
+    [
+      "datacenter",
+      "name",
+      "rack",
+      "server"
+    ]
+
+To filter by prefix:
+
+.. code-block:: none
+
+    $ curl -s "http://graphite/tags/autoComplete/tags?pretty=1&tagPrefix=d"
+
+    [
+      "datacenter"
+    ]
+
+If you provide a list of tag expressions, the specified tags are excluded and the result is filtered to only tags that occur in series matching those expressions:
+
+.. code-block:: none
+
+    $ curl -s "http://graphite/tags/autoComplete/tags?pretty=1&expr=datacenter=dc1&expr=server=web01"
+
+    [
+      "name",
+      "rack"
+    ]
+
+To get an auto-complete list of values for a specified tag (results are limited to 100):
+
+.. code-block:: none
+
+    $ curl -s "http://graphite/tags/autoComplete/values?pretty=1&tag=rack"
+
+    [
+      "a1",
+      "a2",
+      "b1",
+      "b2"
+    ]
+
+To filter by prefix:
+
+.. code-block:: none
+
+    $ curl -s "http://graphite/tags/autoComplete/values?pretty=1&tag=rack&valuePrefix=a"
+
+    [
+      "a1",
+      "a2"
+    ]
+
+If you provide a list of tag expressions, the result is filtered to only values that occur for the specified tag in series matching those expressions:
+
+.. code-block:: none
+
+    $ curl -s "http://graphite/tags/autoComplete/values?pretty=1&tag=rack&expr=datacenter=dc1&expr=server=web01"
+
+    [
+      "a1"
     ]
 
 Removing Series from the TagDB

--- a/webapp/graphite/tags/base.py
+++ b/webapp/graphite/tags/base.py
@@ -145,46 +145,6 @@ class BaseTagDB(object):
     """
     pass
 
-  def auto_complete(self, exprs, tagPrefix=None, valuePrefix=None):
-    """
-    Return auto-complete suggestions for tags and values based on the matches for the specified expressions, optionally filtered by tag and/or value prefix
-    """
-    result = {}
-
-    if not exprs:
-      for tagInfo in self.list_tags(tagFilter=tagPrefix)[:100]:
-        result[tagInfo['tag']] = [v['value'] for v in self.list_values(tagInfo['tag'], valueFilter=valuePrefix)[:100]]
-
-      return result
-
-    searchedTags = set([self.parse_tagspec(expr)[0] for expr in exprs])
-
-    for path in self.find_series(exprs):
-      tags = self.parse(path).tags
-      for tag in tags:
-        if tag in searchedTags:
-          continue
-        if tagPrefix and not tag.startswith(tagPrefix):
-          continue
-        value = tags[tag]
-        if valuePrefix and not value.startswith(valuePrefix):
-          continue
-        if tag not in result:
-          result[tag] = [value]
-          continue
-        if value in result[tag]:
-          continue
-        if value >= result[tag][-1]:
-          if len(result[tag]) >= 100:
-            continue
-          result[tag].append(value)
-        else:
-          bisect.insort_left(result[tag], value)
-        if len(result[tag]) > 100:
-          del result[tag][-1]
-
-    return {tag: result[tag] for tag in sorted(result.keys())[:100]}
-
   def auto_complete_tags(self, exprs, tagPrefix=None):
     """
     Return auto-complete suggestions for tags based on the matches for the specified expressions, optionally filtered by tag prefix
@@ -244,7 +204,6 @@ class BaseTagDB(object):
         del result[-1]
 
     return result
-
 
   @staticmethod
   def parse(path):

--- a/webapp/graphite/tags/base.py
+++ b/webapp/graphite/tags/base.py
@@ -151,6 +151,12 @@ class BaseTagDB(object):
     """
     result = {}
 
+    if not exprs:
+      for tagInfo in self.list_tags(tagFilter=tagPrefix)[:100]:
+        result[tagInfo['tag']] = [v['value'] for v in self.list_values(tagInfo['tag'], valueFilter=valuePrefix)[:100]]
+
+      return result
+
     searchedTags = set([self.parse_tagspec(expr)[0] for expr in exprs])
 
     for path in self.find_series(exprs):
@@ -178,6 +184,67 @@ class BaseTagDB(object):
           del result[tag][-1]
 
     return {tag: result[tag] for tag in sorted(result.keys())[:100]}
+
+  def auto_complete_tags(self, exprs, tagPrefix=None):
+    """
+    Return auto-complete suggestions for tags based on the matches for the specified expressions, optionally filtered by tag prefix
+    """
+    if not exprs:
+      return [tagInfo['tag'] for tagInfo in self.list_tags(tagFilter=('^(' + tagPrefix + ')' if tagPrefix else None))[:100]]
+
+    result = []
+
+    searchedTags = set([self.parse_tagspec(expr)[0] for expr in exprs])
+
+    for path in self.find_series(exprs):
+      tags = self.parse(path).tags
+      for tag in tags:
+        if tag in searchedTags:
+          continue
+        if tagPrefix and not tag.startswith(tagPrefix):
+          continue
+        if tag in result:
+          continue
+        if len(result) == 0 or tag >= result[-1]:
+          if len(result) >= 100:
+            continue
+          result.append(tag)
+        else:
+          bisect.insort_left(result, tag)
+        if len(result) > 100:
+          del result[-1]
+
+    return result
+
+  def auto_complete_values(self, exprs, tag, valuePrefix=None):
+    """
+    Return auto-complete suggestions for tags and values based on the matches for the specified expressions, optionally filtered by tag and/or value prefix
+    """
+    if not exprs:
+      return [v['value'] for v in self.list_values(tag, valueFilter=('^(' + valuePrefix + ')' if valuePrefix else None))[:100]]
+
+    result = []
+
+    for path in self.find_series(exprs):
+      tags = self.parse(path).tags
+      if tag not in tags:
+        continue
+      value = tags[tag]
+      if valuePrefix and not value.startswith(valuePrefix):
+        continue
+      if value in result:
+        continue
+      if len(result) == 0 or value >= result[-1]:
+        if len(result) >= 100:
+          continue
+        result.append(value)
+      else:
+        bisect.insort_left(result, value)
+      if len(result) > 100:
+        del result[-1]
+
+    return result
+
 
   @staticmethod
   def parse(path):

--- a/webapp/graphite/tags/base.py
+++ b/webapp/graphite/tags/base.py
@@ -18,7 +18,7 @@ class BaseTagDB(object):
     pass
 
   @logtime(custom_msg=True, custom_name=True)
-  def find_series(self, tags, msg_setter, name_setter):
+  def find_series(self, tags, msg_setter=None, name_setter=None):
     """
     Find series by tag, accepts a list of tag specifiers and returns a list of matching paths.
 

--- a/webapp/graphite/tags/localdatabase.py
+++ b/webapp/graphite/tags/localdatabase.py
@@ -112,7 +112,7 @@ class LocalDatabaseTagDB(BaseTagDB):
     with connection.cursor() as cursor:
       cursor.execute(sql, params)
 
-      return [row[0] for row in cursor.fetchall() if matches_filters(row[0])]
+      return [row[0] for row in cursor if matches_filters(row[0])]
 
   def get_series(self, path):
     with connection.cursor() as cursor:
@@ -127,7 +127,7 @@ class LocalDatabaseTagDB(BaseTagDB):
 
       series_id = None
 
-      tags = {tag: value for (series_id, tag, value) in cursor.fetchall()}
+      tags = {tag: value for (series_id, tag, value) in cursor}
 
       if not tags:
         return None
@@ -150,7 +150,7 @@ class LocalDatabaseTagDB(BaseTagDB):
       sql += ' ORDER BY t.tag'
       cursor.execute(sql, params)
 
-      return [{'id': tag_id, 'tag': tag} for (tag_id, tag) in cursor.fetchall()]
+      return [{'id': tag_id, 'tag': tag} for (tag_id, tag) in cursor]
 
   def get_tag(self, tag, valueFilter=None):
     with connection.cursor() as cursor:
@@ -193,7 +193,7 @@ class LocalDatabaseTagDB(BaseTagDB):
       sql += ' ORDER BY v.value'
       cursor.execute(sql, params)
 
-      return [{'id': value_id, 'value': value, 'count': count} for (value_id, value, count) in cursor.fetchall()]
+      return [{'id': value_id, 'value': value, 'count': count} for (value_id, value, count) in cursor]
 
   @staticmethod
   def _insert_ignore(table, cols, data):
@@ -254,7 +254,7 @@ class LocalDatabaseTagDB(BaseTagDB):
       sql = 'SELECT id, tag FROM tags_tag WHERE tag IN (' + ', '.join(['%s'] * len(parsed.tags)) + ')'  # nosec
       params = list(parsed.tags.keys())
       cursor.execute(sql, params)
-      tag_ids = {tag: tag_id for (tag_id, tag) in cursor.fetchall()}
+      tag_ids = {tag: tag_id for (tag_id, tag) in cursor}
 
       # tag values
       self._insert_ignore('tags_tagvalue', ['value'], [[value] for value in parsed.tags.values()])
@@ -262,7 +262,7 @@ class LocalDatabaseTagDB(BaseTagDB):
       sql = 'SELECT id, value FROM tags_tagvalue WHERE value IN (' + ', '.join(['%s'] * len(parsed.tags)) + ')'  # nosec
       params = list(parsed.tags.values())
       cursor.execute(sql, params)
-      value_ids = {value: value_id for (value_id, value) in cursor.fetchall()}
+      value_ids = {value: value_id for (value_id, value) in cursor}
 
       # series
       if curr:

--- a/webapp/graphite/tags/urls.py
+++ b/webapp/graphite/tags/urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
   url('tagSeries', views.tagSeries, name='tagSeries'),
   url('delSeries', views.delSeries, name='delSeries'),
   url('findSeries', views.findSeries, name='findSeries'),
+  url('autoComplete', views.autoComplete, name='autoCompleteTags'),
   url('^(.+)$', views.tagDetails, name='tagDetails'),
   url('', views.tagList, name='tagList'),
 ]

--- a/webapp/graphite/tags/urls.py
+++ b/webapp/graphite/tags/urls.py
@@ -21,7 +21,6 @@ urlpatterns = [
   url('findSeries', views.findSeries, name='findSeries'),
   url('autoComplete/tags', views.autoCompleteTags, name='tagAutoCompleteTags'),
   url('autoComplete/values', views.autoCompleteValues, name='tagAutoCompleteValues'),
-  url('autoComplete', views.autoComplete, name='tagAutoComplete'),
   url('^(.+)$', views.tagDetails, name='tagDetails'),
   url('', views.tagList, name='tagList'),
 ]

--- a/webapp/graphite/tags/urls.py
+++ b/webapp/graphite/tags/urls.py
@@ -19,7 +19,9 @@ urlpatterns = [
   url('tagSeries', views.tagSeries, name='tagSeries'),
   url('delSeries', views.delSeries, name='delSeries'),
   url('findSeries', views.findSeries, name='findSeries'),
-  url('autoComplete', views.autoComplete, name='autoCompleteTags'),
+  url('autoComplete/tags', views.autoCompleteTags, name='tagAutoCompleteTags'),
+  url('autoComplete/values', views.autoCompleteValues, name='tagAutoCompleteValues'),
+  url('autoComplete', views.autoComplete, name='tagAutoComplete'),
   url('^(.+)$', views.tagDetails, name='tagDetails'),
   url('', views.tagList, name='tagList'),
 ]

--- a/webapp/graphite/tags/views.py
+++ b/webapp/graphite/tags/views.py
@@ -61,7 +61,7 @@ def findSeries(request):
   return HttpResponse(
     json.dumps(STORE.tagdb.find_series(exprs) if STORE.tagdb else [],
                indent=(2 if queryParams.get('pretty') else None),
-               sort_keys=bool(request.GET.get('pretty'))),
+               sort_keys=bool(queryParams.get('pretty'))),
     content_type='application/json'
   )
 
@@ -123,10 +123,15 @@ def autoComplete(request):
           result[tag] = [value]
         elif value not in result[tag]:
           result[tag].append(value)
+          result[tag].sort()
+          if len(result[tag]) > 100:
+            del result[tag][-1]
+
+    result = {tag: result[tag] for tag in sorted(result.keys())[:100]}
 
   return HttpResponse(
     json.dumps(result,
                indent=(2 if queryParams.get('pretty') else None),
-               sort_keys=bool(request.GET.get('pretty'))),
+               sort_keys=bool(queryParams.get('pretty'))),
     content_type='application/json'
   )

--- a/webapp/graphite/tags/views.py
+++ b/webapp/graphite/tags/views.py
@@ -87,33 +87,6 @@ def tagDetails(request, tag):
     content_type='application/json'
   )
 
-def autoComplete(request):
-  if request.method not in ['GET', 'POST']:
-    return HttpResponse(status=405)
-
-  queryParams = request.GET.copy()
-  queryParams.update(request.POST)
-
-  exprs = []
-  # Normal format: ?expr=tag1=value1&expr=tag2=value2
-  if len(queryParams.getlist('expr')) > 0:
-    exprs = queryParams.getlist('expr')
-  # Rails/PHP/jQuery common practice format: ?expr[]=tag1=value1&expr[]=tag2=value2
-  elif len(queryParams.getlist('expr[]')) > 0:
-    exprs = queryParams.getlist('expr[]')
-
-  tagPrefix = queryParams.get('tagPrefix')
-  valuePrefix = queryParams.get('valuePrefix')
-
-  result = STORE.tagdb.auto_complete(exprs, tagPrefix, valuePrefix)
-
-  return HttpResponse(
-    json.dumps(result,
-               indent=(2 if queryParams.get('pretty') else None),
-               sort_keys=bool(queryParams.get('pretty'))),
-    content_type='application/json'
-  )
-
 def autoCompleteTags(request):
   if request.method not in ['GET', 'POST']:
     return HttpResponse(status=405)

--- a/webapp/graphite/tags/views.py
+++ b/webapp/graphite/tags/views.py
@@ -121,11 +121,16 @@ def autoComplete(request):
         value = tags[tag]
         if tag not in result:
           result[tag] = [value]
-        elif value not in result[tag]:
+          continue
+        if value in result[tag]:
+          continue
+        if len(result[tag]) >= 100:
+          if value >= result[tag][-1]:
+            continue
+          result[tag][-1] = value
+        else:
           result[tag].append(value)
-          result[tag].sort()
-          if len(result[tag]) > 100:
-            del result[tag][-1]
+        result[tag].sort()
 
     result = {tag: result[tag] for tag in sorted(result.keys())[:100]}
 

--- a/webapp/graphite/tags/views.py
+++ b/webapp/graphite/tags/views.py
@@ -1,3 +1,5 @@
+import bisect
+
 from graphite.compat import HttpResponse
 from graphite.util import json
 from graphite.storage import STORE
@@ -124,13 +126,14 @@ def autoComplete(request):
           continue
         if value in result[tag]:
           continue
-        if len(result[tag]) >= 100:
-          if value >= result[tag][-1]:
+        if value >= result[tag][-1]:
+          if len(result[tag]) >= 100:
             continue
-          result[tag][-1] = value
-        else:
           result[tag].append(value)
-        result[tag].sort()
+        else:
+          bisect.insort_left(result[tag], value)
+        if len(result[tag]) > 100:
+          del result[tag][-1]
 
     result = {tag: result[tag] for tag in sorted(result.keys())[:100]}
 

--- a/webapp/graphite/tags/views.py
+++ b/webapp/graphite/tags/views.py
@@ -111,6 +111,9 @@ def autoComplete(request):
       status=400
     )
 
+  tagPrefix = queryParams.get('tagPrefix')
+  valuePrefix = queryParams.get('valuePrefix')
+
   result = {}
 
   if STORE.tagdb:
@@ -120,7 +123,11 @@ def autoComplete(request):
       for tag in tags:
         if tag in searchedTags:
           continue
+        if tagPrefix and not tag.startswith(tagPrefix):
+          continue
         value = tags[tag]
+        if valuePrefix and not value.startswith(valuePrefix):
+          continue
         if tag not in result:
           result[tag] = [value]
           continue

--- a/webapp/graphite/tags/views.py
+++ b/webapp/graphite/tags/views.py
@@ -102,17 +102,70 @@ def autoComplete(request):
   elif len(queryParams.getlist('expr[]')) > 0:
     exprs = queryParams.getlist('expr[]')
 
-  if not exprs:
-    return HttpResponse(
-      json.dumps({'error': 'no tag expressions specified'}),
-      content_type='application/json',
-      status=400
-    )
-
   tagPrefix = queryParams.get('tagPrefix')
   valuePrefix = queryParams.get('valuePrefix')
 
   result = STORE.tagdb.auto_complete(exprs, tagPrefix, valuePrefix)
+
+  return HttpResponse(
+    json.dumps(result,
+               indent=(2 if queryParams.get('pretty') else None),
+               sort_keys=bool(queryParams.get('pretty'))),
+    content_type='application/json'
+  )
+
+def autoCompleteTags(request):
+  if request.method not in ['GET', 'POST']:
+    return HttpResponse(status=405)
+
+  queryParams = request.GET.copy()
+  queryParams.update(request.POST)
+
+  exprs = []
+  # Normal format: ?expr=tag1=value1&expr=tag2=value2
+  if len(queryParams.getlist('expr')) > 0:
+    exprs = queryParams.getlist('expr')
+  # Rails/PHP/jQuery common practice format: ?expr[]=tag1=value1&expr[]=tag2=value2
+  elif len(queryParams.getlist('expr[]')) > 0:
+    exprs = queryParams.getlist('expr[]')
+
+  tagPrefix = queryParams.get('tagPrefix')
+
+  result = STORE.tagdb.auto_complete_tags(exprs, tagPrefix)
+
+  return HttpResponse(
+    json.dumps(result,
+               indent=(2 if queryParams.get('pretty') else None),
+               sort_keys=bool(queryParams.get('pretty'))),
+    content_type='application/json'
+  )
+
+def autoCompleteValues(request):
+  if request.method not in ['GET', 'POST']:
+    return HttpResponse(status=405)
+
+  queryParams = request.GET.copy()
+  queryParams.update(request.POST)
+
+  exprs = []
+  # Normal format: ?expr=tag1=value1&expr=tag2=value2
+  if len(queryParams.getlist('expr')) > 0:
+    exprs = queryParams.getlist('expr')
+  # Rails/PHP/jQuery common practice format: ?expr[]=tag1=value1&expr[]=tag2=value2
+  elif len(queryParams.getlist('expr[]')) > 0:
+    exprs = queryParams.getlist('expr[]')
+
+  tag = queryParams.get('tag')
+  if not tag:
+    return HttpResponse(
+      json.dumps({'error': 'no tag specified'}),
+      content_type='application/json',
+      status=400
+    )
+
+  valuePrefix = queryParams.get('valuePrefix')
+
+  result = STORE.tagdb.auto_complete_values(exprs, tag, valuePrefix)
 
   return HttpResponse(
     json.dumps(result,

--- a/webapp/tests/test_tags.py
+++ b/webapp/tests/test_tags.py
@@ -175,6 +175,8 @@ class TagsTest(TestCase):
 
     search_exprs = ['name=test.a']
 
+    db = LocalDatabaseTagDB()
+
     def mock_find_series(self, exprs):
       if exprs != search_exprs:
         raise Exception('Unexpected exprs %s' % str(exprs))
@@ -182,26 +184,41 @@ class TagsTest(TestCase):
       return [('test.a;tag1=value1.%3d;tag2=value2.%3d' % (i, 201 - i)) for i in range(1,201)]
 
     with patch('graphite.tags.localdatabase.LocalDatabaseTagDB.find_series', mock_find_series):
-      result = LocalDatabaseTagDB().auto_complete(search_exprs)
+      result = db.auto_complete(search_exprs)
       self.assertEqual(result, {
         'tag1': [('value1.%3d' % i) for i in range(1,101)],
         'tag2': [('value2.%3d' % i) for i in range(1,101)],
       })
 
-      result = LocalDatabaseTagDB().auto_complete(search_exprs, 'tag1')
+      result = db.auto_complete(search_exprs, 'tag1')
       self.assertEqual(result, {
         'tag1': [('value1.%3d' % i) for i in range(1,101)],
       })
 
-      result = LocalDatabaseTagDB().auto_complete(search_exprs, 'tag1', 'value1.1')
+      result = db.auto_complete(search_exprs, 'tag1', 'value1.1')
       self.assertEqual(result, {
         'tag1': [('value1.%3d' % i) for i in range(100,200)],
       })
 
-      result = LocalDatabaseTagDB().auto_complete(search_exprs, None, 'value1')
+      result = db.auto_complete(search_exprs, None, 'value1')
       self.assertEqual(result, {
         'tag1': [('value1.%3d' % i) for i in range(1,101)],
       })
+
+      result = db.auto_complete_tags(search_exprs)
+      self.assertEqual(result, [
+        'tag1',
+        'tag2',
+      ])
+
+      result = db.auto_complete_values(search_exprs, 'tag2')
+      self.assertEqual(result, [('value2.%3d' % i) for i in range(1,101)])
+
+      result = db.auto_complete_values(search_exprs, 'tag1', 'value1.1')
+      self.assertEqual(result, [('value1.%3d' % i) for i in range(100,200)])
+
+      result = db.auto_complete_values(search_exprs, 'nonexistenttag1', 'value1.1')
+      self.assertEqual(result, [])
 
   def test_find_series_cached(self):
       def mock_cache_get(cacheKey):
@@ -269,13 +286,18 @@ class TagsTest(TestCase):
   def test_tag_views(self):
     url = reverse('tagList')
 
+    ## tagSeries
+
+    # get should fail
     response = self.client.get(url + '/tagSeries', {'path': 'test.a;hello=tiger;blah=blah'})
     self.assertEqual(response.status_code, 405)
 
+    # post without path should fail
     response = self.client.post(url + '/tagSeries', {})
     self.assertEqual(response.status_code, 400)
     self.assertEqual(response['Content-Type'], 'application/json')
 
+    # tagging a series should succeed
     expected = 'test.a;blah=blah;hello=tiger'
 
     response = self.client.post(url + '/tagSeries', {'path': 'test.a;hello=tiger;blah=blah'})
@@ -283,9 +305,13 @@ class TagsTest(TestCase):
     self.assertEqual(response['Content-Type'], 'application/json')
     self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
+    ## list tags
+
+    # put should fail
     response = self.client.put(url, {})
     self.assertEqual(response.status_code, 405)
 
+    # filtered list
     expected = [{"tag": "hello"}]
 
     response = self.client.get(url, {'filter': 'hello$'})
@@ -295,6 +321,7 @@ class TagsTest(TestCase):
     self.assertEqual(len(result), len(expected))
     self.assertEqual(result[0]['tag'], expected[0]['tag'])
 
+    # pretty output
     response = self.client.get(url, {'filter': 'hello$', 'pretty': 1})
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
@@ -302,6 +329,9 @@ class TagsTest(TestCase):
     self.assertEqual(len(result), len(expected))
     self.assertEqual(result[0]['tag'], expected[0]['tag'])
 
+    ## tag details
+
+    # put should fail
     response = self.client.put(url + '/hello', {})
     self.assertEqual(response.status_code, 405)
 
@@ -316,6 +346,7 @@ class TagsTest(TestCase):
     self.assertEqual(result['values'][0]['count'], expected['values'][0]['count'])
     self.assertEqual(result['values'][0]['value'], expected['values'][0]['value'])
 
+    # pretty output
     response = self.client.get(url + '/hello', {'filter': 'tiger$', 'pretty': 1})
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
@@ -325,13 +356,18 @@ class TagsTest(TestCase):
     self.assertEqual(result['values'][0]['count'], expected['values'][0]['count'])
     self.assertEqual(result['values'][0]['value'], expected['values'][0]['value'])
 
+    ## findSeries
+
+    # put should fail
+    response = self.client.put(url + '/findSeries', {})
+    self.assertEqual(response.status_code, 405)
+
+    # expr is required
     response = self.client.post(url + '/findSeries', {})
     self.assertEqual(response.status_code, 400)
     self.assertEqual(response['Content-Type'], 'application/json')
 
-    response = self.client.put(url + '/findSeries', {})
-    self.assertEqual(response.status_code, 405)
-
+    # basic find
     expected = ['test.a;blah=blah;hello=tiger']
 
     response = self.client.get(url + '/findSeries?expr[]=name=test.a&expr[]=hello=tiger&expr[]=blah=blah&pretty=1')
@@ -339,6 +375,7 @@ class TagsTest(TestCase):
     self.assertEqual(response['Content-Type'], 'application/json')
     self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
+    # tag another series
     expected = 'test.a;blah=blah;hello=lion'
 
     response = self.client.post(url + '/tagSeries', {'path': 'test.a;hello=lion;blah=blah'})
@@ -346,12 +383,22 @@ class TagsTest(TestCase):
     self.assertEqual(response['Content-Type'], 'application/json')
     self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
+    ## autocomplete
+
     response = self.client.put(url + '/autoComplete', {})
     self.assertEqual(response.status_code, 405)
 
     expected = {
       'hello': ['lion','tiger'],
+    }
+
+    response = self.client.get(url + '/autoComplete?tagPrefix=hello&pretty=1')
+    self.assertEqual(response['Content-Type'], 'application/json')
+    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+
+    expected = {
       'blah': ['blah'],
+      'hello': ['lion','tiger'],
     }
 
     response = self.client.get(url + '/autoComplete?expr[]=name=test.a&pretty=1')
@@ -367,23 +414,94 @@ class TagsTest(TestCase):
     self.assertEqual(response['Content-Type'], 'application/json')
     self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
-    response = self.client.post(url + '/autoComplete', {})
+    ## autocomplete tags
+
+    response = self.client.put(url + '/autoComplete/tags', {})
+    self.assertEqual(response.status_code, 405)
+
+    expected = [
+      'hello',
+    ]
+
+    response = self.client.get(url + '/autoComplete/tags?tagPrefix=hello&pretty=1')
+    self.assertEqual(response['Content-Type'], 'application/json')
+    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+
+    expected = [
+      'blah',
+      'hello',
+    ]
+
+    response = self.client.get(url + '/autoComplete/tags?expr[]=name=test.a&pretty=1')
+    self.assertEqual(response['Content-Type'], 'application/json')
+    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+
+    expected = [
+      'hello',
+    ]
+
+    response = self.client.get(url + '/autoComplete/tags?expr=name=test.a&tagPrefix=hell&pretty=1')
+    self.assertEqual(response.status_code, 200)
+    self.assertEqual(response['Content-Type'], 'application/json')
+    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+
+    ## autocomplete values
+
+    response = self.client.put(url + '/autoComplete/values', {})
+    self.assertEqual(response.status_code, 405)
+
+    response = self.client.get(url + '/autoComplete/values', {})
     self.assertEqual(response.status_code, 400)
     self.assertEqual(response['Content-Type'], 'application/json')
+    self.assertEqual(response.content, json.dumps({'error': 'no tag specified'}))
 
+    expected = ['lion','tiger']
+
+    response = self.client.get(url + '/autoComplete/values?tag=hello&pretty=1')
+    self.assertEqual(response['Content-Type'], 'application/json')
+    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+
+    expected = ['lion','tiger']
+
+    response = self.client.get(url + '/autoComplete/values?expr[]=name=test.a&tag=hello&pretty=1')
+    self.assertEqual(response['Content-Type'], 'application/json')
+    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+
+    expected = ['lion']
+
+    response = self.client.get(url + '/autoComplete/values?expr=name=test.a&tag=hello&valuePrefix=li&pretty=1')
+    self.assertEqual(response.status_code, 200)
+    self.assertEqual(response['Content-Type'], 'application/json')
+    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+
+    ## delSeries
+
+    # PUT should fail
+    response = self.client.put(url + '/delSeries', {})
+    self.assertEqual(response.status_code, 405)
+
+    # path is required
     response = self.client.post(url + '/delSeries', {})
     self.assertEqual(response.status_code, 400)
     self.assertEqual(response['Content-Type'], 'application/json')
 
-    response = self.client.put(url + '/delSeries', {})
-    self.assertEqual(response.status_code, 405)
-
+    # delete first series we added
     expected = True
 
     response = self.client.post(url + '/delSeries', {'path': 'test.a;blah=blah;hello=tiger'})
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
     self.assertEqual(response.content, json.dumps(expected))
+
+    # delete second series
+    expected = True
+
+    response = self.client.post(url + '/delSeries', {'path': 'test.a;blah=blah;hello=lion'})
+    self.assertEqual(response.status_code, 200)
+    self.assertEqual(response['Content-Type'], 'application/json')
+    self.assertEqual(response.content, json.dumps(expected))
+
+    # delete nonexistent series
 
     expected = True
 
@@ -392,6 +510,7 @@ class TagsTest(TestCase):
     self.assertEqual(response['Content-Type'], 'application/json')
     self.assertEqual(response.content, json.dumps(expected))
 
+    # find nonexistent series
     expected = []
 
     response = self.client.get(url + '/findSeries?expr=name=test.a&expr=hello=tiger&expr=blah=blah')

--- a/webapp/tests/test_tags.py
+++ b/webapp/tests/test_tags.py
@@ -184,27 +184,6 @@ class TagsTest(TestCase):
       return [('test.a;tag1=value1.%3d;tag2=value2.%3d' % (i, 201 - i)) for i in range(1,201)]
 
     with patch('graphite.tags.localdatabase.LocalDatabaseTagDB.find_series', mock_find_series):
-      result = db.auto_complete(search_exprs)
-      self.assertEqual(result, {
-        'tag1': [('value1.%3d' % i) for i in range(1,101)],
-        'tag2': [('value2.%3d' % i) for i in range(1,101)],
-      })
-
-      result = db.auto_complete(search_exprs, 'tag1')
-      self.assertEqual(result, {
-        'tag1': [('value1.%3d' % i) for i in range(1,101)],
-      })
-
-      result = db.auto_complete(search_exprs, 'tag1', 'value1.1')
-      self.assertEqual(result, {
-        'tag1': [('value1.%3d' % i) for i in range(100,200)],
-      })
-
-      result = db.auto_complete(search_exprs, None, 'value1')
-      self.assertEqual(result, {
-        'tag1': [('value1.%3d' % i) for i in range(1,101)],
-      })
-
       result = db.auto_complete_tags(search_exprs)
       self.assertEqual(result, [
         'tag1',
@@ -379,37 +358,6 @@ class TagsTest(TestCase):
     expected = 'test.a;blah=blah;hello=lion'
 
     response = self.client.post(url + '/tagSeries', {'path': 'test.a;hello=lion;blah=blah'})
-    self.assertEqual(response.status_code, 200)
-    self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
-
-    ## autocomplete
-
-    response = self.client.put(url + '/autoComplete', {})
-    self.assertEqual(response.status_code, 405)
-
-    expected = {
-      'hello': ['lion','tiger'],
-    }
-
-    response = self.client.get(url + '/autoComplete?tagPrefix=hello&pretty=1')
-    self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
-
-    expected = {
-      'blah': ['blah'],
-      'hello': ['lion','tiger'],
-    }
-
-    response = self.client.get(url + '/autoComplete?expr[]=name=test.a&pretty=1')
-    self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
-
-    expected = {
-      'hello': ['lion'],
-    }
-
-    response = self.client.get(url + '/autoComplete?expr=name=test.a&tagPrefix=hell&valuePrefix=li&pretty=1')
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
     self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))


### PR DESCRIPTION
This PR implements a pair of endpoints to be used for providing autocomplete for tags and values based on series matching a given set of tag expressions.

```
# autocomplete list of tags starting with "tag" for series that match "tag1=value1"
/tags/autoComplete/tags?expr=tag1=value1&tagPrefix=tag

# autocomplete list of values starting with "value" for tag "tag2"
# for series that match "tag1=value1"
/tags/autoComplete/values?expr=tag1=value1&tag=tag2&valuePrefix=value
```

Both urls accept 0 or more `expr` or `expr[]` items and will return at most 100 matches.  `tagPrefix` and `valuePrefix` are both optional.