### PR TITLE
Tagging updates

### DIFF
--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -5,6 +5,7 @@ import types
 from collections import defaultdict
 
 from django.conf import settings
+from django.core.cache import cache
 
 try:
     from importlib import import_module
@@ -17,7 +18,6 @@ from graphite.intervals import Interval, IntervalSet
 from graphite.finders.utils import FindQuery, BaseFinder
 from graphite.readers import MultiReader
 from graphite.worker_pool.pool import get_pool, pool_exec, Job, PoolTimeoutError
-from graphite.tags.utils import get_tagdb
 
 
 def get_finders(finder_path):
@@ -35,6 +35,12 @@ def get_finders(finder_path):
     finder.get_index = types.MethodType(BaseFinder.get_index.__func__, finder)
 
     return [finder]
+
+
+def get_tagdb(tagdb_path):
+    module_name, class_name = tagdb_path.rsplit('.', 1)
+    module = import_module(module_name)
+    return getattr(module, class_name)(settings, cache=cache, log=log)
 
 
 class Store(object):

--- a/webapp/graphite/tags/base.py
+++ b/webapp/graphite/tags/base.py
@@ -79,11 +79,11 @@ class BaseTagDB(object):
         },
       ]
 
-    Accepts an optional filter parameter which is a regular expression used to filter the list of returned tags
+    Accepts an optional tagFilter parameter which is a regular expression used to filter the list of returned tags.
     """
 
   @abc.abstractmethod
-  def get_tag(self, tag, valueFilter=None, valueLimit=None, requestContext=None):
+  def get_tag(self, tag, valueFilter=None, limit=None, requestContext=None):
     """
     Get details of a particular tag, accepts a tag name and returns a dict describing the tag.
 
@@ -102,7 +102,7 @@ class BaseTagDB(object):
         ],
       }
 
-    Accepts an optional filter parameter which is a regular expression used to filter the list of returned tags
+    Accepts an optional valueFilter parameter which is a regular expression used to filter the list of returned values.
     """
 
   @abc.abstractmethod
@@ -122,7 +122,7 @@ class BaseTagDB(object):
         },
       ]
 
-    Accepts an optional filter parameter which is a regular expression used to filter the list of returned tags
+    Accepts an optional valueFilter parameter which is a regular expression used to filter the list of returned values.
     """
 
   @abc.abstractmethod

--- a/webapp/graphite/tags/base.py
+++ b/webapp/graphite/tags/base.py
@@ -65,7 +65,7 @@ class BaseTagDB(object):
     """
 
   @abc.abstractmethod
-  def list_tags(self, tagFilter=None, requestContext=None):
+  def list_tags(self, tagFilter=None, limit=None, requestContext=None):
     """
     List defined tags, returns a list of dictionaries describing the tags stored in the TagDB.
 
@@ -83,7 +83,7 @@ class BaseTagDB(object):
     """
 
   @abc.abstractmethod
-  def get_tag(self, tag, valueFilter=None, requestContext=None):
+  def get_tag(self, tag, valueFilter=None, valueLimit=None, requestContext=None):
     """
     Get details of a particular tag, accepts a tag name and returns a dict describing the tag.
 
@@ -106,7 +106,7 @@ class BaseTagDB(object):
     """
 
   @abc.abstractmethod
-  def list_values(self, tag, valueFilter=None, requestContext=None):
+  def list_values(self, tag, valueFilter=None, limit=None, requestContext=None):
     """
     List values for a particular tag, returns a list of dictionaries describing the values stored in the TagDB.
 
@@ -149,9 +149,10 @@ class BaseTagDB(object):
     if not exprs:
       return [
         tagInfo['tag'] for tagInfo in self.list_tags(
-          tagFilter='^(' + tagPrefix + ')' if tagPrefix else None,
+          tagFilter='^(' + re.escape(tagPrefix) + ')' if tagPrefix else None,
+          limit=limit,
           requestContext=requestContext,
-        )[:limit]
+        )
       ]
 
     result = []
@@ -191,14 +192,15 @@ class BaseTagDB(object):
       return [
         v['value'] for v in self.list_values(
           tag,
-          valueFilter='^(' + valuePrefix + ')' if valuePrefix else None,
+          valueFilter='^(' + re.escape(valuePrefix) + ')' if valuePrefix else None,
+          limit=limit,
           requestContext=requestContext,
-        )[:limit]
+        )
       ]
 
     result = []
 
