### PR TITLE
Aggregate points from carbon cache like whisper

### DIFF
--- a/webapp/graphite/readers/utils.py
+++ b/webapp/graphite/readers/utils.py
@@ -121,7 +121,7 @@ class MultiReader(BaseReader):
         return (time_info, values)
 
 
-def merge_with_cache(cached_datapoints, start, step, values, func=None, default_retention=None):
+def merge_with_cache(cached_datapoints, start, step, values, func=None, raw_step=None):
     """Merge values with datapoints from a buffer/cache."""
     consolidated = []
 
@@ -142,16 +142,16 @@ def merge_with_cache(cached_datapoints, start, step, values, func=None, default_
             return usable[-1]
         raise Exception("Invalid consolidation function: '%s'" % func)
 
-    # if we have a default_retention, start by taking only the last data point for each interval to match what whisper will do
-    if default_retention > 1:
+    # if we have a raw_step, start by taking only the last data point for each interval to match what whisper will do
+    if raw_step > 1:
         consolidated_dict = {}
         for (timestamp, value) in cached_datapoints:
-            interval = timestamp - (timestamp % default_retention)
+            interval = timestamp - (timestamp % raw_step)
             consolidated_dict[interval] = value
         cached_datapoints = consolidated_dict.items()
 
     # if we have a consolidation function and the step is not the default interval, consolidate to the requested step
-    if func and step != default_retention:
+    if func and step != raw_step:
         consolidated_dict = {}
         for (timestamp, value) in cached_datapoints:
             interval = timestamp - (timestamp % step)
@@ -189,7 +189,7 @@ def CarbonLink():
     return CarbonLink()
 
 
-def merge_with_carbonlink(metric, start, step, values, aggregation_method=None, default_retention=None):
+def merge_with_carbonlink(metric, start, step, values, aggregation_method=None, raw_step=None):
     """Get points from carbonlink and merge them with existing values."""
     cached_datapoints = []
     try:
@@ -203,4 +203,4 @@ def merge_with_carbonlink(metric, start, step, values, aggregation_method=None, 
 
     return merge_with_cache(
         cached_datapoints, start, step, values,
-        func=aggregation_method, default_retention=default_retention)
+        func=aggregation_method, raw_step=raw_step)

--- a/webapp/graphite/readers/utils.py
+++ b/webapp/graphite/readers/utils.py
@@ -159,7 +159,7 @@ def merge_with_cache(cached_datapoints, start, step, values, func=None, default_
                 consolidated_dict[interval].append(value)
             else:
                 consolidated_dict[interval] = [value]
-        consolidated = [(interval, consolidate(func, consolidated_dict[interval])) for interval in consolidated_dict]
+        consolidated = [(i, consolidate(func, consolidated_dict[i])) for i in consolidated_dict]
     # otherwise just use the points
     else:
         consolidated = cached_datapoints

--- a/webapp/graphite/readers/utils.py
+++ b/webapp/graphite/readers/utils.py
@@ -143,7 +143,7 @@ def merge_with_cache(cached_datapoints, start, step, values, func=None, default_
         raise Exception("Invalid consolidation function: '%s'" % func)
 
     # if we have a default_retention, start by taking only the last data point for each interval to match what whisper will do
-    if default_retention is not None:
+    if default_retention > 1:
         consolidated_dict = {}
         for (timestamp, value) in cached_datapoints:
             interval = timestamp - (timestamp % default_retention)

--- a/webapp/graphite/readers/whisper.py
+++ b/webapp/graphite/readers/whisper.py
@@ -43,6 +43,9 @@ class WhisperReader(BaseReader):
             self.meta_info = whisper.info(self.fs_path)
         return self.meta_info
 
+    def get_default_retention(self):
+        return self.info()['archives'][0]['secondsPerPoint']
+
     def get_intervals(self):
         start = time.time() - self.info()['maxRetention']
         end = max(stat(self.fs_path).st_mtime, start)
@@ -70,7 +73,7 @@ class WhisperReader(BaseReader):
 
         # Merge in data from carbon's cache
         values = merge_with_carbonlink(
-            self.real_metric_path, start, step, values, aggregation_method)
+            self.real_metric_path, start, step, values, aggregation_method, self.get_default_retention())
 
         return time_info, values
 

--- a/webapp/graphite/readers/whisper.py
+++ b/webapp/graphite/readers/whisper.py
@@ -43,7 +43,7 @@ class WhisperReader(BaseReader):
             self.meta_info = whisper.info(self.fs_path)
         return self.meta_info
 
-    def get_default_retention(self):
+    def get_raw_step(self):
         return self.info()['archives'][0]['secondsPerPoint']
 
     def get_intervals(self):
@@ -68,12 +68,10 @@ class WhisperReader(BaseReader):
 
         meta_info = self.info()
         aggregation_method = meta_info['aggregationMethod']
-        lowest_step = min([i['secondsPerPoint']
-                           for i in meta_info['archives']])
 
         # Merge in data from carbon's cache
         values = merge_with_carbonlink(
-            self.real_metric_path, start, step, values, aggregation_method, self.get_default_retention())
+            self.real_metric_path, start, step, values, aggregation_method, self.get_raw_step())
 
         return time_info, values
 

--- a/webapp/tests/test_readers_util.py
+++ b/webapp/tests/test_readers_util.py
@@ -74,7 +74,8 @@ class MergeWithCacheTests(TestCase):
             start=start,
             step=step,
             values=values,
-            func='sum'
+            func='sum',
+            default_retention=1
         )
 
         # Generate the expected values
