### PR TITLE
Fix caching in _merge_results and add tests

### DIFF
--- a/webapp/tests/test_render_datalib.py
+++ b/webapp/tests/test_render_datalib.py
@@ -1,4 +1,5 @@
 import pytz
+import collections
 
 from datetime import datetime
 

--- a/webapp/tests/test_render_datalib.py
+++ b/webapp/tests/test_render_datalib.py
@@ -319,6 +319,39 @@ class DatalibFunctionTest(TestCase):
       ]
       self.assertEqual(results, expectedResults)
 
+    @mock.patch('graphite.logger.log.debug')
+    def test__merge_results_no_results(self, log_debug):
+      pathExpr = 'collectd.test-db.load.value'
+      startTime=datetime(1970, 1, 1, 0, 10, 0, 0, pytz.timezone(settings.TIME_ZONE)),
+      endTime=datetime(1970, 1, 1, 0, 20, 0, 0, pytz.timezone(settings.TIME_ZONE))
+      timeInfo = [startTime, endTime, 60]
+      result_queue = [
+                      [pathExpr, None],
+                     ]
+
+      seriesList = {}
+      requestContext = self._build_requestContext(startTime, endTime)
+      results = _merge_results(pathExpr, startTime, endTime, result_queue, seriesList, requestContext)
+      expectedResults = []
+      self.assertEqual(results, expectedResults)
+      log_debug.assert_called_with("render.datalib.fetchData :: no results for %s.fetch(%s, %s)" % (pathExpr, startTime, endTime))
+
+    @mock.patch('graphite.logger.log.exception')
+    def test__merge_results_bad_results(self, log_exception):
+      pathExpr = 'collectd.test-db.load.value'
+      startTime=datetime(1970, 1, 1, 0, 10, 0, 0, pytz.timezone(settings.TIME_ZONE)),
+      endTime=datetime(1970, 1, 1, 0, 20, 0, 0, pytz.timezone(settings.TIME_ZONE))
+      timeInfo = [startTime, endTime, 60]
+      result_queue = [
+                      [pathExpr, ['invalid input']],
+                     ]
+
+      seriesList = {}
+      requestContext = self._build_requestContext(startTime, endTime)
+      with self.assertRaises(Exception):
+        _merge_results(pathExpr, startTime, endTime, result_queue, seriesList, requestContext)
+        log_exception.assert_called_with("could not parse timeInfo/values from metric '%s': %s" % (pathExpr, 'need more than 1 value to unpack'))
+
     def test__merge_results_multiple_series(self):
       pathExpr = 'collectd.test-db.load.value'
       startTime=datetime(1970, 1, 1, 0, 10, 0, 0, pytz.timezone(settings.TIME_ZONE)),
@@ -342,6 +375,29 @@ class DatalibFunctionTest(TestCase):
       ]
       self.assertEqual(results, expectedResults)
 
+    def test__merge_results_multiple_series_remote_prefetch_data(self):
+      pathExpr = 'collectd.test-db.load.value'
+      startTime=datetime(1970, 1, 1, 0, 10, 0, 0, pytz.timezone(settings.TIME_ZONE)),
+      endTime=datetime(1970, 1, 1, 0, 20, 0, 0, pytz.timezone(settings.TIME_ZONE))
+      timeInfo = [startTime, endTime, 60]
+      result_queue = [
+                      [pathExpr, [timeInfo, [0,1,2,3,4,None,None,None,None,None]]],
+                      [pathExpr, [timeInfo, [None,None,None,None,None,5,6,7,8,9]]],
+                      [pathExpr, [timeInfo, [None,None,None,None,None,None,None,7,8,9]]],
+                      [pathExpr, [timeInfo, [0,1,2,3,4,None,None,7,8,9]]]
+                     ]
+
+      seriesList = {
+                      'collectd.test-db.cpu.value': TimeSeries("collectd.test-db.cpu.value", startTime, endTime, 60, [0,1,2,3,4,5,6,7,8,9])
+                   }
+      requestContext = self._build_requestContext(startTime, endTime)
+      with self.settings(REMOTE_PREFETCH_DATA=True):
+        results = _merge_results(pathExpr, startTime, endTime, result_queue, seriesList, requestContext)
+      expectedResults = [
+          TimeSeries("collectd.test-db.cpu.value", startTime, endTime, 60, [0,1,2,3,4,5,6,7,8,9]),
+          TimeSeries("collectd.test-db.load.value", startTime, endTime, 60, [0,1,2,3,4,5,6,7,8,9]),
+      ]
+      self.assertEqual(results, expectedResults)
 
     def test__merge_results_no_remote_store_merge_results(self):
       pathExpr = 'collectd.test-db.load.value'

--- a/webapp/tests/test_render_datalib.py
+++ b/webapp/tests/test_render_datalib.py
@@ -1,5 +1,4 @@
 import pytz
-import collections
 
 from datetime import datetime
 


### PR DESCRIPTION
While putting test cases together, I noticed I couldn't get this conditional to be true:
```
      # To avoid repeatedly recounting the 'Nones' in series we've already seen, 
      # cache the best known count so far in a dict. 
      if known.name in series_best_nones: 
        known_nones = series_best_nones[known.name]
```

I believe there are two issues.
1. The base case for a key not existing in series_best_nones is missing.
2. The declaration of series_best_nones dictionary is inside the loop.

Also added more test cases for _merge_results() and test cases for FetchData().