-    for path in self.find_series(exprs, requestContext=requestContext):
+    for path in self.find_series(exprs + [tag + '!='], requestContext=requestContext):
       tags = self.parse(path).tags
       if tag not in tags:
         continue

--- a/webapp/graphite/tags/base.py
+++ b/webapp/graphite/tags/base.py
@@ -16,7 +16,7 @@ class BaseTagDB(object):
     self.cache = kwargs.get('cache')
     self.log = kwargs.get('log')
 
-  def find_series(self, tags, timer=None, requestContext=None):
+  def find_series(self, tags, requestContext=None):
     """
     Find series by tag, accepts a list of tag specifiers and returns a list of matching paths.
 
@@ -41,7 +41,7 @@ class BaseTagDB(object):
     log_msg = 'completed in'
 
     try:
-      cacheKey = 'TagDB.find_series:' + ':'.join(sorted(tags))
+      cacheKey = self.find_series_cachekey(tags, requestContext=requestContext)
       result = self.cache.get(cacheKey) if self.cache else None
       if result is not None:
         log_msg = 'completed (cached) in'
@@ -62,6 +62,9 @@ class BaseTagDB(object):
       )
 
     return result
+
+  def find_series_cachekey(self, tags, requestContext=None):
+    return 'TagDB.find_series:' + ':'.join(sorted(tags))
 
   @abc.abstractmethod
   def _find_series(self, tags, requestContext=None):

--- a/webapp/graphite/tags/http.py
+++ b/webapp/graphite/tags/http.py
@@ -40,6 +40,15 @@ class HttpTagDB(BaseTagDB):
 
     return json.loads(result.data.decode('utf-8'))
 
+  def find_series_cachekey(self, tags, requestContext=None):
+    headers = [
+      header + '=' + value
+      for (header, value)
+      in (requestContext.get('forwardHeaders', {}) if requestContext else {}).items()
+    ]
+
+    return 'TagDB.find_series:' + ':'.join(sorted(tags)) + ':' + ':'.join(sorted(headers))
+
   def _find_series(self, tags, requestContext=None):
     return self.request(
       'GET',

--- a/webapp/graphite/tags/http.py
+++ b/webapp/graphite/tags/http.py
@@ -57,14 +57,14 @@ class HttpTagDB(BaseTagDB):
     if parsed.path in seriesList:
       return parsed
 
-  def list_tags(self, tagFilter=None, requestContext=None):
-    return self.request('GET', '/tags', {'filter': tagFilter}, requestContext)
+  def list_tags(self, tagFilter=None, limit=None, requestContext=None):
+    return self.request('GET', '/tags', {'filter': tagFilter, 'limit': limit}, requestContext)
 
-  def get_tag(self, tag, valueFilter=None, requestContext=None):
-    return self.request('GET', '/tags/' + tag, {'filter': valueFilter}, requestContext)
+  def get_tag(self, tag, valueFilter=None, valueLimit=None, requestContext=None):
+    return self.request('GET', '/tags/' + tag, {'filter': valueFilter, 'limit': valueLimit}, requestContext)
 
-  def list_values(self, tag, valueFilter=None, requestContext=None):
-    tagInfo = self.get_tag(tag, valueFilter, requestContext)
+  def list_values(self, tag, valueFilter=None, limit=None, requestContext=None):
+    tagInfo = self.get_tag(tag, valueFilter, valueLimit=limit, requestContext=requestContext)
     if not tagInfo:
       return []
 

--- a/webapp/graphite/tags/http.py
+++ b/webapp/graphite/tags/http.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from urllib import quote
 import json
 
-from django.conf import settings
 from graphite.http_pool import http
 
 from graphite.tags.base import BaseTagDB
@@ -13,7 +12,9 @@ class HttpTagDB(BaseTagDB):
   """
   Stores tag information using an external http service that implements the graphite tags API.
   """
-  def __init__(self):
+  def __init__(self, settings, *args, **kwargs):
+    super(HttpTagDB, self).__init__(settings, *args, **kwargs)
+
     self.base_url = settings.TAGDB_HTTP_URL
     self.username = settings.TAGDB_HTTP_USER
     self.password = settings.TAGDB_HTTP_PASSWORD
@@ -31,7 +32,7 @@ class HttpTagDB(BaseTagDB):
       self.base_url + url,
       fields={field: value for (field, value) in fields.items() if value is not None},
       headers=headers,
-      timeout=settings.REMOTE_FIND_TIMEOUT,
+      timeout=self.settings.REMOTE_FIND_TIMEOUT,
     )
 
     if result.status != 200:
@@ -80,12 +81,12 @@ class HttpTagDB(BaseTagDB):
     """
     Return auto-complete suggestions for tags based on the matches for the specified expressions, optionally filtered by tag prefix
     """
-    if not settings.TAGDB_HTTP_AUTOCOMPLETE:
+    if not self.settings.TAGDB_HTTP_AUTOCOMPLETE:
       return super(HttpTagDB, self).auto_complete_tags(
         exprs, tagPrefix=tagPrefix, limit=limit, requestContext=requestContext)
 
     if limit is None:
-      limit = settings.TAGDB_AUTOCOMPLETE_LIMIT
+      limit = self.settings.TAGDB_AUTOCOMPLETE_LIMIT
 
     url = '/tags/autoComplete/tags?tagPrefix=' + quote(tagPrefix or '') + '&limit=' + quote(str(limit)) + \
       '&' + '&'.join([('expr=%s' % quote(expr or '')) for expr in exprs])
@@ -96,12 +97,12 @@ class HttpTagDB(BaseTagDB):
     """
     Return auto-complete suggestions for tags and values based on the matches for the specified expressions, optionally filtered by tag and/or value prefix
     """
-    if not settings.TAGDB_HTTP_AUTOCOMPLETE:
+    if not self.settings.TAGDB_HTTP_AUTOCOMPLETE:
       return super(HttpTagDB, self).auto_complete_values(
         exprs, tag, valuePrefix=valuePrefix, limit=limit, requestContext=requestContext)
 
     if limit is None:
-      limit = settings.TAGDB_AUTOCOMPLETE_LIMIT
+      limit = self.settings.TAGDB_AUTOCOMPLETE_LIMIT
 
     url = '/tags/autoComplete/values?tag=' + quote(tag or '') + '&valuePrefix=' + quote(valuePrefix or '') + \
       '&limit=' + quote(str(limit)) + '&' + '&'.join([('expr=%s' % quote(expr or '')) for expr in exprs])

--- a/webapp/graphite/tags/http.py
+++ b/webapp/graphite/tags/http.py
@@ -60,11 +60,11 @@ class HttpTagDB(BaseTagDB):
   def list_tags(self, tagFilter=None, limit=None, requestContext=None):
     return self.request('GET', '/tags', {'filter': tagFilter, 'limit': limit}, requestContext)
 
-  def get_tag(self, tag, valueFilter=None, valueLimit=None, requestContext=None):
-    return self.request('GET', '/tags/' + tag, {'filter': valueFilter, 'limit': valueLimit}, requestContext)
+  def get_tag(self, tag, valueFilter=None, limit=None, requestContext=None):
+    return self.request('GET', '/tags/' + tag, {'filter': valueFilter, 'limit': limit}, requestContext)
 
   def list_values(self, tag, valueFilter=None, limit=None, requestContext=None):
-    tagInfo = self.get_tag(tag, valueFilter, valueLimit=limit, requestContext=requestContext)
+    tagInfo = self.get_tag(tag, valueFilter=valueFilter, limit=limit, requestContext=requestContext)
     if not tagInfo:
       return []
 

--- a/webapp/graphite/tags/localdatabase.py
+++ b/webapp/graphite/tags/localdatabase.py
@@ -143,7 +143,7 @@ class LocalDatabaseTagDB(BaseTagDB):
       if tagFilter:
         # make sure regex is anchored
         if not tagFilter.startswith('^'):
-          tagFilter = '^' + tagFilter
+          tagFilter = '^(' + tagFilter + ')'
         sql += ' WHERE t.tag ' + self._regexp_operator(connection) + ' %s'
         params.append(tagFilter)
 
@@ -157,7 +157,7 @@ class LocalDatabaseTagDB(BaseTagDB):
 
       return [{'id': tag_id, 'tag': tag} for (tag_id, tag) in cursor]
 
-  def get_tag(self, tag, valueFilter=None, valueLimit=None, requestContext=None):
+  def get_tag(self, tag, valueFilter=None, limit=None, requestContext=None):
     with connection.cursor() as cursor:
       sql = 'SELECT t.id, t.tag'
       sql += ' FROM tags_tag AS t'
@@ -178,7 +178,7 @@ class LocalDatabaseTagDB(BaseTagDB):
       'values': self.list_values(
         tag,
         valueFilter=valueFilter,
-        limit=valueLimit,
+        limit=limit,
         requestContext=requestContext
       ),
     }
@@ -195,7 +195,7 @@ class LocalDatabaseTagDB(BaseTagDB):
       if valueFilter:
         # make sure regex is anchored
         if not valueFilter.startswith('^'):
-          valueFilter = '^' + valueFilter
+          valueFilter = '^(' + valueFilter + ')'
         sql += ' AND v.value ' + self._regexp_operator(connection) + ' %s'
         params.append(valueFilter)
 

--- a/webapp/graphite/tags/redis.py
+++ b/webapp/graphite/tags/redis.py
@@ -164,7 +164,7 @@ class RedisTagDB(BaseTagDB):
 
     return results
 
-  def get_tag(self, tag, valueFilter=None, valueLimit=None, requestContext=None):
+  def get_tag(self, tag, valueFilter=None, limit=None, requestContext=None):
     if not self.r.sismember('tags', tag):
       return None
 
@@ -173,7 +173,7 @@ class RedisTagDB(BaseTagDB):
       'values': self.list_values(
         tag,
         valueFilter=valueFilter,
-        limit=valueLimit,
+        limit=limit,
         requestContext=requestContext
       ),
     }

--- a/webapp/graphite/tags/redis.py
+++ b/webapp/graphite/tags/redis.py
@@ -159,16 +159,20 @@ class RedisTagDB(BaseTagDB):
   def list_tags(self, tagFilter=None, limit=None, requestContext=None):
     result = []
 
+    if tagFilter:
+      tagFilter = re.compile(tagFilter)
+
     for tag in self.r.sscan_iter('tags'):
-      if not tagFilter or re.match(tagFilter, tag) is not None:
-        if len(result) == 0 or tag >= result[-1]:
-          if limit and len(result) >= limit:
-            continue
-          result.append(tag)
-        else:
-          bisect.insort_left(result, tag)
-        if limit and len(result) > limit:
-          del result[-1]
+      if tagFilter and tagFilter.match(tag) is None:
+        continue
+      if len(result) == 0 or tag >= result[-1]:
+        if limit and len(result) >= limit:
+          continue
+        result.append(tag)
+      else:
+        bisect.insort_left(result, tag)
+      if limit and len(result) > limit:
+        del result[-1]
 
     return [
       {'tag': tag}
@@ -192,16 +196,20 @@ class RedisTagDB(BaseTagDB):
   def list_values(self, tag, valueFilter=None, limit=None, requestContext=None):
     result = []
 
+    if valueFilter:
+      valueFilter = re.compile(valueFilter)
+
     for value in self.r.sscan_iter('tags:' + tag + ':values'):
-      if not valueFilter or re.match(valueFilter, value) is not None:
-        if len(result) == 0 or value >= result[-1]:
-          if limit and len(result) >= limit:
-            continue
-          result.append(value)
-        else:
-          bisect.insort_left(result, value)
-        if limit and len(result) > limit:
-          del result[-1]
+      if valueFilter and valueFilter.match(value) is None:
+        continue
+      if len(result) == 0 or value >= result[-1]:
+        if limit and len(result) >= limit:
+          continue
+        result.append(value)
+      else:
+        bisect.insort_left(result, value)
+      if limit and len(result) > limit:
+        del result[-1]
 
     return [
       {'value': value, 'count': self.r.scard('tags:' + tag + ':values:' + value)}

--- a/webapp/graphite/tags/redis.py
+++ b/webapp/graphite/tags/redis.py
@@ -3,8 +3,6 @@ from __future__ import absolute_import
 import re
 import bisect
 
-from django.conf import settings
-
 from graphite.tags.base import BaseTagDB, TaggedSeries
 
 
@@ -24,10 +22,16 @@ class RedisTagDB(BaseTagDB):
     tags:<tag>:values:<value> # Set of paths matching tag/value
 
   """