@@ -83,6 +84,99 @@ class MergeWithCacheTests(TestCase):
             expected_values.append(60)
 
         self.assertEqual(expected_values, values)
+    def test_merge_with_cache_with_different_step_sum_no_default_retention(self):
+        # Data values from the Reader:
+        start = 1465844460  # (Mon Jun 13 19:01:00 UTC 2016)
+        window_size = 7200  # (2 hour)
+        step = 60           # (1 minute)
+
+        # Fill in half the data.  Nones for the rest.
+        values = range(0, window_size/2, step)
+        for i in range(0, window_size/2, step):
+            values.append(None)
+
+        # Generate data that would normally come from Carbon.
+        # Step will be different since that is what we are testing
+        cache_results = []
+        for i in range(start+window_size/2, start+window_size, 1):
+            cache_results.append((i, 1))
+
+        # merge the db results with the cached results
+        values = merge_with_cache(
+            cached_datapoints=cache_results,
+            start=start,
+            step=step,
+            values=values,
+            func='sum'
+        )
+
+        # Generate the expected values
+        expected_values = range(0, window_size/2, step)
+        for i in range(0, window_size/2, step):
+            expected_values.append(60)
+
+    def test_merge_with_cache_with_different_step_sum_same_default_retention(self):
+        # Data values from the Reader:
+        start = 1465844460  # (Mon Jun 13 19:01:00 UTC 2016)
+        window_size = 7200  # (2 hour)
+        step = 60           # (1 minute)
+
+        # Fill in half the data.  Nones for the rest.
+        values = range(0, window_size/2, step)
+        for i in range(0, window_size/2, step):
+            values.append(None)
+
+        # Generate data that would normally come from Carbon.
+        # Step will be different since that is what we are testing
+        cache_results = []
+        for i in range(start+window_size/2, start+window_size, 1):
+            cache_results.append((i, 1))
+
+        # merge the db results with the cached results
+        values = merge_with_cache(
+            cached_datapoints=cache_results,
+            start=start,
+            step=step,
+            values=values,
+            func='sum'
+        )
+
+        # Generate the expected values
+        expected_values = range(0, window_size/2, step)
+        for i in range(0, window_size/2, step):
+            expected_values.append(60)
+
+    def test_merge_with_cache_with_different_step_sum_and_default_retention(self):
+        # Data values from the Reader:
+        start = 1465844460  # (Mon Jun 13 19:01:00 UTC 2016)
+        window_size = 7200  # (2 hour)
+        step = 60           # (1 minute)
+
+        # Fill in half the data.  Nones for the rest.
+        values = range(0, window_size/2, step)
+        for i in range(0, window_size/2, step):
+            values.append(None)
+
+        # Generate data that would normally come from Carbon.
+        # Step will be different since that is what we are testing
+        cache_results = []
+        for i in range(start+window_size/2, start+window_size, 1):
+            cache_results.append((i, 1))
+
+        # merge the db results with the cached results
+        values = merge_with_cache(
+            cached_datapoints=cache_results,
+            start=start,
+            step=step,
+            values=values,
+            func='sum',
+            default_retention=30
+        )
+
+        # Generate the expected values
+        expected_values = range(0, window_size/2, step)
+        for i in range(0, window_size/2, step):
+            expected_values.append(2)
 
     def test_merge_with_cache_with_different_step_average(self):
         # Data values from the Reader:

--- a/webapp/tests/test_readers_util.py
+++ b/webapp/tests/test_readers_util.py
@@ -84,6 +84,7 @@ class MergeWithCacheTests(TestCase):
             expected_values.append(60)
 
         self.assertEqual(expected_values, values)
+
     def test_merge_with_cache_with_different_step_sum_no_default_retention(self):
         # Data values from the Reader:
         start = 1465844460  # (Mon Jun 13 19:01:00 UTC 2016)

--- a/webapp/tests/test_readers_util.py
+++ b/webapp/tests/test_readers_util.py
@@ -116,6 +116,8 @@ class MergeWithCacheTests(TestCase):
         for i in range(0, window_size/2, step):
             expected_values.append(60)
 
+        self.assertEqual(expected_values, values)
+
     def test_merge_with_cache_with_different_step_sum_same_raw_step(self):
         # Data values from the Reader:
         start = 1465844460  # (Mon Jun 13 19:01:00 UTC 2016)
