### PR TITLE
removeEmptySeries xFilesFactor support

### DIFF
--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -2259,16 +2259,56 @@ class FunctionsTest(TestCase):
 
     def test_check_empty_lists(self):
         seriesList = []
-        config = [[1000, 100, 10, 0], []]
+        config = [[1000, 100, 10, 0], [2000, 200, None, None], [None, None, None, None]]
         for i, c in enumerate(config):
-            seriesList.append(TimeSeries('Test(%d)' % i, 0, 0, 0, c))
+            seriesList.append(TimeSeries('Test(%d)' % i, 0, 3, 1, c))
 
-        self.assertTrue(functions.safeIsNotEmpty(seriesList[0]))
-        self.assertFalse(functions.safeIsNotEmpty(seriesList[1]))
+        self.assertTrue(functions.xffValues(seriesList[0], 0))
+        self.assertTrue(functions.xffValues(seriesList[0], 0.25))
+        self.assertTrue(functions.xffValues(seriesList[0], 0.5))
+        self.assertTrue(functions.xffValues(seriesList[0], 0.75))
+        self.assertTrue(functions.xffValues(seriesList[0], 1))
+
+        self.assertTrue(functions.xffValues(seriesList[1], 0))
+        self.assertTrue(functions.xffValues(seriesList[1], 0.25))
+        self.assertTrue(functions.xffValues(seriesList[1], 0.5))
+        self.assertFalse(functions.xffValues(seriesList[1], 0.75))
+        self.assertFalse(functions.xffValues(seriesList[1], 1))
+
+        self.assertFalse(functions.xffValues(seriesList[2], 0))
+        self.assertFalse(functions.xffValues(seriesList[2], 0.25))
+        self.assertFalse(functions.xffValues(seriesList[2], 0.5))
+        self.assertFalse(functions.xffValues(seriesList[2], 0.75))
+        self.assertFalse(functions.xffValues(seriesList[2], 1))
 
         result = functions.removeEmptySeries({}, seriesList)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0][0], 1000)
+        self.assertEqual(result[1][0], 2000)
 
-        self.assertEqual(1, len(result))
+        result = functions.removeEmptySeries({}, seriesList, 0)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0][0], 1000)
+        self.assertEqual(result[1][0], 2000)
+
+        result = functions.removeEmptySeries({}, seriesList, 0.25)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0][0], 1000)
+        self.assertEqual(result[1][0], 2000)
+
+        result = functions.removeEmptySeries({}, seriesList, 0.5)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0][0], 1000)
+        self.assertEqual(result[1][0], 2000)
+
+        result = functions.removeEmptySeries({}, seriesList, 0.75)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][0], 1000)
+
+        result = functions.removeEmptySeries({}, seriesList, 1)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][0], 1000)
+
 
     def test_unique(self):
         seriesList = [

--- a/webapp/tests/test_util.py
+++ b/webapp/tests/test_util.py
@@ -4,6 +4,7 @@ import socket
 import time
 import whisper
 import pytz
+
 from datetime import datetime
 from mock import patch
 
@@ -49,9 +50,21 @@ class UtilTest(TestCase):
         self.assertEqual( results, [True, True, False] )
 
     def test_is_local_interface_ipv6(self):
+        # we need to know whether the host provides an ipv6 callback address
+        ipv6_support = True
+        try:
+            sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+            sock.bind( ('::1', 0) )
+            sock.close()
+        except Exception:
+            ipv6_support = False
+
         addresses = ['::1', '[::1]:8080', '[::1]', '::1:8080']
         results = [ util.is_local_interface(a) for a in addresses ]
-        self.assertEqual( results, [True, True, True, False] )
+        if ipv6_support:
+            self.assertEqual( results, [True, True, True, False] )
+        else:
+            self.assertEqual( results, [False, False, False, False] )
 
     def test_is_local_interface_dns(self):
         addresses = ['localhost', socket.gethostname(), 'google.com']


### PR DESCRIPTION
This PR adds support for passing an optional `xFilesFactor` parameter to `removeEmptySeries()`, so the user can control the threshold for considering a series to be non-empty.  This can be useful for removing series that have patchy data eg before using a function like `averageSeries()`.

As `removeEmptySeries()` now uses `xffValues()`, the now-unused `safeIsNotEmpty()` function has been removed.

This PR also includes a fix for running tests on hosts that don't provide an ipv6 address for the local interface, as it seems that the latest travis-ci update uses an ipv4-only `lo`.