-  def __init__(self):
+  def __init__(self, settings, *args, **kwargs):
+    super(RedisTagDB, self).__init__(settings, *args, **kwargs)
+
     from redis import Redis
 
-    self.r = Redis(host=settings.TAGDB_REDIS_HOST,port=settings.TAGDB_REDIS_PORT,db=settings.TAGDB_REDIS_DB)
+    self.r = Redis(
+      host=settings.TAGDB_REDIS_HOST,
+      port=settings.TAGDB_REDIS_PORT,
+      db=settings.TAGDB_REDIS_DB
+    )
 
   def _find_series(self, tags, requestContext=None):
     selector = None

--- a/webapp/graphite/tags/utils.py
+++ b/webapp/graphite/tags/utils.py
@@ -3,17 +3,6 @@ import re
 
 from hashlib import sha256
 
-try:
-    from importlib import import_module
-except ImportError:  # python < 2.7 compatibility
-    from django.utils.importlib import import_module
-
-
-def get_tagdb(tagdb_path):
-    module_name, class_name = tagdb_path.rsplit('.', 1)
-    module = import_module(module_name)
-    return getattr(module, class_name)()
-
 
 class TaggedSeries(object):
   @classmethod

--- a/webapp/graphite/tags/views.py
+++ b/webapp/graphite/tags/views.py
@@ -105,7 +105,7 @@ def tagDetails(request, tag):
       STORE.tagdb.get_tag(
         tag,
         valueFilter=request.GET.get('filter'),
-        valueLimit=request.GET.get('limit'),
+        limit=request.GET.get('limit'),
         requestContext=_requestContext(request),
       ) if STORE.tagdb else None,
       indent=(2 if request.GET.get('pretty') else None),

