### PR TITLE
tags: avoid dependencies in base.TagDB

### DIFF
--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -147,7 +147,7 @@ def extractPathExpressions(requestContext, targets):
       # if we're prefetching seriesByTag, look up the matching series and prefetch those
       if tokens.call.funcname == 'seriesByTag':
         if STORE.tagdb:
-          for series in STORE.tagdb.find_series(tuple([t.string[1:-1] for t in tokens.call.args if t.string])):
+          for series in STORE.find_series(tuple([t.string[1:-1] for t in tokens.call.args if t.string])):
             pathExpressions.add(series)
       else:
         for a in tokens.call.args:

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -4275,7 +4275,7 @@ def seriesByTag(requestContext, *tagExpressions):
     log.info('seriesByTag called but no TagDB configured')
     return []
 
-  taggedSeries = STORE.tagdb.find_series(tagExpressions)
+  taggedSeries = STORE.find_series(tagExpressions)
   if not taggedSeries:
     return []
 

--- a/webapp/graphite/tags/autocomplete.py
+++ b/webapp/graphite/tags/autocomplete.py
@@ -1,0 +1,86 @@
+"""Default implementation of auto-completion functions.
+
+These are not in base.py to make sure it is possible to import
+base.py without bringing all the Graphite dependencies.
+"""
+import bisect
+
+from django.conf import settings
+
+
+def auto_complete_tags(tagdb, exprs, tagPrefix=None, limit=None):
+    """
+    Return auto-complete suggestions for tags based on the matches for the specified expressions, optionally filtered by tag prefix
+    """
+    from graphite.storage import STORE
+
+    if limit is None:
+        limit = settings.TAGDB_AUTOCOMPLETE_LIMIT
+    else:
+        limit = int(limit)
+
+    if not exprs:
+        return [tagInfo['tag'] for tagInfo in
+                tagdb.list_tags(tagFilter=('^(' + tagPrefix + ')' if tagPrefix else None))[:limit]]
+
+    result = []
+
+    searched_tags = set([tagdb.parse_tagspec(expr)[0] for expr in exprs])
+
+    for path in STORE.find_series(exprs):
+        tags = tagdb.parse(path).tags
+        for tag in tags:
+            if tag in searched_tags:
+                continue
+            if tagPrefix and not tag.startswith(tagPrefix):
+                continue
+            if tag in result:
+                continue
+            if len(result) == 0 or tag >= result[-1]:
+                if len(result) >= limit:
+                    continue
+                result.append(tag)
+            else:
+                bisect.insort_left(result, tag)
+            if len(result) > limit:
+                del result[-1]
+
+    return result
+
+
+def auto_complete_values(tagdb, exprs, tag, valuePrefix=None, limit=None):
+    """
+    Return auto-complete suggestions for tags and values based on the matches for the specified expressions, optionally filtered by tag and/or value prefix
+    """
+    from graphite.storage import STORE
+
+    if limit is None:
+        limit = settings.TAGDB_AUTOCOMPLETE_LIMIT
+    else:
+        limit = int(limit)
+
+    if not exprs:
+        return [v['value'] for v in
+                tagdb.list_values(tag, valueFilter=('^(' + valuePrefix + ')' if valuePrefix else None))[:limit]]
+
+    result = []
+
+    for path in STORE.find_series(exprs):
+        tags = tagdb.parse(path).tags
+        if tag not in tags:
+            continue
+        value = tags[tag]
+        if valuePrefix and not value.startswith(valuePrefix):
+            continue
+        if value in result:
+            continue
+        if len(result) == 0 or value >= result[-1]:
+            if len(result) >= limit:
+                continue
+            result.append(value)
+        else:
+            bisect.insort_left(result, value)
+        if len(result) > limit:
+            del result[-1]
+
+    return result

--- a/webapp/graphite/tags/http.py
+++ b/webapp/graphite/tags/http.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from graphite.http_pool import http
 
 from graphite.tags.base import BaseTagDB
+from graphite.tags import autocomplete
 
 
 class HttpTagDB(BaseTagDB):
@@ -39,7 +40,7 @@ class HttpTagDB(BaseTagDB):
 
     return json.loads(result.data.decode('utf-8'))
 
-  def _find_series(self, tags):
+  def find_series(self, tags):
     return self.request('GET', '/tags/findSeries?' + '&'.join([('expr=%s' % quote(tag)) for tag in tags]))
 
   def get_series(self, path):
