### PR TITLE
update perSecond to return float values

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1591,8 +1591,8 @@ def perSecond(requestContext, seriesList, maxValue=None):
     &target=perSecond(company.server.application01.ifconfig.TXPackets)
 
   Each time you run ifconfig, the RX and TXPackets are higher (assuming there
-  is network traffic.) By applying the nonNegativeDerivative function, you can get an
-  idea of the packets per minute sent or received, even though you're only
+  is network traffic.) By applying the perSecond function, you can get an
+  idea of the packets per second sent or received, even though you're only
   recording the total.
   """
   results = []
@@ -1612,9 +1612,9 @@ def perSecond(requestContext, seriesList, maxValue=None):
 
       diff = val - prev
       if diff >= 0:
-        newValues.append(diff // step)
+        newValues.append(round(diff / step, 6))
       elif maxValue is not None and maxValue >= val:
-        newValues.append( ((maxValue - prev) + val  + 1) // step )
+        newValues.append(round((maxValue + diff) / step, 6))
       else:
         newValues.append(None)
 

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -1554,6 +1554,13 @@ class FunctionsTest(TestCase):
         self.assertEqual(list(expected[0]), list(result[0]))
         self.assertEqual(expected, result)
 
+    def test_perSecond_float(self):
+        seriesList = self._gen_series_list_with_data(key='test',start=0,end=600,step=60,data=[0, 90, 186, 291, 411, 561, 747, 939, 137, 337])
+        expected = [TimeSeries('perSecond(test)', 0, 600, 60, [None, 1.5, 1.6, 1.75, 2, 2.5, 3.1, 3.2, 3.3, 3.333333])]
+        result = functions.perSecond({}, seriesList, maxValue=1000)
+        self.assertEqual(list(expected[0]), list(result[0]))
+        self.assertEqual(expected, result)
+
     def test_perSecond_nones(self):
         seriesList = self._gen_series_list_with_data(key='test',start=0,end=600,step=60,data=[0, 60, None, 180, None, None, None, 420, None, 540])
         expected = [TimeSeries('perSecond(test)', 0, 600, 60, [None, 1, None, 1, None, None, None, 1, None, 1])]


### PR DESCRIPTION
Historically `perSecond` has returned only integer values, which causes problems when dealing with series that have fractional per-second rates.

This PR updates `perSecond` to use float division and return the resulting values rounded to 6 digits (like we do in `exponentialMovingAverage`).

I also corrected some language in the docs, and added a test to verify that `perSecond` now works properly with fractional rates.

I'm not entirely sure why the old code had `+ 1` in the rollover code, possibly it was related to the integer division.  In any case the new code does pass all the old tests without changes (with the `+ 1` in place it would produce fractional results).