### PR TITLE
[Issue #2101] Use WEBAPP_VERSION in documentation link

### DIFF
--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -113,7 +113,8 @@ REMOTE_RENDER_CONNECT_TIMEOUT = 1.0
 
 #Miscellaneous settings
 SMTP_SERVER = "localhost"
-DOCUMENTATION_URL = "http://graphite.readthedocs.io/"
+DOCUMENTATION_VERSION = 'latest' if 'dev' in WEBAPP_VERSION else WEBAPP_VERSION
+DOCUMENTATION_URL = 'https://graphite.readthedocs.io/en/{}/'.format(DOCUMENTATION_VERSION)
 ALLOW_ANONYMOUS_CLI = True
 LEGEND_MAX_ITEMS = 10
 RRD_CF = 'AVERAGE'


### PR DESCRIPTION
Fixed #2101.

Will link to `latest` if version contains `-dev`.

I also made the URL https.