### PR TITLE
Get rid of OverflowError in perSecond and scaleToSeconds

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1177,7 +1177,11 @@ def scaleToSeconds(requestContext, seriesList, seconds):
 
     for i,value in enumerate(series):
       if value is not None:
-        series[i] = round(value * factor, 6)
+        # Division long by float cause OverflowError
+        try:
+          series[i] = round(value * factor, 6)
+        except OverflowError:
+          series[i] = (value // series.step) * seconds
 
   return seriesList
 
@@ -1609,7 +1613,11 @@ def perSecond(requestContext, seriesList, maxValue=None):
       delta, prev = _nonNegativeDelta(val, prev, maxValue)
 
       if delta is not None:
-        newValues.append(round(delta / step, 6))
+        # Division long by float cause OverflowError
+        try:
+          newValues.append(round(delta / step, 6))
+        except OverflowError:
+          newValues.append(delta // step)
       else:
         newValues.append(None)
 

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -1581,8 +1581,8 @@ class FunctionsTest(TestCase):
         self.assertEqual(expected, result, 'nonNegativeDerivative result incorrect')
 
     def test_perSecond(self):
-        seriesList = self._gen_series_list_with_data(key='test',start=0,end=600,step=60,data=[0, 120, 240, 480, 960, 1920, 3840, 7680, 15360, 30720])
-        expected = [TimeSeries('perSecond(test)', 0, 600, 60, [None, 2, 2, 4, 8, 16, 32, 64, 128, 256])]
+        seriesList = self._gen_series_list_with_data(key='test',start=0,end=600,step=60,data=[0, 120, 240, 480, 960, 1920, 3840, 7680, 15360, 60 ** 256 + 15360 ])
+        expected = [TimeSeries('perSecond(test)', 0, 600, 60, [None, 2, 2, 4, 8, 16, 32, 64, 128, 60 ** 255])]
         result = functions.perSecond({}, seriesList)
         self.assertEqual(list(expected[0]), list(result[0]))
         self.assertEqual(expected, result)
@@ -1592,8 +1592,8 @@ class FunctionsTest(TestCase):
         self.assertEqual(list(expected[0]), list(result[0]))
 
     def test_perSecond_float(self):
-        seriesList = self._gen_series_list_with_data(key='test',start=0,end=600,step=60,data=[0, 90, 186, 291, 411, 561, 747, 939, 136, 336])
-        expected = [TimeSeries('perSecond(test)', 0, 600, 60, [None, 1.5, 1.6, 1.75, 2, 2.5, 3.1, 3.2, 3.3, 3.333333])]
+        seriesList = self._gen_series_list_with_data(key='test',start=0,end=600,step=60,data=[0, 90, 186, 291, 411, 561, 747, 136, 336, 60**256 + 336])
+        expected = [TimeSeries('perSecond(test)', 0, 600, 60, [None, 1.5, 1.6, 1.75, 2, 2.5, 3.1, 6.5, 3.333333, None])]
         result = functions.perSecond({}, seriesList, maxValue=1000)
         self.assertEqual(list(expected[0]), list(result[0]))
         self.assertEqual(expected, result)


### PR DESCRIPTION
OverflowError for perSecond was fixed in #2029, but in #2115 OverflowError is back.
There fix of perSecond, scaleToSeconds and updated tests.