### PR TITLE
Fix name of variable from xFilesFactor to xfilesfactor

### DIFF
--- a/docs/config-carbon.rst
+++ b/docs/config-carbon.rst
@@ -99,7 +99,7 @@ Important notes before continuing:
 
 * This file is optional.  If it is not present, defaults will be used.
 * There is no ``retentions`` line.  Instead, there are ``xFilesFactor`` and/or ``aggregationMethod`` lines.
-* ``xFilesFactor`` should be a floating point number between 0 and 1, and specifies what fraction of the previous retention level's slots must have non-null values in order to aggregate to a non-null value.  The default is 0.5.
+* ``xfilesfactor`` should be a floating point number between 0 and 1, and specifies what fraction of the previous retention level's slots must have non-null values in order to aggregate to a non-null value.  The default is 0.5.
 * ``aggregationMethod`` specifies the function used to aggregate values for the next retention level.  Legal methods are ``average``, ``sum``, ``min``, ``max``, and ``last``. The default is ``average``.
 * These are set at the time the first metric is sent.
 * Changing this file will not affect .wsp files already created on disk. Use whisper-set-aggregation-method.py to change those.


### PR DESCRIPTION
Proof of change.
I tried to find why the carbon don`t set xFilesFactor into my configuration:

[carbon]
pattern = ^carbon\.
xFilesFactor = 0.1
retentions = 1m:30d,15m:91d,1h:3y
aggregation-method = max

I use ceres as storage backed of graphite. I expect in .ceres_node something like that:
{"timeStep": 60, "retentions": [[60, 129600]], "xFilesFactor": 0.1, "aggregationMethod": "average"}
but xFilesFactor still have value 0.5 (value by-default)
I looked for the sources and found this expression:

# grep -R "xFilesFactor" lib64/
lib64/carbon/database.py:      options['xFilesFactor'] = options.pop('xfilesfactor')
lib64/carbon/database.py:      options['xFilesFactor'] = options.pop('xfilesfactor')