--- a/webapp/graphite/tags/views.py
+++ b/webapp/graphite/tags/views.py
@@ -74,7 +74,8 @@ def findSeries(request):
         requestContext=_requestContext(request),
       ) if STORE.tagdb else [],
       indent=(2 if queryParams.get('pretty') else None),
-      sort_keys=bool(queryParams.get('pretty'))),
+      sort_keys=bool(queryParams.get('pretty'))
+    ),
     content_type='application/json'
   )
 
@@ -86,10 +87,12 @@ def tagList(request):
     json.dumps(
       STORE.tagdb.list_tags(
         tagFilter=request.GET.get('filter'),
+        limit=request.GET.get('limit'),
         requestContext=_requestContext(request),
       ) if STORE.tagdb else [],
       indent=(2 if request.GET.get('pretty') else None),
-      sort_keys=bool(request.GET.get('pretty'))),
+      sort_keys=bool(request.GET.get('pretty'))
+    ),
     content_type='application/json'
   )
 
@@ -102,10 +105,12 @@ def tagDetails(request, tag):
       STORE.tagdb.get_tag(
         tag,
         valueFilter=request.GET.get('filter'),
+        valueLimit=request.GET.get('limit'),
         requestContext=_requestContext(request),
       ) if STORE.tagdb else None,
       indent=(2 if request.GET.get('pretty') else None),
