### PR TITLE
TagDB caching

### DIFF
--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -372,6 +372,24 @@ DEFAULT_XFILES_FACTOR = 0
 # This should usually match the value configured in Carbon.
 #REPLICATION_FACTOR = 1
 
+#####################################
+# TagDB Settings #
+#####################################
+# Tag Database
+#TAGDB = 'graphite.tags.localdatabase.LocalDatabaseTagDB'
+
+# Time to cache seriesByTag results
+#TAGDB_CACHE_DURATION = 60
+
+# Settings for Redis TagDB
+#TAGDB_REDIS_HOST = 'localhost'
+#TAGDB_REDIS_PORT = 6379
+#TAGDB_REDIS_DB = 0
+
+# Settings for HTTP TagDB
+#TAGDB_HTTP_URL = ''
+#TAGDB_HTTP_USER = ''
+#TAGDB_HTTP_PASSWORD = ''
 
 #####################################
 # Additional Django Settings #

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -121,7 +121,11 @@ STORAGE_FINDERS = (
     'graphite.finders.remote.RemoteFinder',
     'graphite.finders.standard.StandardFinder',
 )
+
+# TagDB settings
 TAGDB = 'graphite.tags.localdatabase.LocalDatabaseTagDB'
+
+TAGDB_CACHE_DURATION = 60
 
 TAGDB_REDIS_HOST = 'localhost'
 TAGDB_REDIS_PORT = 6379

--- a/webapp/graphite/tags/base.py
+++ b/webapp/graphite/tags/base.py
@@ -2,7 +2,12 @@
 import abc
 import re
 
+from django.conf import settings
+from django.core.cache import cache
+
+from graphite.logger import log
 from graphite.tags.utils import TaggedSeries
+from graphite.util import logtime
 
 
 class BaseTagDB(object):
@@ -12,8 +17,8 @@ class BaseTagDB(object):
     """Initialize the tag db."""
     pass
 
-  @abc.abstractmethod
-  def find_series(self, tags):
+  @logtime(custom_msg=True, custom_name=True)
+  def find_series(self, tags, msg_setter, name_setter):
     """
     Find series by tag, accepts a list of tag specifiers and returns a list of matching paths.
 
@@ -33,6 +38,23 @@ class BaseTagDB(object):
     Regular expression conditions are treated as being anchored at the start of the value.
 
     Matching paths are returned as a list of strings.
+    """
+    name_setter('%s.%s.find_series' % (self.__module__, self.__class__.__name__))
+
+    cacheKey = 'TagDB.find_series:' + ':'.join(sorted(tags))
+    result = cache.get(cacheKey)
+    if result is not None:
+      msg_setter('completed (cached) in')
+    else:
+      result = self._find_series(tags)
+      cache.set(cacheKey, result, settings.TAGDB_CACHE_DURATION)
+
+    return result
+
+  @abc.abstractmethod
+  def _find_series(self, tags):
+    """
+    Internal function called by find_series, follows the same semantics allowing base class to implement caching
     """
     pass
 

--- a/webapp/graphite/tags/base.py
+++ b/webapp/graphite/tags/base.py
@@ -5,7 +5,6 @@ import re
 from django.conf import settings
 from django.core.cache import cache
 
-from graphite.logger import log
 from graphite.tags.utils import TaggedSeries
 from graphite.util import logtime
 