@@ -74,7 +75,7 @@ class HttpTagDB(BaseTagDB):
     Return auto-complete suggestions for tags based on the matches for the specified expressions, optionally filtered by tag prefix
     """
     if not settings.TAGDB_HTTP_AUTOCOMPLETE:
-      return super(HttpTagDB, self).auto_complete_tags(exprs, tagPrefix=tagPrefix, limit=limit)
+      return autocomplete.auto_complete_tags(self, exprs, tagPrefix=tagPrefix, limit=limit)
 
     if limit is None:
       limit = settings.TAGDB_AUTOCOMPLETE_LIMIT
@@ -89,7 +90,7 @@ class HttpTagDB(BaseTagDB):
     Return auto-complete suggestions for tags and values based on the matches for the specified expressions, optionally filtered by tag and/or value prefix
     """
     if not settings.TAGDB_HTTP_AUTOCOMPLETE:
-      return super(HttpTagDB, self).auto_complete_values(exprs, tag, valuePrefix=valuePrefix, limit=limit)
+      return autocomplete.auto_complete_values(self, exprs, tag, valuePrefix=valuePrefix, limit=limit)
 
     if limit is None:
       limit = settings.TAGDB_AUTOCOMPLETE_LIMIT
@@ -98,3 +99,4 @@ class HttpTagDB(BaseTagDB):
       '&limit=' + quote(str(limit)) + '&' + '&'.join([('expr=%s' % quote(expr or '')) for expr in exprs])
 
     return self.request('GET', url)
+

--- a/webapp/graphite/tags/localdatabase.py
+++ b/webapp/graphite/tags/localdatabase.py
@@ -4,6 +4,7 @@ from django.db import connection
 from hashlib import sha256
 
 from graphite.tags.base import BaseTagDB, TaggedSeries
+from graphite.tags import autocomplete
 
 
 class LocalDatabaseTagDB(BaseTagDB):
@@ -88,7 +89,7 @@ class LocalDatabaseTagDB(BaseTagDB):
 
     return sql, params, filters
 
-  def _find_series(self, tags):
+  def find_series(self, tags):
     sql, params, filters = self.find_series_query(tags)
 
     def matches_filters(path):
@@ -314,3 +315,9 @@ class LocalDatabaseTagDB(BaseTagDB):
       cursor.execute(sql, params)
 
     return True
+
+  def auto_complete_tags(self, exprs, tagPrefix=None, limit=None):
+    return autocomplete.auto_complete_tags(self, exprs, tagPrefix=tagPrefix, limit=limit)
+
+  def auto_complete_values(self, exprs, tag, valuePrefix=None, limit=None):
+    return autocomplete.auto_complete_values(self, exprs, tag, valuePrefix=valuePrefix, limit=limit)

--- a/webapp/graphite/tags/redis.py
+++ b/webapp/graphite/tags/redis.py
@@ -5,6 +5,7 @@ import re
 from django.conf import settings
 
 from graphite.tags.base import BaseTagDB, TaggedSeries
+from graphite.tags import autocomplete
 
 
 class RedisTagDB(BaseTagDB):
@@ -28,7 +29,7 @@ class RedisTagDB(BaseTagDB):
 
     self.r = Redis(host=settings.TAGDB_REDIS_HOST,port=settings.TAGDB_REDIS_PORT,db=settings.TAGDB_REDIS_DB)
 
-  def _find_series(self, tags):
+  def find_series(self, tags):
     selector = None
     selector_cnt = None
     filters = []
@@ -213,3 +214,9 @@ class RedisTagDB(BaseTagDB):
       pipe.execute()
 
     return True
+
+  def auto_complete_tags(self, exprs, tagPrefix=None, limit=None):
+    return autocomplete.auto_complete_tags(self, exprs, tagPrefix=tagPrefix, limit=limit)
+
+  def auto_complete_values(self, exprs, tag, valuePrefix=None, limit=None):
+    return autocomplete.auto_complete_values(self, exprs, tag, valuePrefix=valuePrefix, limit=limit)

--- a/webapp/graphite/tags/views.py
+++ b/webapp/graphite/tags/views.py
@@ -59,7 +59,7 @@ def findSeries(request):
     )
 
   return HttpResponse(
-    json.dumps(STORE.tagdb.find_series(exprs) if STORE.tagdb else [],
+    json.dumps(STORE.find_series(exprs) if STORE.tagdb else [],
                indent=(2 if queryParams.get('pretty') else None),
                sort_keys=bool(queryParams.get('pretty'))),
     content_type='application/json'


### PR DESCRIPTION
This makes it easilly importable anywhere.
- auto-completion code moved to autocomplete.py
- caching code more to storage.py

Another option could be to keep a light interface
and have a less abstract class with a few pre-filled methods.