### PR TITLE
pass headers to tag db

### DIFF
--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -147,7 +147,10 @@ def extractPathExpressions(requestContext, targets):
       # if we're prefetching seriesByTag, look up the matching series and prefetch those
       if tokens.call.funcname == 'seriesByTag':
         if STORE.tagdb:
-          for series in STORE.tagdb.find_series(tuple([t.string[1:-1] for t in tokens.call.args if t.string])):
+          for series in STORE.tagdb.find_series(
+              tuple([t.string[1:-1] for t in tokens.call.args if t.string]),
+              requestContext=requestContext,
+          ):
             pathExpressions.add(series)
       else:
         for a in tokens.call.args:

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -4270,7 +4270,7 @@ def seriesByTag(requestContext, *tagExpressions):
     log.info('seriesByTag called but no TagDB configured')
     return []
 
-  taggedSeries = STORE.tagdb.find_series(tagExpressions)
+  taggedSeries = STORE.tagdb.find_series(tagExpressions, requestContext=requestContext)
   if not taggedSeries:
     return []
 

--- a/webapp/graphite/tags/http.py
+++ b/webapp/graphite/tags/http.py
@@ -18,11 +18,11 @@ class HttpTagDB(BaseTagDB):
     self.username = settings.TAGDB_HTTP_USER
     self.password = settings.TAGDB_HTTP_PASSWORD
 
-  def request(self, method, url, fields=None):
+  def request(self, method, url, fields=None, requestContext=None):
     if not fields:
       fields = {}
 
-    headers = {}
+    headers = requestContext.get('forwardHeaders') if requestContext else {}
     if 'Authorization' not in headers and self.username and self.password:
       headers['Authorization'] = 'Basic ' + ('%s:%s' % (self.username, self.password)).encode('base64')
 
@@ -39,42 +39,50 @@ class HttpTagDB(BaseTagDB):
 
     return json.loads(result.data.decode('utf-8'))
 
-  def _find_series(self, tags):
-    return self.request('GET', '/tags/findSeries?' + '&'.join([('expr=%s' % quote(tag)) for tag in tags]))
+  def _find_series(self, tags, requestContext=None):
+    return self.request(
+      'GET',
+      '/tags/findSeries?' + '&'.join([('expr=%s' % quote(tag)) for tag in tags]),
+      requestContext=requestContext,
+    )
 
-  def get_series(self, path):
+  def get_series(self, path, requestContext=None):
     parsed = self.parse(path)
 
-    seriesList = self.find_series([('%s=%s' % (tag, parsed.tags[tag])) for tag in parsed.tags])
+    seriesList = self.find_series(
+      [('%s=%s' % (tag, parsed.tags[tag])) for tag in parsed.tags],
+      requestContext=requestContext,
+    )
 
     if parsed.path in seriesList:
       return parsed
 
-  def list_tags(self, tagFilter=None):
-    return self.request('GET', '/tags', {'filter': tagFilter})
+  def list_tags(self, tagFilter=None, requestContext=None):
+    return self.request('GET', '/tags', {'filter': tagFilter}, requestContext)
 
-  def get_tag(self, tag, valueFilter=None):
-    return self.request('GET', '/tags/' + tag, {'filter': valueFilter})
+  def get_tag(self, tag, valueFilter=None, requestContext=None):
+    return self.request('GET', '/tags/' + tag, {'filter': valueFilter}, requestContext)
 
-  def list_values(self, tag, valueFilter=None):
-    tagInfo = self.get_tag(tag, valueFilter)
+  def list_values(self, tag, valueFilter=None, requestContext=None):
+    tagInfo = self.get_tag(tag, valueFilter, requestContext)
     if not tagInfo:
       return []
 
     return tagInfo['values']
 
-  def tag_series(self, series):
-    return self.request('POST', '/tags/tagSeries', {'path': series})
+  def tag_series(self, series, requestContext=None):
+    return self.request('POST', '/tags/tagSeries', {'path': series}, requestContext)
 
-  def del_series(self, series):
-    return self.request('POST', '/tags/delSeries', {'path': series})
+  def del_series(self, series, requestContext=None):
+    return self.request('POST', '/tags/delSeries', {'path': series}, requestContext)
 
