### PR TITLE
Add REMOTE_USER_MIDDLEWARE configuration option and fix REMOTE_USER_BACKEND documentation

### DIFF
--- a/docs/config-local-settings.rst
+++ b/docs/config-local-settings.rst
@@ -310,7 +310,7 @@ USE_REMOTE_USER_AUTHENTICATION
   Enables the use of the Django `RemoteUserBackend` authentication backend. See the `Django documentation <https://docs.djangoproject.com/en/dev/howto/auth-remote-user/>`__ for further details.
 
 REMOTE_USER_BACKEND
-  `Default: "django.contrib.auth.middleware.RemoteUserMiddleware"`
+  `Default: "django.contrib.auth.middleware.RemoteUserBackend"`
 
   Enables the use of an alternative remote authentication backend.
 

--- a/docs/config-local-settings.rst
+++ b/docs/config-local-settings.rst
@@ -314,6 +314,11 @@ REMOTE_USER_BACKEND
 
   Enables the use of an alternative remote authentication backend.
 
+REMOTE_USER_MIDDLEWARE
+  `Default: "django.contrib.auth.middleware.RemoteUserMiddleware"`
+
+  Enables the use of an alternative remote authentication middleware.
+
 LOGIN_URL
   `Default: /account/login`
 

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -156,6 +156,7 @@ LDAP_USER_DN_TEMPLATE = None
 #Set this to True to delegate authentication to the web server
 USE_REMOTE_USER_AUTHENTICATION = False
 REMOTE_USER_BACKEND = "" # Provide an alternate or subclassed backend
+REMOTE_USER_MIDDLEWARE = "" # Provide an alternate or subclassed middleware
 AUTHENTICATION_BACKENDS=[]
 
 # Django 1.5 requires this so we set a default but warn the user
@@ -289,7 +290,10 @@ if USE_LDAP_AUTH and LDAP_URI is None:
   LDAP_URI = "ldap://%s:%d/" % (LDAP_SERVER, LDAP_PORT)
 
 if USE_REMOTE_USER_AUTHENTICATION or REMOTE_USER_BACKEND:
-  MIDDLEWARE += ('django.contrib.auth.middleware.RemoteUserMiddleware',)
+  if REMOTE_USER_MIDDLEWARE:
+    MIDDLEWARE += (REMOTE_USER_MIDDLEWARE,)
+  else:
+    MIDDLEWARE += ('django.contrib.auth.middleware.RemoteUserMiddleware',)
   if DJANGO_VERSION < (1, 10):
       MIDDLEWARE_CLASSES = MIDDLEWARE
   if REMOTE_USER_BACKEND:


### PR DESCRIPTION
This is useful if you want to use a custom HTTP header for authentication.

The current code will always append the Djangos `RemoteUserMiddleware`  to `MIDDLEWARE`. Even if you add your own middleware (using Django imports at the bottom of `local_settings.py`), the `RemoteUserMiddleware` will always be executed last and your custom middleware will do nothing.

It's possible to hardcode a full set of middlewares at the bottom of `local_settings.py` (which is what I am doing at the moment), but it's will probably break with future updates.

I also fixed the `REMOTE_USER_BACKEND` documentation which was confusing.