-      sort_keys=bool(request.GET.get('pretty'))),
+      sort_keys=bool(request.GET.get('pretty'))
+    ),
     content_type='application/json'
   )
 
@@ -124,15 +129,17 @@ def autoCompleteTags(request):
   elif len(queryParams.getlist('expr[]')) > 0:
     exprs = queryParams.getlist('expr[]')
 
-  tagPrefix = queryParams.get('tagPrefix')
-
-  result = STORE.tagdb.auto_complete_tags(
-    exprs, tagPrefix, limit=queryParams.get('limit'), requestContext=_requestContext(request))
-
   return HttpResponse(
-    json.dumps(result,
-               indent=(2 if queryParams.get('pretty') else None),
-               sort_keys=bool(queryParams.get('pretty'))),
+    json.dumps(
+      STORE.tagdb.auto_complete_tags(
+        exprs,
+        tagPrefix=queryParams.get('tagPrefix'),
+        limit=queryParams.get('limit'),
+        requestContext=_requestContext(request)
+      ) if STORE.tagdb else [],
+      indent=(2 if queryParams.get('pretty') else None),
+      sort_keys=bool(queryParams.get('pretty'))
+    ),
     content_type='application/json'
   )
 
@@ -159,14 +166,17 @@ def autoCompleteValues(request):
       status=400
     )
 
