### PR TITLE
Move /metrics/index.json handling into finders & use worker pool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   - TOXENV=py27-django18-pyparsing2
   - TOXENV=py27-django19-pyparsing2
   - TOXENV=py27-django110-pyparsing2
-  - TOXENV=py27-django111-pyparsing2
+  - TOXENV=py27-django111-pyparsing2-rrdtool
   - TOXENV=py27-django111-pyparsing2-mysql TEST_MYSQL_PASSWORD=graphite
   - TOXENV=py27-django111-pyparsing2-postgresql TEST_POSTGRESQL_PASSWORD=graphite
   - TOXENV=docs
@@ -16,6 +16,7 @@ addons:
   apt:
     packages:
       - libcairo2-dev
+      - librrd-dev
   postgresql: "9.5"
 
 services:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-	py27-django1{8,9,10,11}-pyparsing2,
-	py27-django111-pyparsing2-{mysql,postgresql,rrdtool},
+	py27-django1{8,9,10,11}-pyparsing2{,-mysql,-postgresql,-rrdtool},
 	lint, docs
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
 	py27-django1{8,9,10,11}-pyparsing2,
-	py27-django111-pyparsing2-{mysql,postgresql},
+	py27-django111-pyparsing2-{mysql,postgresql,rrdtool},
 	lint, docs
 
 [testenv]
@@ -38,6 +38,7 @@ deps =
 	redis
 	mysql: mysqlclient
 	postgresql: psycopg2
+	rrdtool: rrdtool
 
 [testenv:docs]
 basepython = python2.7

--- a/webapp/graphite/finders/ceres.py
+++ b/webapp/graphite/finders/ceres.py
@@ -58,7 +58,7 @@ class CeresFinder(BaseFinder):
     def get_index(self, requestContext=None):
         matches = []
 
-        for root, dirs, files in walk(settings.CERES_DIR):
+        for root, _, files in walk(settings.CERES_DIR):
           root = root.replace(settings.CERES_DIR, '')
           for filename in files:
             if filename == '.ceres-node':

--- a/webapp/graphite/finders/ceres.py
+++ b/webapp/graphite/finders/ceres.py
@@ -2,6 +2,13 @@ from __future__ import absolute_import
 
 import os.path
 
+# Use the built-in version of walk if possible, otherwise
+# use the scandir module version
+try:
+    from os import walk
+except ImportError:
+    from scandir import walk
+
 from glob import glob
 from ceres import CeresTree, CeresNode
 from django.conf import settings
@@ -47,3 +54,17 @@ class CeresFinder(BaseFinder):
 
                 elif os.path.isdir(fs_path):
                     yield BranchNode(metric_path)
+
+    def get_index(self, requestContext=None):
+        matches = []
+
+        for root, dirs, files in walk(settings.CERES_DIR):
+          root = root.replace(settings.CERES_DIR, '')
+          for filename in files:
+            if filename == '.ceres-node':
+              matches.append(root)
+
+        return sorted([
+          m.replace('/', '.').lstrip('.')
+          for m in matches
+        ])

--- a/webapp/graphite/finders/ceres.py
+++ b/webapp/graphite/finders/ceres.py
@@ -55,7 +55,7 @@ class CeresFinder(BaseFinder):
                 elif os.path.isdir(fs_path):
                     yield BranchNode(metric_path)
 
-    def get_index(self, requestContext=None):
+    def get_index(self, requestContext):
         matches = []
 
         for root, _, files in walk(settings.CERES_DIR):

--- a/webapp/graphite/finders/remote.py
+++ b/webapp/graphite/finders/remote.py
@@ -126,10 +126,10 @@ class RemoteFinder(BaseFinder):
         reader = RemoteReader(self, {}, bulk_query=patterns)
         return reader.fetch_multi(start_time, end_time, now, requestContext)
 
-    def get_index(self, requestContext=None):
+    def get_index(self, requestContext):
         url = '/metrics/index.json'
 