--- a/webapp/graphite/tags/base.py
+++ b/webapp/graphite/tags/base.py
@@ -1,0 +1,140 @@
+"""Base tag database"""
+import abc
+import re
+
+from graphite.tags.utils import TaggedSeries
+
+
+class BaseTagDB(object):
+  __metaclass__ = abc.ABCMeta
+
+  def __init__(self):
+    """Initialize the tag db."""
+    pass
+
+  @abc.abstractmethod
+  def find_series(self, tags):
+    """
+    Find series by tag, accepts a list of tag specifiers and returns a list of matching paths.
+
+    Tags specifiers are strings, and may have the following formats:
+
+    .. code-block:: none
+
+      tag=spec    tag value exactly matches spec
+      tag!=spec   tag value does not exactly match spec
+      tag=~value  tag value matches the regular expression spec
+      tag!=~spec  tag value does not match the regular expression spec
+
+    Any tag spec that matches an empty value is considered to match series that don't have that tag.
+
+    At least one tag spec must require a non-empty value.
+
+    Regular expression conditions are treated as being anchored at the start of the value.
+
+    Matching paths are returned as a list of strings.
+    """
+    pass
+
+  @abc.abstractmethod
+  def get_series(self, path):
+    """
+    Get series by path, accepts a path string and returns a TaggedSeries object describing the series.
+
+    If the path is not found in the TagDB, returns None.
+    """
+    pass
+
+  @abc.abstractmethod
+  def list_tags(self, tagFilter=None):
+    """
+    List defined tags, returns a list of dictionaries describing the tags stored in the TagDB.
+
+    Each tag dict contains the key "tag" which holds the name of the tag.  Additional keys may be returned.
+
+    .. code-block:: none
+
+      [
+        {
+          'tag': 'tag1',
+        },
+      ]
+
+    Accepts an optional filter parameter which is a regular expression used to filter the list of returned tags
+    """
+    pass
+
+  @abc.abstractmethod
+  def get_tag(self, tag, valueFilter=None):
+    """
+    Get details of a particular tag, accepts a tag name and returns a dict describing the tag.
+
+    The dict contains the key "tag" which holds the name of the tag.  It also includes a "values" key,
+    which holds a list of the values for each tag.  See list_values() for the structure of each value.
+
+    .. code-block:: none
+
+      {
+        'tag': 'tag1',
+        'values': [
+          {
+            'value': 'value1',
+            'count': 1,
+          }
+        ],
+      }
+
+    Accepts an optional filter parameter which is a regular expression used to filter the list of returned tags
+    """
+    pass
+
+  @abc.abstractmethod
+  def list_values(self, tag, valueFilter=None):
+    """
+    List values for a particular tag, returns a list of dictionaries describing the values stored in the TagDB.
+
+    Each value dict contains the key "value" which holds the value, and the key "count" which is the number of
+    series that have that value.  Additional keys may be returned.
+
+    .. code-block:: none
+
+      [
+        {
+          'value': 'value1',
+          'count': 1,
+        },
+      ]
+
+    Accepts an optional filter parameter which is a regular expression used to filter the list of returned tags
+    """
+    pass
+
+  @abc.abstractmethod
+  def tag_series(self, series):
+    """
+    Enter series into database.  Accepts a series string, upserts into the TagDB and returns the canonicalized series name.
+    """
+    pass
+
+  @abc.abstractmethod
+  def del_series(self, series):
+    """
+    Remove series from database.  Accepts a series string and returns True
+    """
+    pass
+
+  @staticmethod
+  def parse(path):
+    return TaggedSeries.parse(path)
+
+  @staticmethod
+  def parse_tagspec(tagspec):
+    m = re.match('^([^;!=]+)(!?=~?)([^;]*)$', tagspec)
+    if m is None:
+      raise ValueError("Invalid tagspec %s" % tagspec)
+
+    tag = m.group(1)
+    operator = m.group(2)
+    spec = m.group(3)
+
+    return (tag, operator, spec)

--- a/webapp/graphite/tags/http.py
+++ b/webapp/graphite/tags/http.py
@@ -4,7 +4,6 @@ from urllib import quote
 import json
 
 from django.conf import settings
-from graphite.util import logtime
 from graphite.http_pool import http
 
 from graphite.tags.base import BaseTagDB
@@ -40,8 +39,7 @@ class HttpTagDB(BaseTagDB):
 
     return json.loads(result.data.decode('utf-8'))
 
-  @logtime()
-  def find_series(self, tags):
+  def _find_series(self, tags):
     return self.request('POST', '/tags/findSeries?' + '&'.join([('expr=%s' % quote(tag)) for tag in tags]))
 
   def get_series(self, path):