-  valuePrefix = queryParams.get('valuePrefix')
-
-  result = STORE.tagdb.auto_complete_values(
-    exprs, tag, valuePrefix, limit=queryParams.get('limit'), requestContext=_requestContext(request))
-
   return HttpResponse(
-    json.dumps(result,
-               indent=(2 if queryParams.get('pretty') else None),
-               sort_keys=bool(queryParams.get('pretty'))),
+    json.dumps(
+      STORE.tagdb.auto_complete_values(
+        exprs,
+        tag,
+        valuePrefix=queryParams.get('valuePrefix'),
+        limit=queryParams.get('limit'),
+        requestContext=_requestContext(request)
+      ) if STORE.tagdb else [],
+      indent=(2 if queryParams.get('pretty') else None),
+      sort_keys=bool(queryParams.get('pretty'))
+    ),
     content_type='application/json'
   )

--- a/webapp/tests/test_tags.py
+++ b/webapp/tests/test_tags.py
@@ -103,7 +103,7 @@ class TagsTest(TestCase):
     self.assertEqual(valueList[1]['value'], 'tiger')
 
     # get tag & limited list of values
-    result = db.get_tag('hello', valueLimit=1)
+    result = db.get_tag('hello', limit=1)
     self.assertEqual(result['tag'], 'hello')
     valueList = [value for value in result['values'] if value['value'] in ['tiger', 'lion']]
     self.assertEqual(len(valueList), 1)

--- a/webapp/tests/test_tags.py
+++ b/webapp/tests/test_tags.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 try:
   from django.urls import reverse
@@ -53,11 +53,11 @@ class TagsTest(TestCase):
     db.del_series('test.a;blah=blah;hello=tiger')
 
     result = db.get_series('test.a;blah=blah;hello=tiger')
-    self.assertEquals(result, None)
+    self.assertEqual(result, None)
 
     # tag a series
     result = db.tag_series('test.a;hello=tiger;blah=blah')
-    self.assertEquals(result, 'test.a;blah=blah;hello=tiger')
+    self.assertEqual(result, 'test.a;blah=blah;hello=tiger')
 
     # get series details
     result = db.get_series('test.a;blah=blah;hello=tiger')
@@ -67,47 +67,64 @@ class TagsTest(TestCase):
 
     # tag the same series again
     result = db.tag_series('test.a;blah=blah;hello=tiger')
-    self.assertEquals(result, 'test.a;blah=blah;hello=tiger')
+    self.assertEqual(result, 'test.a;blah=blah;hello=tiger')
 
     # tag another series
     result = db.tag_series('test.a;blah=blah;hello=lion')
-    self.assertEquals(result, 'test.a;blah=blah;hello=lion')
+    self.assertEqual(result, 'test.a;blah=blah;hello=lion')
 
     # get list of tags
     result = db.list_tags()
     tagList = [tag for tag in result if tag['tag'] in ['name', 'hello', 'blah']]
-    self.assertEquals(len(tagList), 3)
-    self.assertEquals(tagList[0]['tag'], 'blah')
-    self.assertEquals(tagList[1]['tag'], 'hello')
-    self.assertEquals(tagList[2]['tag'], 'name')
+    self.assertEqual(len(tagList), 3)
+    self.assertEqual(tagList[0]['tag'], 'blah')
+    self.assertEqual(tagList[1]['tag'], 'hello')
+    self.assertEqual(tagList[2]['tag'], 'name')
 
     # get filtered list of tags
     result = db.list_tags(tagFilter='hello|bla')
     tagList = [tag for tag in result if tag['tag'] in ['name', 'hello', 'blah']]