-  def auto_complete_tags(self, exprs, tagPrefix=None, limit=None):
+  def auto_complete_tags(self, exprs, tagPrefix=None, limit=None, requestContext=None):
     """
     Return auto-complete suggestions for tags based on the matches for the specified expressions, optionally filtered by tag prefix
     """
     if not settings.TAGDB_HTTP_AUTOCOMPLETE:
-      return super(HttpTagDB, self).auto_complete_tags(exprs, tagPrefix=tagPrefix, limit=limit)
+      return super(HttpTagDB, self).auto_complete_tags(
+        exprs, tagPrefix=tagPrefix, limit=limit, requestContext=requestContext)
 
     if limit is None:
       limit = settings.TAGDB_AUTOCOMPLETE_LIMIT
@@ -84,12 +92,13 @@ class HttpTagDB(BaseTagDB):
 
     return self.request('GET', url)
 
-  def auto_complete_values(self, exprs, tag, valuePrefix=None, limit=None):
+  def auto_complete_values(self, exprs, tag, valuePrefix=None, limit=None, requestContext=None):
     """
     Return auto-complete suggestions for tags and values based on the matches for the specified expressions, optionally filtered by tag and/or value prefix
     """
     if not settings.TAGDB_HTTP_AUTOCOMPLETE:
-      return super(HttpTagDB, self).auto_complete_values(exprs, tag, valuePrefix=valuePrefix, limit=limit)
+      return super(HttpTagDB, self).auto_complete_values(
+        exprs, tag, valuePrefix=valuePrefix, limit=limit, requestContext=requestContext)
 
     if limit is None:
       limit = settings.TAGDB_AUTOCOMPLETE_LIMIT

--- a/webapp/graphite/tags/localdatabase.py
+++ b/webapp/graphite/tags/localdatabase.py
@@ -88,7 +88,7 @@ class LocalDatabaseTagDB(BaseTagDB):
 
     return sql, params, filters
 
-  def _find_series(self, tags):
+  def _find_series(self, tags, requestContext=None):
     sql, params, filters = self.find_series_query(tags)
 
     def matches_filters(path):
@@ -114,7 +114,7 @@ class LocalDatabaseTagDB(BaseTagDB):
 
       return [row[0] for row in cursor if matches_filters(row[0])]
 
-  def get_series(self, path):
+  def get_series(self, path, requestContext=None):
     with connection.cursor() as cursor:
       sql = 'SELECT s.id, t.tag, v.value'
       sql += ' FROM tags_series AS s'
@@ -134,7 +134,7 @@ class LocalDatabaseTagDB(BaseTagDB):
 
       return TaggedSeries(tags['name'], tags, series_id=series_id)
 
-  def list_tags(self, tagFilter=None):
+  def list_tags(self, tagFilter=None, requestContext=None):
     with connection.cursor() as cursor:
       sql = 'SELECT t.id, t.tag'
       sql += ' FROM tags_tag AS t'
@@ -152,7 +152,7 @@ class LocalDatabaseTagDB(BaseTagDB):
 
       return [{'id': tag_id, 'tag': tag} for (tag_id, tag) in cursor]
 
-  def get_tag(self, tag, valueFilter=None):
+  def get_tag(self, tag, valueFilter=None, requestContext=None):
     with connection.cursor() as cursor:
       sql = 'SELECT t.id, t.tag'
       sql += ' FROM tags_tag AS t'
@@ -173,7 +173,7 @@ class LocalDatabaseTagDB(BaseTagDB):
       'values': self.list_values(tag, valueFilter=valueFilter),
     }
 
-  def list_values(self, tag, valueFilter=None ):
+  def list_values(self, tag, valueFilter=None, requestContext=None):
     with connection.cursor() as cursor:
       sql = 'SELECT v.id, v.value, COUNT(st.id)'
       sql += ' FROM tags_tagvalue AS v'
@@ -236,7 +236,7 @@ class LocalDatabaseTagDB(BaseTagDB):
       return '!~*'
     raise Exception('Database vendor ' + connection.vendor + ' does not support regular expressions')
 