--- a/webapp/graphite/tags/http.py
+++ b/webapp/graphite/tags/http.py
@@ -7,7 +7,8 @@ from django.conf import settings
 from graphite.util import logtime
 from graphite.http_pool import http
 
-from graphite.tags.utils import BaseTagDB
+from graphite.tags.base import BaseTagDB
+
 
 class HttpTagDB(BaseTagDB):
   """

--- a/webapp/graphite/tags/localdatabase.py
+++ b/webapp/graphite/tags/localdatabase.py
@@ -88,7 +88,7 @@ class LocalDatabaseTagDB(BaseTagDB):
 
     return sql, params, filters
 
-  def find_series(self, tags):
+  def _find_series(self, tags):
     sql, params, filters = self.find_series_query(tags)
 
     def matches_filters(path):

--- a/webapp/graphite/tags/localdatabase.py
+++ b/webapp/graphite/tags/localdatabase.py
@@ -3,7 +3,8 @@ import re
 from django.db import connection
 from hashlib import sha256
 
-from graphite.tags.utils import BaseTagDB, TaggedSeries
+from graphite.tags.base import BaseTagDB, TaggedSeries
+
 
 class LocalDatabaseTagDB(BaseTagDB):
   def find_series_query(self, tags):

--- a/webapp/graphite/tags/redis.py
+++ b/webapp/graphite/tags/redis.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import re
 
 from django.conf import settings
-from graphite.util import logtime
 
 from graphite.tags.base import BaseTagDB, TaggedSeries
 
@@ -29,8 +28,7 @@ class RedisTagDB(BaseTagDB):
 
     self.r = Redis(host=settings.TAGDB_REDIS_HOST,port=settings.TAGDB_REDIS_PORT,db=settings.TAGDB_REDIS_DB)
 
-  @logtime()
-  def find_series(self, tags):
+  def _find_series(self, tags):
     selector = None
     selector_cnt = None
     filters = []

--- a/webapp/graphite/tags/redis.py
+++ b/webapp/graphite/tags/redis.py
@@ -5,7 +5,8 @@ import re
 from django.conf import settings
 from graphite.util import logtime
 
-from graphite.tags.utils import BaseTagDB, TaggedSeries
+from graphite.tags.base import BaseTagDB, TaggedSeries
+
 
 class RedisTagDB(BaseTagDB):
   """

--- a/webapp/graphite/tags/utils.py
+++ b/webapp/graphite/tags/utils.py
@@ -1,5 +1,4 @@
 """Utility functions for tag databases."""
-import abc
 import re
 
 from hashlib import sha256
@@ -8,6 +7,12 @@ try:
     from importlib import import_module
 except ImportError:  # python < 2.7 compatibility
     from django.utils.importlib import import_module
+
+
+def get_tagdb(tagdb_path):
+    module_name, class_name = tagdb_path.rsplit('.', 1)
+    module = import_module(module_name)
+    return getattr(module, class_name)()
 
 
 class TaggedSeries(object):
@@ -114,144 +119,3 @@ class TaggedSeries(object):
   @property
   def path(self):
     return self.__class__.format(self.tags)