-    self.assertEquals(len(tagList), 2)
-    self.assertEquals(tagList[0]['tag'], 'blah')
-    self.assertEquals(tagList[1]['tag'], 'hello')
+    self.assertEqual(len(tagList), 2)
+    self.assertEqual(tagList[0]['tag'], 'blah')
+    self.assertEqual(tagList[1]['tag'], 'hello')
+
+    # get filtered & limited list of tags
+    result = db.list_tags(tagFilter='hello|bla', limit=1)
+    tagList = [tag for tag in result if tag['tag'] in ['name', 'hello', 'blah']]
+    self.assertEqual(len(tagList), 1)
+    self.assertEqual(tagList[0]['tag'], 'blah')
 
     # get tag & list of values
     result = db.get_tag('hello')
-    self.assertEquals(result['tag'], 'hello')
+    self.assertEqual(result['tag'], 'hello')
     valueList = [value for value in result['values'] if value['value'] in ['tiger', 'lion']]
-    self.assertEquals(len(valueList), 2)
-    self.assertEquals(valueList[0]['value'], 'lion')
-    self.assertEquals(valueList[1]['value'], 'tiger')
+    self.assertEqual(len(valueList), 2)
+    self.assertEqual(valueList[0]['value'], 'lion')
+    self.assertEqual(valueList[1]['value'], 'tiger')
+
+    # get tag & limited list of values
+    result = db.get_tag('hello', valueLimit=1)
+    self.assertEqual(result['tag'], 'hello')
+    valueList = [value for value in result['values'] if value['value'] in ['tiger', 'lion']]
+    self.assertEqual(len(valueList), 1)
+    self.assertEqual(valueList[0]['value'], 'lion')
 
     # get tag & filtered list of values (match)
     result = db.get_tag('hello', valueFilter='tig')
-    self.assertEquals(result['tag'], 'hello')
+    self.assertEqual(result['tag'], 'hello')
     valueList = [value for value in result['values'] if value['value'] in ['tiger', 'lion']]
-    self.assertEquals(len(valueList), 1)
-    self.assertEquals(valueList[0]['value'], 'tiger')
+    self.assertEqual(len(valueList), 1)
+    self.assertEqual(valueList[0]['value'], 'tiger')
 
     # get tag & filtered list of values (no match)
     result = db.get_tag('hello', valueFilter='^tigr')
-    self.assertEquals(result['tag'], 'hello')
+    self.assertEqual(result['tag'], 'hello')
     valueList = [value for value in result['values'] if value['value'] in ['tiger', 'lion']]
-    self.assertEquals(len(valueList), 0)
+    self.assertEqual(len(valueList), 0)
+
+    # get nonexistent tag
+    result = db.get_tag('notarealtag')
+    self.assertIsNone(result)
 
     # basic find
     result = db.find_series(['hello=tiger'])
@@ -143,7 +160,7 @@ class TagsTest(TestCase):
 
     # add series without 'hello' tag
     result = db.tag_series('test.b;blah=blah')
-    self.assertEquals(result, 'test.b;blah=blah')
+    self.assertEqual(result, 'test.b;blah=blah')
 
     # find series without tag
     result = db.find_series(['name=test.b', 'hello='])
@@ -181,11 +198,13 @@ class TagsTest(TestCase):
   def _test_autocomplete(self, db, patch_target):
     search_exprs = ['name=test.a']
 
+    find_result = [('test.a;tag1=value1.%3d;tag2=value2.%3d' % (i, 201 - i)) for i in range(1,201)]
+
     def mock_find_series(self, exprs, requestContext=None):
-      if exprs != search_exprs:
+      if search_exprs[0] not in exprs:
         raise Exception('Unexpected exprs %s' % str(exprs))
 
-      return [('test.a;tag1=value1.%3d;tag2=value2.%3d' % (i, 201 - i)) for i in range(1,201)]
+      return find_result
 
     with patch(patch_target, mock_find_series):
       result = db.auto_complete_tags(search_exprs)
@@ -208,8 +227,16 @@ class TagsTest(TestCase):
       result = db.auto_complete_values(search_exprs, 'tag1', 'value1.1')
       self.assertEqual(result, [('value1.%3d' % i) for i in range(100,200)])
 