-  def tag_series(self, series):
+  def tag_series(self, series, requestContext=None):
     # extract tags and normalize path
     parsed = self.parse(series)
 
@@ -286,7 +286,7 @@ class LocalDatabaseTagDB(BaseTagDB):
 
     return path
 
-  def del_series(self, series):
+  def del_series(self, series, requestContext=None):
     # extract tags and normalize path
     parsed = self.parse(series)
 

--- a/webapp/graphite/tags/redis.py
+++ b/webapp/graphite/tags/redis.py
@@ -28,7 +28,7 @@ class RedisTagDB(BaseTagDB):
 
     self.r = Redis(host=settings.TAGDB_REDIS_HOST,port=settings.TAGDB_REDIS_PORT,db=settings.TAGDB_REDIS_DB)
 
-  def _find_series(self, tags):
+  def _find_series(self, tags, requestContext=None):
     selector = None
     selector_cnt = None
     filters = []
@@ -142,7 +142,7 @@ class RedisTagDB(BaseTagDB):
 
     return sorted(results)
 
-  def get_series(self, path):
+  def get_series(self, path, requestContext=None):
     tags = {}
 
     tags = self.r.hgetall('series:' + path + ':tags')
@@ -151,14 +151,14 @@ class RedisTagDB(BaseTagDB):
 
     return TaggedSeries(tags['name'], tags)
 
-  def list_tags(self, tagFilter=None):
+  def list_tags(self, tagFilter=None, requestContext=None):
     return sorted([
       {'tag': tag}
       for tag in self.r.sscan_iter('tags')
       if not tagFilter or re.match(tagFilter, tag) is not None
     ], key=lambda x: x['tag'])
 
-  def get_tag(self, tag, valueFilter=None):
+  def get_tag(self, tag, valueFilter=None, requestContext=None):
     if not self.r.sismember('tags', tag):
       return None
 
@@ -167,14 +167,14 @@ class RedisTagDB(BaseTagDB):
       'values': self.list_values(tag, valueFilter=valueFilter),
     }
 
-  def list_values(self, tag, valueFilter=None):
+  def list_values(self, tag, valueFilter=None, requestContext=None):
     return sorted([
       {'value': value, 'count': self.r.scard('tags:' + tag + ':values:' + value)}
       for value in self.r.sscan_iter('tags:' + tag + ':values')
       if not valueFilter or re.match(valueFilter, value) is not None
     ], key=lambda x: x['value'])
 
-  def tag_series(self, series):
+  def tag_series(self, series, requestContext=None):
     # extract tags and normalize path
     parsed = self.parse(series)
 
@@ -195,7 +195,7 @@ class RedisTagDB(BaseTagDB):
 
     return path
 
-  def del_series(self, series):
+  def del_series(self, series, requestContext=None):
     # extract tags and normalize path
     parsed = self.parse(series)
 

--- a/webapp/graphite/tags/views.py
+++ b/webapp/graphite/tags/views.py
@@ -1,6 +1,11 @@
 from graphite.compat import HttpResponse
 from graphite.util import json
-from graphite.storage import STORE
+from graphite.storage import STORE, extractForwardHeaders
+
+def _requestContext(request):
+  return {
+    'forwardHeaders': extractForwardHeaders(request),
+  }
 
 def tagSeries(request):
   if request.method != 'POST':
@@ -15,7 +20,9 @@ def tagSeries(request):
     )
 
   return HttpResponse(
-    json.dumps(STORE.tagdb.tag_series(path)) if STORE.tagdb else 'null',
+    json.dumps(
+      STORE.tagdb.tag_series(path, requestContext=_requestContext(request)),
+    ) if STORE.tagdb else 'null',
     content_type='application/json'
   )
 
@@ -32,7 +39,9 @@ def delSeries(request):
     )
 
   return HttpResponse(
-    json.dumps(STORE.tagdb.del_series(path)) if STORE.tagdb else 'null',
+    json.dumps(
+      STORE.tagdb.del_series(path, requestContext=_requestContext(request)),
+    ) if STORE.tagdb else 'null',
     content_type='application/json'
   )
 