@@ -146,6 +148,8 @@ class MergeWithCacheTests(TestCase):
         expected_values = range(0, window_size/2, step)
         for i in range(0, window_size/2, step):
             expected_values.append(60)
+
+        self.assertEqual(expected_values, values)
 
     def test_merge_with_cache_with_different_step_sum_and_raw_step(self):
         # Data values from the Reader:
@@ -178,6 +182,8 @@ class MergeWithCacheTests(TestCase):
         expected_values = range(0, window_size/2, step)
         for i in range(0, window_size/2, step):
             expected_values.append(2)
+
+        self.assertEqual(expected_values, values)
 
     def test_merge_with_cache_with_different_step_average(self):
         # Data values from the Reader:

--- a/webapp/tests/test_readers_util.py
+++ b/webapp/tests/test_readers_util.py
@@ -75,7 +75,7 @@ class MergeWithCacheTests(TestCase):
             step=step,
             values=values,
             func='sum',
-            default_retention=1
+            raw_step=1
         )
 
         # Generate the expected values
@@ -85,7 +85,7 @@ class MergeWithCacheTests(TestCase):
 
         self.assertEqual(expected_values, values)
 
-    def test_merge_with_cache_with_different_step_sum_no_default_retention(self):
+    def test_merge_with_cache_with_different_step_sum_no_raw_step(self):
         # Data values from the Reader:
         start = 1465844460  # (Mon Jun 13 19:01:00 UTC 2016)
         window_size = 7200  # (2 hour)
@@ -116,7 +116,7 @@ class MergeWithCacheTests(TestCase):
         for i in range(0, window_size/2, step):
             expected_values.append(60)
 
-    def test_merge_with_cache_with_different_step_sum_same_default_retention(self):
+    def test_merge_with_cache_with_different_step_sum_same_raw_step(self):
         # Data values from the Reader:
         start = 1465844460  # (Mon Jun 13 19:01:00 UTC 2016)
         window_size = 7200  # (2 hour)
@@ -147,7 +147,7 @@ class MergeWithCacheTests(TestCase):
         for i in range(0, window_size/2, step):
             expected_values.append(60)
 
-    def test_merge_with_cache_with_different_step_sum_and_default_retention(self):
+    def test_merge_with_cache_with_different_step_sum_and_raw_step(self):
         # Data values from the Reader:
         start = 1465844460  # (Mon Jun 13 19:01:00 UTC 2016)
         window_size = 7200  # (2 hour)
@@ -171,7 +171,7 @@ class MergeWithCacheTests(TestCase):
             step=step,
             values=values,
             func='sum',
-            default_retention=30
+            raw_step=30
         )
 
         # Generate the expected values

--- a/webapp/tests/test_readers_whisper.py
+++ b/webapp/tests/test_readers_whisper.py
@@ -129,6 +129,19 @@ class WhisperReadersTests(TestCase):
           self.assertEqual(int(interval.start),ts-60)
           self.assertEqual(int(interval.end), ts)
 
+    # Confirm get_default_retention works
+    def test_WhisperReader_get_default_retention(self):
+        self.create_whisper_hosts()
+        self.addCleanup(self.wipe_whisper_hosts)
+
+        reader = WhisperReader(self.worker1, 'hosts.worker1.cpu')
+        default_retention = reader.get_default_retention()
+        self.assertEqual(int(default_retention),1)
+
+        # read it again to validate cache works
+        default_retention = reader.get_default_retention()
+        self.assertEqual(int(default_retention),1)
+
     # Confirm fetch works.
     def test_WhisperReader_fetch(self):
         self.create_whisper_hosts()

--- a/webapp/tests/test_readers_whisper.py
+++ b/webapp/tests/test_readers_whisper.py
@@ -129,18 +129,18 @@ class WhisperReadersTests(TestCase):
           self.assertEqual(int(interval.start),ts-60)
           self.assertEqual(int(interval.end), ts)
 
-    # Confirm get_default_retention works
-    def test_WhisperReader_get_default_retention(self):
+    # Confirm get_raw_step works
+    def test_WhisperReader_get_raw_step(self):
         self.create_whisper_hosts()
         self.addCleanup(self.wipe_whisper_hosts)
 
         reader = WhisperReader(self.worker1, 'hosts.worker1.cpu')
-        default_retention = reader.get_default_retention()
-        self.assertEqual(int(default_retention),1)
+        raw_step = reader.get_raw_step()
+        self.assertEqual(int(raw_step),1)
 
         # read it again to validate cache works
-        default_retention = reader.get_default_retention()
-        self.assertEqual(int(default_retention),1)
+        raw_step = reader.get_raw_step()
+        self.assertEqual(int(raw_step),1)
 
     # Confirm fetch works.
     def test_WhisperReader_fetch(self):


### PR DESCRIPTION
This follows on from #2081 and simplifies the logic used to pre-aggregate the points from carbon cache before using the specified consolidation function.  It also includes a small optimization to use an array comprehension instead of `append` in a loop to build `consolidated`.

@olevchyk does this make sense to you?