-
-
-class BaseTagDB(object):
-  __metaclass__ = abc.ABCMeta
-
-  def __init__(self):
-    """Initialize the tag db."""
-    pass
-
-  @abc.abstractmethod
-  def find_series(self, tags):
-    """
-    Find series by tag, accepts a list of tag specifiers and returns a list of matching paths.
-
-    Tags specifiers are strings, and may have the following formats:
-
-    .. code-block:: none
-
-      tag=spec    tag value exactly matches spec
-      tag!=spec   tag value does not exactly match spec
-      tag=~value  tag value matches the regular expression spec
-      tag!=~spec  tag value does not match the regular expression spec
-
-    Any tag spec that matches an empty value is considered to match series that don't have that tag.
-
-    At least one tag spec must require a non-empty value.
-
-    Regular expression conditions are treated as being anchored at the start of the value.
-
-    Matching paths are returned as a list of strings.
-    """
-    pass
-
-  @abc.abstractmethod
-  def get_series(self, path):
-    """
-    Get series by path, accepts a path string and returns a TaggedSeries object describing the series.
-
-    If the path is not found in the TagDB, returns None.
-    """
-    pass
-
-  @abc.abstractmethod
-  def list_tags(self, tagFilter=None):
-    """
-    List defined tags, returns a list of dictionaries describing the tags stored in the TagDB.
-
-    Each tag dict contains the key "tag" which holds the name of the tag.  Additional keys may be returned.
-
-    .. code-block:: none
-
-      [
-        {
-          'tag': 'tag1',
-        },
-      ]
-
-    Accepts an optional filter parameter which is a regular expression used to filter the list of returned tags
-    """
-    pass
-
-  @abc.abstractmethod
-  def get_tag(self, tag, valueFilter=None):
-    """
-    Get details of a particular tag, accepts a tag name and returns a dict describing the tag.
-
-    The dict contains the key "tag" which holds the name of the tag.  It also includes a "values" key,
-    which holds a list of the values for each tag.  See list_values() for the structure of each value.
-
-    .. code-block:: none
-
-      {
-        'tag': 'tag1',
-        'values': [
-          {
-            'value': 'value1',
-            'count': 1,
-          }
-        ],
-      }
-
-    Accepts an optional filter parameter which is a regular expression used to filter the list of returned tags
-    """
-    pass
-
-  @abc.abstractmethod
-  def list_values(self, tag, valueFilter=None):
-    """
-    List values for a particular tag, returns a list of dictionaries describing the values stored in the TagDB.
-
-    Each value dict contains the key "value" which holds the value, and the key "count" which is the number of
-    series that have that value.  Additional keys may be returned.
-
-    .. code-block:: none
-
-      [
-        {
-          'value': 'value1',
-          'count': 1,
-        },
-      ]
-
-    Accepts an optional filter parameter which is a regular expression used to filter the list of returned tags
-    """
-    pass
-
-  @abc.abstractmethod
-  def tag_series(self, series):
-    """
-    Enter series into database.  Accepts a series string, upserts into the TagDB and returns the canonicalized series name.
-    """
-    pass
-
-  @abc.abstractmethod
-  def del_series(self, series):
-    """
-    Remove series from database.  Accepts a series string and returns True
-    """
-    pass
-
-  @staticmethod
-  def parse(path):
-    return TaggedSeries.parse(path)
-
-  @staticmethod
-  def parse_tagspec(tagspec):
-    m = re.match('^([^;!=]+)(!?=~?)([^;]*)$', tagspec)
-    if m is None:
-      raise ValueError("Invalid tagspec %s" % tagspec)
-
-    tag = m.group(1)
-    operator = m.group(2)
-    spec = m.group(3)
-
-    return (tag, operator, spec)
-
-
-def get_tagdb(tagdb_path):
-    module_name, class_name = tagdb_path.rsplit('.', 1)
-    module = import_module(module_name)
-    return getattr(module, class_name)()


### PR DESCRIPTION
This PR implements support for caching the results of calls to the TagDB `find_series` function.

It avoids having to re-implement the caching code in each TagDB by updating them to implement `_find_series` and adding a new `find_series` in `BaseTagDB` that handles the caching.  A TagDB may handle caching itself by implementing `find_series` directly (though it will still need to provide an implementation of `_find_series` as well to satisfy the metaclass requirements).

I also refactored the `BaseTagDB` class into its own file, and added support in the `@logtime` decorator for logging time taken for failures (exception raised by function) and for customizing the module name in the log output.

Finally, I added a new setting `TAGDB_CACHE_DURATION` (default to 60s) and added the `TAGDB_*` settings to `local_settings.py.example` with some comments.