### PR TITLE
Fix issues when combining series with different intervals

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -3979,7 +3979,7 @@ def _summarizeValues(series, func, interval, newStart=None, newEnd=None):
   intervalPoints = interval / series.step
 
   i = 0
-  numPoints = len(timestamps)
+  numPoints = min(len(timestamps), len(datapoints))
 
   newValues = []
   timestamp_ = newStart

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -410,6 +410,39 @@ class FunctionsTest(TestCase):
         seriesList = self._generate_series_list()
         self.assertEqual(functions.normalize([seriesList]), (seriesList, 0, 101, 1))
 
+    def test_normalize_different_steps(self):
+        seriesList = [
+          TimeSeries("test.1", 0, 120 * 31, 120, values=range(1, 32)),
+          TimeSeries("test.2", 0, 30 * 120, 30, values=range(1, 121)),
+        ]
+
+        self.assertEqual(seriesList[0].start, 0)
+        self.assertEqual(seriesList[0].end, 120 * 31)
+        self.assertEqual(seriesList[0].step, 120)
+        self.assertEqual(seriesList[0].valuesPerPoint, 1)
+        self.assertEqual(len(list(seriesList[0])), 31)
+
+        self.assertEqual(seriesList[1].start, 0)
+        self.assertEqual(seriesList[1].end, 30 * 120)
+        self.assertEqual(seriesList[1].step, 30)
+        self.assertEqual(seriesList[1].valuesPerPoint, 1)
+        self.assertEqual(len(list(seriesList[1])), 120)
+
+        # normalize seriesList
+        self.assertEqual(functions.normalize([seriesList]), (seriesList, 0, 3720, 120))
+
+        self.assertEqual(seriesList[0].start, 0)
+        self.assertEqual(seriesList[0].end, 120 * 31)
+        self.assertEqual(seriesList[0].step, 120)
+        self.assertEqual(seriesList[0].valuesPerPoint, 1)
+        self.assertEqual(len(list(seriesList[0])), 31)
+
+        self.assertEqual(seriesList[1].start, 0)
+        self.assertEqual(seriesList[1].end, 30 * 120)
+        self.assertEqual(seriesList[1].step, 30)
+        self.assertEqual(seriesList[1].valuesPerPoint, 4)
+        self.assertEqual(len(list(seriesList[1])), 30)
+
     #
     # Test matchSeries()
     #


### PR DESCRIPTION
When combining series with different intervals using `normalize`, the number of resulting values may not always be equal.  In the past the consolidating generator worked around this problem by yielding an extra `None` value, but that wasn't a great way to solve the problem.

Now that we require Python 2.7, we can switch from using `izip` to `izip_longest` when combining values from multiple `TimeSeries`, which will pad any short series with `None` to avoid this problem when aggregating series with a different number of values.

In `_summarizeValues` I also made a change to avoid trying to walk past the end of the `datapoints` array if for some reason it still ended up shorter than expected.

Finally, I added some test code to validate functionality with series having differing steps, as the current tests only use series with `step=1`.

This should solve the issue in #2113