### PR TITLE
use timezone-aware dates in hitcount, update epoch to handle naive dates

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -4042,11 +4042,11 @@ def hitcount(requestContext, seriesList, intervalString, alignToInterval = False
     requestContext = requestContext.copy()
     s = requestContext['startTime']
     if interval >= DAY:
-      requestContext['startTime'] = datetime(s.year, s.month, s.day)
+      requestContext['startTime'] = datetime(s.year, s.month, s.day, tzinfo = s.tzinfo)
     elif interval >= HOUR:
-      requestContext['startTime'] = datetime(s.year, s.month, s.day, s.hour)
+      requestContext['startTime'] = datetime(s.year, s.month, s.day, s.hour, tzinfo = s.tzinfo)
     elif interval >= MINUTE:
-      requestContext['startTime'] = datetime(s.year, s.month, s.day, s.hour, s.minute)
+      requestContext['startTime'] = datetime(s.year, s.month, s.day, s.hour, s.minute, tzinfo = s.tzinfo)
 
     # Ignore the originally fetched data and pull new using
     # the modified requestContext.

--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -57,6 +57,8 @@ def epoch(dt):
   """
   Returns the epoch timestamp of a timezone-aware datetime object.
   """
+  if not dt.tzinfo:
+    return calendar.timegm(make_aware(dt, pytz.timezone(settings.TIME_ZONE)).astimezone(pytz.utc).timetuple())
   return calendar.timegm(dt.astimezone(pytz.utc).timetuple())
 
 

--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -19,6 +19,7 @@ import time
 import sys
 import calendar
 import pytz
+import traceback
 from datetime import datetime
 from os.path import splitext, basename, relpath
 from shutil import move
@@ -58,6 +59,8 @@ def epoch(dt):
   Returns the epoch timestamp of a timezone-aware datetime object.
   """
   if not dt.tzinfo:
+    tb = traceback.extract_stack(None, 2)
+    log.warning('epoch() called with non-timezone-aware datetime in %s at %s:%d' % (tb[0][2], tb[0][0], tb[0][1]))
     return calendar.timegm(make_aware(dt, pytz.timezone(settings.TIME_ZONE)).astimezone(pytz.utc).timetuple())
   return calendar.timegm(dt.astimezone(pytz.utc).timetuple())
 

--- a/webapp/tests/test_util.py
+++ b/webapp/tests/test_util.py
@@ -3,6 +3,8 @@ import shutil
 import socket
 import time
 import whisper
+import pytz
+from datetime import datetime
 
 from .base import TestCase
 
@@ -12,6 +14,26 @@ from graphite.wsgi import application  # NOQA makes sure we have a working WSGI 
 
 
 class UtilTest(TestCase):
+
+    def test_epoch_tz_aware(self):
+        dt = pytz.utc.localize(datetime(1970, 1, 1, 0, 10, 0, 0))
+        self.assertEqual(util.epoch(dt), 600)
+
+        dt = pytz.timezone('Europe/Berlin').localize(datetime(1970, 1, 1, 1, 10, 0, 0))
+        self.assertEqual(util.epoch(dt), 600)
+
+    def test_epoch_naive(self):
+        with self.settings(TIME_ZONE='UTC'):
+            dt = datetime(1970, 1, 1, 0, 10, 0, 0)
+            self.assertEqual(util.epoch(dt), 600)
+
+        with self.settings(TIME_ZONE='Europe/Berlin'):
+            dt = datetime(1970, 1, 1, 1, 10, 0, 0)
+            self.assertEqual(util.epoch(dt), 600)
+
+    def test_epoch_to_dt(self):
+        dt = pytz.utc.localize(datetime(1970, 1, 1, 0, 10, 0, 0))
+        self.assertEqual(util.epoch_to_dt(600), dt)
 
     def test_is_local_interface_ipv4(self):
         addresses = ['127.0.0.1', '127.0.0.1:8080', '8.8.8.8']


### PR DESCRIPTION
The `hitcount` function creates a `requestContext['startTime']` date that isn't timezone-aware, which can cause problems. This patch updates it to pass the `tzinfo` parameter like `smartSummarize` does.

The `epoch` function fails when passed a naive datetime (without timezone info), this patch updates it to interpret it as a date in the timezone specified in settings.

This patch also adds test for `epoch` and `epoch_to_dt`.