-        headers = requestContext.get('forwardHeaders') if requestContext else None
+        headers = requestContext.get('forwardHeaders')
 
         result = self.request(
             url,

--- a/webapp/graphite/finders/standard.py
+++ b/webapp/graphite/finders/standard.py
@@ -168,7 +168,7 @@ class StandardFinder(BaseFinder):
             for base_name in matching_files + matching_subdirs:
                 yield join(current_dir, base_name)
 
-    def get_index(self, requestContext=None):
+    def get_index(self, requestContext):
         matches = []
 
         # unlike 0.9.x, we're going to use os.walk with followlinks

--- a/webapp/graphite/finders/standard.py
+++ b/webapp/graphite/finders/standard.py
@@ -171,21 +171,21 @@ class StandardFinder(BaseFinder):
     def get_index(self, requestContext=None):
         matches = []
 
-        for root, dirs, files in walk(settings.WHISPER_DIR):
+        # unlike 0.9.x, we're going to use os.walk with followlinks
+        # since we require Python 2.7 and newer that supports it
+        for root, _, files in walk(settings.WHISPER_DIR):
           root = root.replace(settings.WHISPER_DIR, '')
           for base_name in files:
             if fnmatch.fnmatch(base_name, '*.wsp'):
               matches.append(join(root, base_name).replace('.wsp', ''))
 
-        # unlike 0.9.x, we're going to use os.walk with followlinks
-        # since we require Python 2.7 and newer that supports it
         if RRDReader.supported:
-          for root, dirs, files in walk(settings.RRD_DIR, followlinks=True):
+          for root, _, files in walk(settings.RRD_DIR, followlinks=True):
             root = root.replace(settings.RRD_DIR, '')
             for base_name in files:
               if fnmatch.fnmatch(base_name, '*.rrd'):
                 absolute_path = join(settings.RRD_DIR, root, base_name)
-                (base_name,extension) = splitext(base_name)
+                base_name = splitext(base_name)[0]
                 metric_path = join(root, base_name)
                 rrd = RRDReader(absolute_path, metric_path)
                 for datasource_name in rrd.get_datasources(absolute_path):

--- a/webapp/graphite/finders/standard.py
+++ b/webapp/graphite/finders/standard.py
@@ -1,5 +1,6 @@
+import fnmatch
 import operator
-from os.path import isdir, isfile, join, basename
+from os.path import isdir, isfile, join, basename, splitext
 from django.conf import settings
 
 # Use the built-in version of scandir/walk if possible, otherwise
@@ -166,3 +167,31 @@ class StandardFinder(BaseFinder):
 
             for base_name in matching_files + matching_subdirs:
                 yield join(current_dir, base_name)
+
+    def get_index(self, requestContext=None):
+        matches = []
+
+        for root, dirs, files in walk(settings.WHISPER_DIR):
+          root = root.replace(settings.WHISPER_DIR, '')
+          for base_name in files:
+            if fnmatch.fnmatch(base_name, '*.wsp'):
+              matches.append(join(root, base_name).replace('.wsp', ''))
+
+        # unlike 0.9.x, we're going to use os.walk with followlinks
+        # since we require Python 2.7 and newer that supports it
+        if RRDReader.supported:
+          for root, dirs, files in walk(settings.RRD_DIR, followlinks=True):
+            root = root.replace(settings.RRD_DIR, '')
+            for base_name in files:
+              if fnmatch.fnmatch(base_name, '*.rrd'):
+                absolute_path = join(settings.RRD_DIR, root, base_name)
+                (base_name,extension) = splitext(base_name)
+                metric_path = join(root, base_name)
+                rrd = RRDReader(absolute_path, metric_path)
+                for datasource_name in rrd.get_datasources(absolute_path):
+                  matches.append(join(metric_path, datasource_name).replace('.rrd', ''))
+
+        return sorted([
+          m.replace('/', '.').lstrip('.')
+          for m in matches
+        ])

--- a/webapp/graphite/finders/utils.py
+++ b/webapp/graphite/finders/utils.py
@@ -57,7 +57,7 @@ class BaseFinder(object):
           generator of Node
         """
 
-    def get_index(self, requestContext=None):
+    def get_index(self, requestContext):
         """Get a list of all series
 
         Args:

--- a/webapp/graphite/finders/utils.py
+++ b/webapp/graphite/finders/utils.py
@@ -57,6 +57,24 @@ class BaseFinder(object):
           generator of Node
         """
 
+    def get_index(self, requestContext=None):
+        """Get a list of all series
+
+        Args:
+          requestContext
+
+        Returns:
+          list of series
+        """
+        query = FindQuery(
+            '**', None, None,
+            local=requestContext.get('localOnly'),
+            headers=requestContext.get('forwardHeaders'),
+            leaves_only=True,
+        )
+
+        return sorted([node.path for node in self.find_nodes(query) if node.is_leaf])
+
     # The methods below are fully optional and BaseFinder provides
     # a default implementation. They can be re-implemented by finders
     # that could provide a more efficient way of doing it.

--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -268,6 +268,9 @@ DEFAULT_XFILES_FACTOR = 0
 # Use a pool of worker threads to dispatch finder requests in parallel
 #USE_WORKER_POOL = True
 
+# Maximum number of worker threads for concurrent storage operations
+#POOL_MAX_WORKERS = 10
+
 # This setting controls whether https is used to communicate between cluster members
 #INTRACLUSTER_HTTPS = False
 

--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -265,26 +265,8 @@ DEFAULT_XFILES_FACTOR = 0
 # used.
 #CLUSTER_SERVERS = ["10.0.2.2:80", "10.0.2.3:80"]
 
-# Creates a pool of worker threads to which tasks can be dispatched. This makes
-# sense if there are multiple CLUSTER_SERVERS because then the communication
-# with them can be parallelized
-# The number of threads is equal to:
-#   POOL_WORKERS_PER_BACKEND * len(CLUSTER_SERVERS) + POOL_WORKERS
-# Be careful when increasing the number of threads, in particular if your start
-# multiple graphite-web processes (with uwsgi or similar) as this will increase
-# memory consumption (and number of connections to memcached).
+# Use a pool of worker threads to dispatch finder requests in parallel
 #USE_WORKER_POOL = True
-
-# The number of worker threads that should be created per backend server.
-# It makes sense to have more than one thread per backend server if
-# the graphite-web web server itself is multi threaded and can handle multiple
-# incoming requests at once.
-#POOL_WORKERS_PER_BACKEND = 1
-
-# A baseline number of workers that should always be created, no matter how many
-# cluster servers are configured. These are used for other tasks that can be
-# off-loaded from the request handling threads.
-#POOL_WORKERS = 1
 
 # This setting controls whether https is used to communicate between cluster members
 #INTRACLUSTER_HTTPS = False

--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -45,7 +45,7 @@ def index_json(request):
     }
 
     matches = STORE.get_index(requestContext)
-  except Exception as err:
+  except Exception:
     log.exception()
     return json_response_for(request, [], jsonp=jsonp, status=500)
 

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -56,8 +56,6 @@ STANDARD_DIRS = []
 # Cluster settings
 CLUSTER_SERVERS = []
 USE_WORKER_POOL = True
-POOL_WORKERS_PER_BACKEND = 1
-POOL_WORKERS = 1
 
 # This settings control whether https is used to communicate between cluster members
 INTRACLUSTER_HTTPS = False

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -55,7 +55,10 @@ STANDARD_DIRS = []
 
 # Cluster settings
 CLUSTER_SERVERS = []
+
+# Worker Pool
 USE_WORKER_POOL = True
+POOL_MAX_WORKERS = 10
 
 # This settings control whether https is used to communicate between cluster members
 INTRACLUSTER_HTTPS = False

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -63,7 +63,9 @@ class Store(object):
             yield finder
 
     def pool_exec(self, jobs, timeout):
-        thread_count = len(self.finders) if settings.USE_WORKER_POOL else 0
+        thread_count = 0
+        if settings.USE_WORKER_POOL:
+            thread_count = min(len(self.finders), settings.POOL_MAX_WORKERS)
 
         return pool_exec(get_pool('finders', thread_count), jobs, timeout)
 

--- a/webapp/graphite/worker_pool/pool.py
+++ b/webapp/graphite/worker_pool/pool.py
@@ -79,7 +79,7 @@ def pool_exec(pool, jobs, timeout):
 
   If not all jobs have been executed after the specified timeout a
   PoolTimeoutError will be raised. When operating synchronously the
-  timeout is checked after each job is run.
+  timeout is checked before each job is run.
   """
   start = time.time()
   deadline = start + timeout

--- a/webapp/graphite/worker_pool/pool.py
+++ b/webapp/graphite/worker_pool/pool.py
@@ -35,7 +35,7 @@ class Job(object):
       self.exception = err
 
 
-def get_pool(name="default", thread_count=0):
+def get_pool(name="default", thread_count=1):
   """Get (and initialize) a Thread pool.
 
   If thread_count is 0, then None is returned.

--- a/webapp/graphite/worker_pool/pool.py
+++ b/webapp/graphite/worker_pool/pool.py
@@ -2,7 +2,6 @@ import Queue
 import time
 
 from threading import Lock
-from django.conf import settings
 from multiprocessing.pool import ThreadPool
 
 _init_lock = Lock()
@@ -36,16 +35,15 @@ class Job(object):
       self.exception = err
 
 
-def get_pool(name="default", thread_count=settings.POOL_WORKERS):
+def get_pool(name="default", thread_count=0):
   """Get (and initialize) a Thread pool.
 
-  If settings.USE_WORKER_POOL is False or thread_count (default: settings.POOL_WORKERS)
-  is 0, then None is returned.
+  If thread_count is 0, then None is returned.
 
   If the thread pool had already been initialized, thread_count will
   be ignored.
   """
-  if not settings.USE_WORKER_POOL or not thread_count:
+  if not thread_count:
     return None
 
   with _init_lock:
@@ -92,8 +90,7 @@ def pool_exec(pool, jobs, timeout):
       job.run()
       queue.put(job)
 
-    for job in jobs:
-      pool.apply_async(func=pool_executor, args=[job])
+    pool.map_async(pool_executor, jobs)
 
     done = 0
     total = len(jobs)
@@ -109,9 +106,9 @@ def pool_exec(pool, jobs, timeout):
       yield job
   else:
     for job in jobs:
-      job.run()
-
       if time.time() > deadline:
         raise PoolTimeoutError("Timed out after %fs" % (time.time() - start))
+
+      job.run()
 
       yield job

--- a/webapp/graphite/worker_pool/pool.py
+++ b/webapp/graphite/worker_pool/pool.py
@@ -90,7 +90,8 @@ def pool_exec(pool, jobs, timeout):
       job.run()
       queue.put(job)
 
-    pool.map_async(pool_executor, jobs)
+    for job in jobs:
+      pool.apply_async(func=pool_executor, args=[job])
 
     done = 0
     total = len(jobs)

--- a/webapp/tests/test_finders.py
+++ b/webapp/tests/test_finders.py
@@ -365,6 +365,10 @@ class CeresFinderTest(TestCase):
             self.assertEqual(len(list(nodes)), 0)
             self.assertEqual(self._listdir_counter, 0)
 
+            # get index
+            result = finder.get_index({})
+            self.assertEqual(result, ['bar.baz.foo', 'foo', 'foo.bar.baz'])
+
         finally:
             os.listdir = self._original_listdir
             wipe_ceres()

--- a/webapp/tests/test_metrics.py
+++ b/webapp/tests/test_metrics.py
@@ -20,8 +20,6 @@ class MetricsTester(TestCase):
     db = os.path.join(settings.WHISPER_DIR, 'test.wsp')
     hostcpu = os.path.join(settings.WHISPER_DIR, 'hosts/hostname/cpu.wsp')
 
-    settings.CLUSTER_SERVERS = ['127.1.1.1', '127.1.1.2']
-
     def wipe_whisper(self):
         try:
             os.remove(self.db)

--- a/webapp/tests/test_metrics.py
+++ b/webapp/tests/test_metrics.py
@@ -4,6 +4,8 @@ import os
 import shutil
 import time
 
+from mock import patch
+
 from django.conf import settings
 try:
     from django.urls import reverse
@@ -81,6 +83,16 @@ class MetricsTester(TestCase):
         self.assertEqual(data[0], 'hosts.worker1.cpu')
         self.assertEqual(data[1], 'hosts.worker2.cpu')
 
+        # failure
+        def mock_STORE_get_index(self, requestContext=None):
+          raise Exception('test')
+
+        with patch('graphite.metrics.views.STORE.get_index', mock_STORE_get_index):
+          request = {}
+          response = self.client.post(url, request)
+          self.assertEqual(response.status_code, 500)
+          data = json.loads(response.content)
+          self.assertEqual(data, [])
 
     def test_find_view(self):
         ts = int(time.time())

--- a/webapp/tests/test_util.py
+++ b/webapp/tests/test_util.py
@@ -1,8 +1,5 @@
 import os
-import shutil
 import socket
-import time
-import whisper
 import pytz
 
 from datetime import datetime
@@ -88,43 +85,6 @@ class UtilTest(TestCase):
         self.assertEqual( list(util.find_escaped_pattern_fields('a.b.\[c].d')), [2])
 
     hostcpu = os.path.join(settings.WHISPER_DIR, 'hosts/hostname/cpu.wsp')
-
-    def create_whisper_hosts(self):
-        worker1 = self.hostcpu.replace('hostname', 'worker1')
-        worker2 = self.hostcpu.replace('hostname', 'worker2')
-        bogus_file = os.path.join(settings.WHISPER_DIR, 'a/b/c/bogus_file.txt')
-
-        try:
-            os.makedirs(worker1.replace('cpu.wsp', ''))
-            os.makedirs(worker2.replace('cpu.wsp', ''))
-            os.makedirs(bogus_file.replace('bogus_file.txt', ''))
-        except OSError:
-            pass
-
-        open(bogus_file, 'a').close()
-        whisper.create(worker1, [(1, 60)])
-        whisper.create(worker2, [(1, 60)])
-
-        ts = int(time.time())
-        whisper.update(worker1, 1, ts)
-        whisper.update(worker2, 2, ts)
-
-    def wipe_whisper_hosts(self):
-        try:
-            os.remove(self.hostcpu.replace('hostname', 'worker1'))
-            os.remove(self.hostcpu.replace('hostname', 'worker2'))
-            os.remove(os.path.join(settings.WHISPER_DIR, 'a/b/c/bogus_file.txt'))
-            shutil.rmtree(self.hostcpu.replace('hostname/cpu.wsp', ''))
-            shutil.rmtree(os.path.join(settings.WHISPER_DIR, 'a'))
-        except OSError:
-            pass
-
-    def test_write_index(self):
-        self.create_whisper_hosts()
-        self.addCleanup(self.wipe_whisper_hosts)
-
-        self.assertEqual(None, util.write_index() )
-        self.assertEqual(None, util.write_index(settings.WHISPER_DIR, settings.CERES_DIR, settings.INDEX_FILE) )
 
     def test_load_module(self):
         with self.assertRaises(IOError):


### PR DESCRIPTION
This PR moves all code used for generating `/metrics/index.json` into a new `get_index` function in `STORE` which uses the same worker pool approach as `find` and `fetch`.  It also provides a default implementation of `get_index` in `BaseFinder` so that all existing plugins will now expose their metrics automatically (the default implementation maps `get_index` to a `find_nodes` call with pattern `**`).  Finders are able to override `get_index` to provide their own more efficient implementation, which is what the `standard`, `ceres` & `remote` finders now do.

The only non-BC change introduced is to remove the old `cluster` parameter and behavior from `/metrics/index.json` and replace it with the same `local=1` behavior as `/metrics/find` and `/render`.  This means the following changes:

```
Old behavior:
/metrics/index.json           Returns an index of only local metrics
/metrics/index.json?cluster=1 Returns an index of only remote metrics

New behavior:
/metrics/index.json           Returns an index of all known (local & remote) metrics
/metrics/index.json?local=1   Returns an index of only local metrics
```