+      result = db.auto_complete_values(search_exprs, 'tag1', 'value1.1', limit=50)
+      self.assertEqual(result, [('value1.%3d' % i) for i in range(100,150)])
+
       result = db.auto_complete_values(search_exprs, 'nonexistenttag1', 'value1.1')
       self.assertEqual(result, [])
+
+      find_result = [('test.a;tag1=value1.%3d;tag2=value2.%3d' % (i // 2, (201 - i) // 2)) for i in range(2,202)]
+
+      result = db.auto_complete_values(search_exprs, 'tag1', 'value1.', limit=50)
+      self.assertEqual(result, [('value1.%3d' % i) for i in range(1,51)])
 
   def test_find_series_cached(self):
       def mock_cache_get(cacheKey):
@@ -279,15 +306,15 @@ class TagsTest(TestCase):
       db.password = 'test'
 
       result = db.tag_series('test.a;hello=tiger;blah=blah')
-      self.assertEquals(result, 'test.a;blah=blah;hello=tiger')
+      self.assertEqual(result, 'test.a;blah=blah;hello=tiger')
 
       result = db.list_values('hello')
       valueList = [value for value in result if value['value'] in ['tiger', 'lion']]
-      self.assertEquals(len(valueList), 1)
-      self.assertEquals(valueList[0]['value'], 'tiger')
+      self.assertEqual(len(valueList), 1)
+      self.assertEqual(valueList[0]['value'], 'tiger')
 
       result = db.list_values('notarealtag')
-      self.assertEquals(result, [])
+      self.assertEqual(result, [])
 
       self.assertTrue(db.del_series('test.a;blah=blah;hello=tiger'))
 

--- a/webapp/tests/test_util.py
+++ b/webapp/tests/test_util.py
@@ -89,3 +89,27 @@ class UtilTest(TestCase):
     def test_load_module(self):
         with self.assertRaises(IOError):
             module = util.load_module('test', member=None)
+
+    @patch('graphite.util.log')
+    def test_logtime(self, log):
+      @util.logtime
+      def test_logtime(ok, custom=None, timer=None):
+        timer.set_name('test')
+        if custom:
+          timer.set_msg(custom)
+        if ok:
+          return True
+        raise Exception('testException')
+
+      test_logtime(True)
+      self.assertEqual(log.info.call_count, 1)
+      self.assertRegexpMatches(log.info.call_args[0][0], r'test :: completed in [-.e0-9]+s')
+
+      test_logtime(True, 'custom')
+      self.assertEqual(log.info.call_count, 2)
+      self.assertRegexpMatches(log.info.call_args[0][0], r'test :: custom [-.e0-9]+s')
+
+      with self.assertRaisesRegexp(Exception, 'testException'):
+        test_logtime(False)
+      self.assertEqual(log.info.call_count, 3)
+      self.assertRegexpMatches(log.info.call_args[0][0], r'test :: failed in [-.e0-9]+s')

--- a/webapp/tests/test_worker_pool.py
+++ b/webapp/tests/test_worker_pool.py
@@ -54,7 +54,7 @@ class TestPool(unittest.TestCase):
         self.assertEqual(list(results)[0].result, 'a')
 
     def test_timeout(self):
-        p = pool.get_pool(thread_count=4)
+        p = pool.get_pool(thread_count=2)
 
         jobs = [pool.Job(lambda v: time.sleep(1) and v, i) for i in range(1, 5)]
 


### PR DESCRIPTION
This PR makes a number of updates to the internal TagDB APIs, so I bundled them together to avoid plugin authors having to update multiple times.

The first change is to add a `limit` parameter to the `list_tags`, `get_tag` & `list_values` methods, which allow for better efficiency in the autocomplete case where there is no starting expression because we can push the limit down to the database or out to the remote http tagdb.

The second change standardizes the internal parameter names to keep things clean, though it doesn't change the `tagPrefix` and `valuePrefix` query parameters for auto-complete, since Grafana already uses those.

The last change is a refactor so that the base TagDB uses dependency injection to get the settings, cache & log objects, so that the internal dependencies are minimal.  This should address the concerns in #2112 

I also updated the tag tests to use `assertEqual` instead of the deprecated `assertEquals`