@@ -59,9 +68,13 @@ def findSeries(request):
     )
 
   return HttpResponse(
-    json.dumps(STORE.tagdb.find_series(exprs) if STORE.tagdb else [],
-               indent=(2 if queryParams.get('pretty') else None),
-               sort_keys=bool(queryParams.get('pretty'))),
+    json.dumps(
+      STORE.tagdb.find_series(
+        exprs,
+        requestContext=_requestContext(request),
+      ) if STORE.tagdb else [],
+      indent=(2 if queryParams.get('pretty') else None),
+      sort_keys=bool(queryParams.get('pretty'))),
     content_type='application/json'
   )
 
@@ -70,9 +83,13 @@ def tagList(request):
     return HttpResponse(status=405)
 
   return HttpResponse(
-    json.dumps(STORE.tagdb.list_tags(tagFilter=request.GET.get('filter')) if STORE.tagdb else [],
-               indent=(2 if request.GET.get('pretty') else None),
-               sort_keys=bool(request.GET.get('pretty'))),
+    json.dumps(
+      STORE.tagdb.list_tags(
+        tagFilter=request.GET.get('filter'),
+        requestContext=_requestContext(request),
+      ) if STORE.tagdb else [],
+      indent=(2 if request.GET.get('pretty') else None),
+      sort_keys=bool(request.GET.get('pretty'))),
     content_type='application/json'
   )
 
@@ -81,9 +98,14 @@ def tagDetails(request, tag):
     return HttpResponse(status=405)
 
   return HttpResponse(
-    json.dumps(STORE.tagdb.get_tag(tag, valueFilter=request.GET.get('filter')) if STORE.tagdb else None,
-               indent=(2 if request.GET.get('pretty') else None),
-               sort_keys=bool(request.GET.get('pretty'))),
+    json.dumps(
+      STORE.tagdb.get_tag(
+        tag,
+        valueFilter=request.GET.get('filter'),
+        requestContext=_requestContext(request),
+      ) if STORE.tagdb else None,
+      indent=(2 if request.GET.get('pretty') else None),
+      sort_keys=bool(request.GET.get('pretty'))),
     content_type='application/json'
   )
 
@@ -104,7 +126,8 @@ def autoCompleteTags(request):
 
   tagPrefix = queryParams.get('tagPrefix')
 
-  result = STORE.tagdb.auto_complete_tags(exprs, tagPrefix, limit=queryParams.get('limit'))
+  result = STORE.tagdb.auto_complete_tags(
+    exprs, tagPrefix, limit=queryParams.get('limit'), requestContext=_requestContext(request))
 
   return HttpResponse(
     json.dumps(result,
@@ -138,7 +161,8 @@ def autoCompleteValues(request):
 
   valuePrefix = queryParams.get('valuePrefix')
 
-  result = STORE.tagdb.auto_complete_values(exprs, tag, valuePrefix, limit=queryParams.get('limit'))
+  result = STORE.tagdb.auto_complete_values(
+    exprs, tag, valuePrefix, limit=queryParams.get('limit'), requestContext=_requestContext(request))
 
   return HttpResponse(
     json.dumps(result,

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -5939,7 +5939,7 @@ class FunctionsTest(TestCase):
     @patch('graphite.render.evaluator.prefetchData', lambda *_: None)
     def test_seriesByTag(self):
         class MockTagDB(object):
-            def find_series(self, tagExpressions):
+            def find_series(self, tagExpressions, requestContext=None):
                 if tagExpressions == ('name=disk.bytes_used', 'server=server1'):
                     return ['disk.bytes_used;server=server1']
 

--- a/webapp/tests/test_tags.py
+++ b/webapp/tests/test_tags.py
@@ -181,7 +181,7 @@ class TagsTest(TestCase):
   def _test_autocomplete(self, db, patch_target):
     search_exprs = ['name=test.a']
 
-    def mock_find_series(self, exprs):
+    def mock_find_series(self, exprs, requestContext=None):
       if exprs != search_exprs:
         raise Exception('Unexpected exprs %s' % str(exprs))
 


### PR DESCRIPTION
The tagdb http backend might require the `X-Org-Id` header, this patch passes it through