### PR TITLE
Use GET for HTTP TagDB findSeries requests

### DIFF
--- a/webapp/graphite/tags/http.py
+++ b/webapp/graphite/tags/http.py
@@ -40,7 +40,7 @@ class HttpTagDB(BaseTagDB):
     return json.loads(result.data.decode('utf-8'))
 
   def _find_series(self, tags):
-    return self.request('POST', '/tags/findSeries?' + '&'.join([('expr=%s' % quote(tag)) for tag in tags]))
+    return self.request('GET', '/tags/findSeries?' + '&'.join([('expr=%s' % quote(tag)) for tag in tags]))
 
   def get_series(self, path):
     parsed = self.parse(path)


### PR DESCRIPTION
This PR switches the HTTP TagDB code to use GET for its requests, since currently it sends a POST with the tags expressions in the URL and an empty body.