### PR TITLE
Tag federation & py3 fixes

### DIFF
--- a/webapp/graphite/finders/remote.py
+++ b/webapp/graphite/finders/remote.py
@@ -191,9 +191,13 @@ class RemoteFinder(BaseFinder):
             ('limit', str(limit)),
         ]
         for expr in exprs:
-          fields.append(('expr', expr))
+            fields.append(('expr', expr))
 
-        result = self.request('/tags/autoComplete/tags', fields, requestContext)
+        result = self.request(
+            '/tags/autoComplete/tags',
+            fields,
+            headers=requestContext.get('forwardHeaders') if requestContext else None,
+            timeout=settings.REMOTE_FIND_TIMEOUT)
         try:
             reader = codecs.getreader('utf-8')
             results = json.load(reader(result))
@@ -213,7 +217,7 @@ class RemoteFinder(BaseFinder):
         Return auto-complete suggestions for tags and values based on the matches for the specified expressions, optionally filtered by tag and/or value prefix
         """
         if limit is None:
-            limit = self.settings.TAGDB_AUTOCOMPLETE_LIMIT
+            limit = settings.TAGDB_AUTOCOMPLETE_LIMIT
 
         fields = [
             ('tag', tag or ''),
@@ -221,9 +225,13 @@ class RemoteFinder(BaseFinder):
             ('limit', str(limit)),
         ]
         for expr in exprs:
-          fields.append(('expr', expr))
+            fields.append(('expr', expr))
 
-        result = self.request('/tags/autoComplete/values', fields, requestContext)
+        result = self.request(
+            '/tags/autoComplete/values',
+            fields,
+            headers=requestContext.get('forwardHeaders') if requestContext else None,
+            timeout=settings.REMOTE_FIND_TIMEOUT)
         try:
             reader = codecs.getreader('utf-8')
             results = json.load(reader(result))

--- a/webapp/graphite/finders/remote.py
+++ b/webapp/graphite/finders/remote.py
@@ -49,6 +49,7 @@ class RemoteFinder(BaseFinder):
         self.url = parsed['url']
         self.params = parsed['params']
         self.last_failure = 0
+        self.tags = not self.params.get('noTags')
 
     @property
     def disabled(self):

--- a/webapp/graphite/finders/utils.py
+++ b/webapp/graphite/finders/utils.py
@@ -43,6 +43,8 @@ class BaseFinder(object):
     local = True
     # set to True if this finder shouldn't be used
     disabled = False
+    # set to True if this finder supports seriesByTag
+    tags = False
 
     def __init__(self):
         """Initialize the finder."""

--- a/webapp/graphite/finders/utils.py
+++ b/webapp/graphite/finders/utils.py
@@ -149,3 +149,9 @@ class BaseFinder(object):
             })
 
         return result
+
+    def auto_complete_tags(self, exprs, tagPrefix=None, limit=None, requestContext=None):
+        return []
+
+    def auto_complete_values(self, exprs, tag, valuePrefix=None, limit=None, requestContext=None):
+        return []

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -25,7 +25,7 @@ from graphite.util import timebounds, logtime
 
 
 class TimeSeries(list):
-  def __init__(self, name, start, end, step, values, consolidate='average', tags=None, xFilesFactor=None):
+  def __init__(self, name, start, end, step, values, consolidate='average', tags=None, xFilesFactor=None, pathExpression=None):
     list.__init__(self, values)
     self.name = name
     self.start = start
@@ -34,7 +34,7 @@ class TimeSeries(list):
     self.consolidationFunc = consolidate
     self.valuesPerPoint = 1
     self.options = {}
-    self.pathExpression = name
+    self.pathExpression = pathExpression or name
     self.xFilesFactor = xFilesFactor if xFilesFactor is not None else settings.DEFAULT_XFILES_FACTOR
 
     if tags:

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -6,13 +6,12 @@ from graphite.render.datalib import fetchData, TimeSeries, prefetchData
 from graphite.storage import STORE
 
 
-def evaluateTarget(requestContext, targets, noPrefetch=False):
+def evaluateTarget(requestContext, targets):
   if not isinstance(targets, list):
     targets = [targets]
 
-  if not noPrefetch:
-    pathExpressions = extractPathExpressions(requestContext, targets)
-    prefetchData(requestContext, pathExpressions)
+  pathExpressions = extractPathExpressions(requestContext, targets)
+  prefetchData(requestContext, pathExpressions)
 
   seriesList = []
 

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -1,9 +1,9 @@
 import re
+import six
 
 from graphite.render.grammar import grammar
 from graphite.render.datalib import fetchData, TimeSeries, prefetchData
 from graphite.storage import STORE
-import six
 
 
 def evaluateTarget(requestContext, targets, noPrefetch=False):
@@ -78,6 +78,9 @@ def evaluateTokens(requestContext, tokens, replacements=None, pipedArg=None):
       # as tokens.template. this generally happens if you try to pass non-numeric/string args
       raise ValueError("invalid template() syntax, only string/numeric arguments are allowed")
 
+    if tokens.call.funcname == 'seriesByTag':
+      return fetchData(requestContext, tokens.call.raw)
+
     func = SeriesFunctions[tokens.call.funcname]
     rawArgs = tokens.call.args or []
     if pipedArg is not None:
@@ -145,14 +148,9 @@ def extractPathExpressions(requestContext, targets):
             expression = expression.replace('$'+name, str(replacements[name]))
       pathExpressions.add(expression)
     elif tokens.call:
-      # if we're prefetching seriesByTag, look up the matching series and prefetch those
+      # if we're prefetching seriesByTag, pass the entire call back as a path expression
       if tokens.call.funcname == 'seriesByTag':
-        if STORE.tagdb:
-          for series in STORE.tagdb.find_series(
-              tuple([t.string[1:-1] for t in tokens.call.args if t.string]),
-              requestContext=requestContext,
-          ):
-            pathExpressions.add(series)
+        pathExpressions.add(tokens.call.raw)
       else:
         for a in tokens.call.args:
           extractPathExpression(requestContext, a, replacements)

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -3,7 +3,6 @@ import six
 
 from graphite.render.grammar import grammar
 from graphite.render.datalib import fetchData, TimeSeries, prefetchData
-from graphite.storage import STORE
 
 
 def evaluateTarget(requestContext, targets):

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -4303,28 +4303,7 @@ def seriesByTag(requestContext, *tagExpressions):
 
   See :ref:`querying tagged series <querying-tagged-series>` for more detail.
   """
-
-  if STORE.tagdb is None:
-    log.info('seriesByTag called but no TagDB configured')
-    return []
-
-  taggedSeries = STORE.tagdb.find_series(tagExpressions, requestContext=requestContext)
-  if not taggedSeries:
-    return []
-
-  taggedSeriesQuery = 'group(' + ','.join(taggedSeries) + ')'
-
-  log.debug('taggedSeriesQuery %s' % taggedSeriesQuery)
-
-  seriesList = evaluateTarget(requestContext, taggedSeriesQuery, noPrefetch=True)
-
-  pathExpr = 'seriesByTag(%s)' % ','.join(['"%s"' % expr for expr in tagExpressions])
-  for series in seriesList:
-    series.pathExpression = pathExpr
-
-  log.debug('seriesByTag found [%s]' % ', '.join([series.name for series in seriesList]))
-
-  return seriesList
+  # the handling of seriesByTag is implemented in STORE.fetch
 
 def groupByTags(requestContext, seriesList, callback, *tags):
   """

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -21,19 +21,12 @@ from django.conf import settings
 import pytz
 
 from graphite.render.datalib import TimeSeries
-from graphite.util import json
+from graphite.util import json, BytesIO
 
 try:
     import cairocffi as cairo
 except ImportError:
     import cairo
-
-# BytesIO is needed on py3 as StringIO does not operate on byte input anymore
-# We could use BytesIO on py2 as well but it is slower than StringIO
-if sys.version_info >= (3, 0):
-  from io import BytesIO as StringIO
-else:
-  from cStringIO import StringIO
 
 INFINITY = float('inf')
 
@@ -585,10 +578,10 @@ class Graph:
     if outputFormat == 'png':
       self.surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, self.width, self.height)
     elif outputFormat == 'svg':
-      self.surfaceData = StringIO.StringIO()
+      self.surfaceData = BytesIO()
       self.surface = cairo.SVGSurface(self.surfaceData, self.width, self.height)
     elif outputFormat == 'pdf':
-      self.surfaceData = StringIO.StringIO()
+      self.surfaceData = BytesIO()
       self.surface = cairo.PDFSurface(self.surfaceData, self.width, self.height)
       res_x, res_y = self.surface.get_fallback_resolution()
       self.width = float(self.width / res_x) * 72

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-import math, itertools, re, sys
+import math, itertools, re
 from datetime import datetime, timedelta
 from six.moves import range, zip
 from six.moves.urllib.parse import unquote_plus

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -882,7 +882,7 @@ class Graph:
         metaData = { }
 
       self.surface.finish()
-      svgData = self.surfaceData.getvalue()
+      svgData = str(self.surfaceData.getvalue())
       self.surfaceData.close()
 
       svgData = svgData.replace('pt"', 'px"', 2) # we expect height/width in pixels, not points
@@ -905,13 +905,13 @@ class Graph:
           svgData += "</g>"
         svgData = svgData.replace(' data-header="true"','')
 
-      fileObj.write(svgData)
-      fileObj.write("""<script>
+      fileObj.write(svgData.encode('utf-8'))
+      fileObj.write(("""<script>
   <![CDATA[
     metadata = %s
   ]]>
 </script>
-</svg>""" % json.dumps(metaData))
+</svg>""" % json.dumps(metaData)).encode('utf-8'))
 
 
 class LineGraph(Graph):

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -24,7 +24,7 @@ from cgi import parse_qs
 
 from graphite.compat import HttpResponse
 from graphite.user_util import getProfileByUsername
-from graphite.util import json, unpickle, pickle, msgpack, StringIO
+from graphite.util import json, unpickle, pickle, msgpack, BytesIO
 from graphite.storage import extractForwardHeaders
 from graphite.logger import log
 from graphite.render.evaluator import evaluateTarget
@@ -515,7 +515,7 @@ def delegateRendering(graphType, graphOptions, headers=None):
 def renderLocalView(request):
   try:
     start = time()
-    reqParams = StringIO(request.body)
+    reqParams = BytesIO(request.body)
     graphType = reqParams.readline().strip()
     optionsPickle = reqParams.read()
     reqParams.close()
@@ -569,7 +569,7 @@ def renderMyGraphView(request,username,graphName):
 
 
 def doImageRender(graphClass, graphOptions):
-  pngData = StringIO()
+  pngData = BytesIO()
   t = time()
   img = graphClass(**graphOptions)
   img.output(pngData)

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -99,32 +99,16 @@ class Store(object):
         tag_patterns = None
         pattern_aliases = defaultdict(list)
         for finder in self.get_finders(requestContext.get('localOnly')):
+          # if the finder supports tags, just pass the patterns through
           if getattr(finder, 'tags', False):
             jobs.append(Job(finder.fetch, patterns, startTime, endTime, now=now, requestContext=requestContext))
             continue
 
+          # if we haven't resolved the seriesByTag calls, build resolved patterns and translation table
           if tag_patterns is None:
-            tag_patterns = []
-            for pattern in patterns:
-              if not pattern.startswith('seriesByTag('):
-                tag_patterns.append(pattern)
-                continue
+            tag_patterns, pattern_aliases = self._tag_patterns(patterns, requestContext)
 
-              exprs = tuple([
-                t.string[1:-1]
-                for t in grammar.parseString(pattern).expression.call.args
-                if t.string
-              ])
-              taggedSeries = self.tagdb.find_series(exprs, requestContext=requestContext)
-              if not taggedSeries:
-                continue
-
-              for series in taggedSeries:
-                pattern_aliases[series].append(pattern)
-
-              tag_patterns.extend(taggedSeries)
-            tag_patterns = sorted(set(tag_patterns))
-
+          # dispatch resolved patterns to finder
           jobs.append(Job(finder.fetch, tag_patterns, startTime, endTime, now=now, requestContext=requestContext))
 
         results = []
@@ -153,7 +137,7 @@ class Store(object):
             raise Exception("Fetch for %s failed: %s" % (str(patterns), str(job.exception)))
           raise Exception('All fetches failed for %s' % (str(patterns)))
 
-        # translate path expressions for seriesByTag calls
+        # translate path expressions for responses from resolved seriesByTag patterns
         for result in results:
           if result['name'] == result['pathExpression'] and result['pathExpression'] in pattern_aliases:
             for pathExpr in pattern_aliases[result['pathExpression']]:
@@ -163,6 +147,35 @@ class Store(object):
 
         log.debug("Got all fetch results for %s in %fs" % (str(patterns), time.time() - start))
         return results
+
+    def _tag_patterns(self, patterns, requestContext):
+      tag_patterns = []
+      pattern_aliases = defaultdict(list)
+
+      for pattern in patterns:
+        # if pattern isn't a seriesByTag call, just add it to the list
+        if not pattern.startswith('seriesByTag('):
+          tag_patterns.append(pattern)
+          continue
+
+        # perform the tagdb lookup
+        exprs = tuple([
+          t.string[1:-1]
+          for t in grammar.parseString(pattern).expression.call.args
+          if t.string
+        ])
+        taggedSeries = self.tagdb.find_series(exprs, requestContext=requestContext)
+        if not taggedSeries:
+          continue
+
+        # add to translation table for path matching
+        for series in taggedSeries:
+          pattern_aliases[series].append(pattern)
+
+        # add to list of resolved patterns
+        tag_patterns.extend(taggedSeries)
+
+      return sorted(set(tag_patterns)), pattern_aliases
 
     def get_index(self, requestContext=None):
         log.debug('graphite.storage.Store.get_index :: Starting get_index on all backends')

--- a/webapp/graphite/tags/views.py
+++ b/webapp/graphite/tags/views.py
@@ -153,7 +153,7 @@ def autoCompleteTags(request, queryParams):
   elif len(queryParams.getlist('expr[]')) > 0:
     exprs = queryParams.getlist('expr[]')
 
-  return STORE.tagdb.auto_complete_tags(
+  return STORE.tagdb_auto_complete_tags(
     exprs,
     tagPrefix=queryParams.get('tagPrefix'),
     limit=queryParams.get('limit'),
@@ -177,7 +177,7 @@ def autoCompleteValues(request, queryParams):
   if not tag:
     raise HttpError('no tag specified', status=400)
 
-  return STORE.tagdb.auto_complete_values(
+  return STORE.tagdb_auto_complete_values(
     exprs,
     tag,
     valuePrefix=queryParams.get('valuePrefix'),

--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -37,21 +37,10 @@ if sys.version_info >= (3, 0):
   PY3 = True
   import pickle
   from io import BytesIO
-
-
-  class StringIO(BytesIO):
-    def __init__(self, buffer=None):
-      if buffer is None:
-        super().__init__()
-      elif isinstance(buffer, six.string_types):
-        super().__init__(buffer.encode('utf-8'))
-      else:
-        super().__init__(buffer)
-
 else:
   PY3 = False
   import cPickle as pickle
-  from cStringIO import StringIO
+  from cStringIO import StringIO as BytesIO
 
 # use https://github.com/msgpack/msgpack-python if available
 try:
@@ -177,7 +166,7 @@ if not PY3:
 
     @classmethod
     def loads(cls, pickle_string):
-      pickle_obj = pickle.Unpickler(StringIO(pickle_string))
+      pickle_obj = pickle.Unpickler(BytesIO(pickle_string))
       pickle_obj.find_global = cls.find_class
       return pickle_obj.load()
 
@@ -211,7 +200,7 @@ else:
   class unpickle(object):
     @staticmethod
     def loads(pickle_string):
-      return SafeUnpickler(StringIO(pickle_string)).load()
+      return SafeUnpickler(BytesIO(pickle_string)).load()
 
     @staticmethod
     def load(file):

--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -36,7 +36,18 @@ from graphite.logger import log
 if sys.version_info >= (3, 0):
   PY3 = True
   import pickle
-  from io import BytesIO as StringIO
+  from io import BytesIO
+
+
+  class StringIO(BytesIO):
+    def __init__(self, buffer=None):
+      if buffer is None:
+        super().__init__()
+      elif isinstance(buffer, six.string_types):
+        super().__init__(buffer.encode('utf-8'))
+      else:
+        super().__init__(buffer)
+
 else:
   PY3 = False
   import cPickle as pickle

--- a/webapp/tests/test_finders_remote.py
+++ b/webapp/tests/test_finders_remote.py
@@ -9,7 +9,7 @@ from mock import patch
 from graphite.finders.remote import RemoteFinder
 from graphite.finders.utils import FindQuery
 from graphite.node import BranchNode, LeafNode
-from graphite.util import json, pickle, StringIO, msgpack
+from graphite.util import json, pickle, BytesIO, msgpack
 
 from .base import TestCase
 
@@ -78,7 +78,7 @@ class RemoteFinderTest(TestCase):
           'is_leaf': True,
         },
       ]
-      responseObject = HTTPResponse(body=StringIO(pickle.dumps(data)), status=200, preload_content=False)
+      responseObject = HTTPResponse(body=BytesIO(pickle.dumps(data)), status=200, preload_content=False)
       http_request.return_value = responseObject
 
       query = FindQuery('a.b.c', startTime, endTime)
@@ -126,7 +126,7 @@ class RemoteFinderTest(TestCase):
         },
       ]
       responseObject = HTTPResponse(
-        body=StringIO(msgpack.dumps(data)),
+        body=BytesIO(msgpack.dumps(data)),
         status=200,
         preload_content=False,
         headers={'Content-Type': 'application/x-msgpack'}
@@ -164,7 +164,7 @@ class RemoteFinderTest(TestCase):
       self.assertEqual(nodes[1].path, 'a.b.c.d')
 
       # non-pickle response
-      responseObject = HTTPResponse(body=StringIO('error'), status=200, preload_content=False)
+      responseObject = HTTPResponse(body=BytesIO(b'error'), status=200, preload_content=False)
       http_request.return_value = responseObject
 
       result = finder.find_nodes(query)
@@ -236,7 +236,7 @@ class RemoteFinderTest(TestCase):
           'name': 'a.b.c.d',
         },
       ]
-      responseObject = HTTPResponse(body=StringIO(pickle.dumps(data)), status=200, preload_content=False)
+      responseObject = HTTPResponse(body=BytesIO(pickle.dumps(data)), status=200, preload_content=False)
       http_request.return_value = responseObject
 
       result = finder.fetch(['a.b.c.d'], startTime, endTime)
@@ -278,7 +278,7 @@ class RemoteFinderTest(TestCase):
         'a.b.c',
         'a.b.c.d',
       ]
-      responseObject = HTTPResponse(body=StringIO(json.dumps(data)), status=200, preload_content=False)
+      responseObject = HTTPResponse(body=BytesIO(json.dumps(data).encode('utf-8')), status=200, preload_content=False)
       http_request.return_value = responseObject
 
       result = finder.get_index({})
@@ -304,7 +304,7 @@ class RemoteFinderTest(TestCase):
       self.assertEqual(result[1], 'a.b.c.d')
 
       # non-json response
-      responseObject = HTTPResponse(body=StringIO('error'), status=200, preload_content=False)
+      responseObject = HTTPResponse(body=BytesIO(b'error'), status=200, preload_content=False)
       http_request.return_value = responseObject
 
       with self.assertRaisesRegexp(Exception, 'Error decoding index response from http://[^ ]+: .+'):
@@ -324,7 +324,7 @@ class RemoteFinderTest(TestCase):
         'tag2',
       ]
 
-      responseObject = HTTPResponse(body=StringIO(json.dumps(data)), status=200, preload_content=False)
+      responseObject = HTTPResponse(body=BytesIO(json.dumps(data).encode('utf-8')), status=200, preload_content=False)
       http_request.return_value = responseObject
 
       result = finder.auto_complete_tags(['name=test'], 'tag')
@@ -352,7 +352,7 @@ class RemoteFinderTest(TestCase):
       self.assertEqual(result[1], 'tag2')
 
       # explicit limit & forward headers
-      responseObject = HTTPResponse(body=StringIO(json.dumps(data)), status=200, preload_content=False)
+      responseObject = HTTPResponse(body=BytesIO(json.dumps(data).encode('utf-8')), status=200, preload_content=False)
       http_request.return_value = responseObject
 
       result = finder.auto_complete_tags(['name=test', 'tag3=value3'], 'tag', limit=5, requestContext={'forwardHeaders': {'X-Test': 'test'}})
@@ -381,7 +381,7 @@ class RemoteFinderTest(TestCase):
       self.assertEqual(result[1], 'tag2')
 
       # non-json response
-      responseObject = HTTPResponse(body=StringIO('error'), status=200, preload_content=False)
+      responseObject = HTTPResponse(body=BytesIO(b'error'), status=200, preload_content=False)
       http_request.return_value = responseObject
 
       with self.assertRaisesRegexp(Exception, 'Error decoding autocomplete tags response from http://[^ ]+: .+'):
@@ -401,7 +401,7 @@ class RemoteFinderTest(TestCase):
         'value2',
       ]
 
-      responseObject = HTTPResponse(body=StringIO(json.dumps(data)), status=200, preload_content=False)
+      responseObject = HTTPResponse(body=BytesIO(json.dumps(data).encode('utf-8')), status=200, preload_content=False)
       http_request.return_value = responseObject
 
       result = finder.auto_complete_values(['name=test'], 'tag1', 'value')
@@ -430,7 +430,7 @@ class RemoteFinderTest(TestCase):
       self.assertEqual(result[1], 'value2')
 
       # explicit limit & forward headers
-      responseObject = HTTPResponse(body=StringIO(json.dumps(data)), status=200, preload_content=False)
+      responseObject = HTTPResponse(body=BytesIO(json.dumps(data).encode('utf-8')), status=200, preload_content=False)
       http_request.return_value = responseObject
 
       result = finder.auto_complete_values(['name=test', 'tag3=value3'], 'tag1', 'value', limit=5, requestContext={'forwardHeaders': {'X-Test': 'test'}})
@@ -460,7 +460,7 @@ class RemoteFinderTest(TestCase):
       self.assertEqual(result[1], 'value2')
 
       # non-json response
-      responseObject = HTTPResponse(body=StringIO('error'), status=200, preload_content=False)
+      responseObject = HTTPResponse(body=BytesIO(b'error'), status=200, preload_content=False)
       http_request.return_value = responseObject
 
       with self.assertRaisesRegexp(Exception, 'Error decoding autocomplete values response from http://[^ ]+: .+'):

--- a/webapp/tests/test_finders_remote.py
+++ b/webapp/tests/test_finders_remote.py
@@ -164,7 +164,7 @@ class RemoteFinderTest(TestCase):
       self.assertEqual(nodes[1].path, 'a.b.c.d')
 
       # non-pickle response
-      responseObject = HTTPResponse(body=StringIO(b'error'), status=200, preload_content=False)
+      responseObject = HTTPResponse(body=StringIO('error'), status=200, preload_content=False)
       http_request.return_value = responseObject
 
       result = finder.find_nodes(query)
@@ -278,7 +278,7 @@ class RemoteFinderTest(TestCase):
         'a.b.c',
         'a.b.c.d',
       ]
-      responseObject = HTTPResponse(body=StringIO(json.dumps(data).encode('ascii')), status=200, preload_content=False)
+      responseObject = HTTPResponse(body=StringIO(json.dumps(data)), status=200, preload_content=False)
       http_request.return_value = responseObject
 
       result = finder.get_index({})
@@ -304,7 +304,7 @@ class RemoteFinderTest(TestCase):
       self.assertEqual(result[1], 'a.b.c.d')
 
       # non-json response
-      responseObject = HTTPResponse(body=StringIO(b'error'), status=200, preload_content=False)
+      responseObject = HTTPResponse(body=StringIO('error'), status=200, preload_content=False)
       http_request.return_value = responseObject
 
       with self.assertRaisesRegexp(Exception, 'Error decoding index response from http://[^ ]+: .+'):

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -871,7 +871,7 @@ class FunctionsTest(TestCase):
         gotList = functions.delay({}, source, delay)
         self.assertEqual(len(gotList), len(expectedList))
         for got, expected in zip(gotList, expectedList):
-            self.assertListEqual(got, expected)
+            self.assertEqual(got, expected)
 
     def test_asPercent_error(self):
         seriesList = self._gen_series_list_with_data(
@@ -4195,7 +4195,7 @@ class FunctionsTest(TestCase):
             data=list(range(20, 25))
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return self._gen_series_list_with_data(
                 key='collectd.test-db0.load.value',
                 start=10,
@@ -4215,7 +4215,7 @@ class FunctionsTest(TestCase):
             data=list(range(0, 10))
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return self._gen_series_list_with_data(
                 key='collectd.test-db0.load.value',
                 start=10,
@@ -4249,7 +4249,7 @@ class FunctionsTest(TestCase):
             data=list(range(10, 25))
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return self._gen_series_list_with_data(
                 key='collectd.test-db0.load.value',
                 start=10,
@@ -4279,7 +4279,7 @@ class FunctionsTest(TestCase):
             data=list(range(10, 110))
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return self._gen_series_list_with_data(
                 key='collectd.test-db0.load.value',
                 start=10,
@@ -4309,7 +4309,7 @@ class FunctionsTest(TestCase):
             data=list(range(10, 110))
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return []
 
         expectedResults = []
@@ -4332,7 +4332,7 @@ class FunctionsTest(TestCase):
             data=list(range(10, 110))
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return self._gen_series_list_with_data(
                 key='collectd.test-db0.load.value',
                 start=600,
@@ -4362,7 +4362,7 @@ class FunctionsTest(TestCase):
             data=list(range(10, 610))
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return self._gen_series_list_with_data(
                 key='collectd.test-db0.load.value',
                 start=600,
@@ -4395,7 +4395,7 @@ class FunctionsTest(TestCase):
             data=list(range(0, 25))
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return self._gen_series_list_with_data(
                 key='collectd.test-db0.load.value',
                 start=10,
@@ -4425,7 +4425,7 @@ class FunctionsTest(TestCase):
             data=list(range(0, 10))
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return self._gen_series_list_with_data(
                 key='collectd.test-db0.load.value',
                 start=10,
@@ -4456,7 +4456,7 @@ class FunctionsTest(TestCase):
             data=list(range(10, 110))
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return []
 
         expectedResults = []
@@ -4479,7 +4479,7 @@ class FunctionsTest(TestCase):
             data=list(range(10, 110))
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return self._gen_series_list_with_data(
                 key='collectd.test-db0.load.value',
                 start=600,
@@ -4513,7 +4513,7 @@ class FunctionsTest(TestCase):
             data=list(range(10, 110))
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return self._gen_series_list_with_data(
                 key='collectd.test-db0.load.value',
                 start=600,
@@ -4553,7 +4553,7 @@ class FunctionsTest(TestCase):
             data=list(range(start, end))
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             seriesList = [
                 TimeSeries('collectd.test-db0.load.value', 10, 25, 1, [None, None, None, None, None, None, None, None, None, None, None, None, None, None, None])
             ]
@@ -4583,7 +4583,7 @@ class FunctionsTest(TestCase):
             data=[2, 1] * 5
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             seriesList = [
                 TimeSeries('collectd.test-db0.load.value', 10, 30, 1, [None] * 10 + [2, 1] * 5)
             ]
@@ -4613,7 +4613,7 @@ class FunctionsTest(TestCase):
             data=list(range(10, 10 + 100))
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return []
 
         expectedResults = []
@@ -4636,7 +4636,7 @@ class FunctionsTest(TestCase):
             data=[10, 1] * 5
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return self._gen_series_list_with_data(
                 key='collectd.test-db0.load.value',
                 start=10,
@@ -4666,7 +4666,7 @@ class FunctionsTest(TestCase):
             data=[10, 1] * 50
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return self._gen_series_list_with_data(
                 key='collectd.test-db0.load.value',
                 start=600,
@@ -4701,7 +4701,7 @@ class FunctionsTest(TestCase):
             data=list(range(start, end))
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             seriesList = [
                 TimeSeries('collectd.test-db0.load.value', 10, 25, 1, [None, None, None, None, None, None, None, None, None, None, None, None, None, None, None])
             ]
@@ -4731,7 +4731,7 @@ class FunctionsTest(TestCase):
             data=[1, 2] * 5
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             seriesList = [
                 TimeSeries('collectd.test-db0.load.value', 10, 30, 1, [None] * 10 + [1, 2] * 5)
             ]
@@ -4761,7 +4761,7 @@ class FunctionsTest(TestCase):
             data=list(range(10, 10 + 100))
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return []
 
         expectedResults = []
@@ -4784,7 +4784,7 @@ class FunctionsTest(TestCase):
             data=[1, 2] * 5
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return self._gen_series_list_with_data(
                 key='collectd.test-db0.load.value',
                 start=10,
@@ -4814,7 +4814,7 @@ class FunctionsTest(TestCase):
             data=[1, 10] * 50
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return self._gen_series_list_with_data(
                 key='collectd.test-db0.load.value',
                 start=600,
@@ -4862,7 +4862,7 @@ class FunctionsTest(TestCase):
             data=list(range(start, end))
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             seriesList = [
                 TimeSeries('collectd.test-db0.load.value', 10, 25, 1, [None, None, None, None, None, None, None, None, None, None, None, None, None, None, None])
             ]
@@ -4892,7 +4892,7 @@ class FunctionsTest(TestCase):
             data=list(range(0, 10))
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             seriesList = [
                 TimeSeries('collectd.test-db0.load.value', 10, 30, 1, [None] * 10 + list(range(0, 10)))
             ]
@@ -4922,7 +4922,7 @@ class FunctionsTest(TestCase):
             data=list(range(10, 10 + 100))
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return []
 
         expectedResults = []
@@ -4945,7 +4945,7 @@ class FunctionsTest(TestCase):
             data=[1] * 100
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return self._gen_series_list_with_data(key='collectd.test-db0.load.value', start=600, end=700, step=1, data=[1] * 100)
 
         expectedResults = [
@@ -4970,7 +4970,7 @@ class FunctionsTest(TestCase):
             data=[1] * 100
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return self._gen_series_list_with_data(key='collectd.test-db0.load.value', start=600, end=700, step=1, data=[1] * 100)
 
         expectedResults = [
@@ -4998,7 +4998,7 @@ class FunctionsTest(TestCase):
 
         seriesList = gen_seriesList(10)
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return gen_seriesList()
 
         expectedResults = [
@@ -5036,7 +5036,7 @@ class FunctionsTest(TestCase):
 
         seriesList = gen_seriesList(start_time, points)
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return gen_seriesList(start_time-week_seconds, (week_seconds/step)+points)
 
         expectedResults = [
@@ -5075,7 +5075,7 @@ class FunctionsTest(TestCase):
 
         seriesList = gen_seriesList(start_time, points)
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return gen_seriesList(start_time-week_seconds, (week_seconds/step)+points)
 
         expectedResults = [
@@ -5116,7 +5116,7 @@ class FunctionsTest(TestCase):
 
         seriesList = gen_seriesList(start_time, points)
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return gen_seriesList(start_time-week_seconds, (week_seconds/step)+points)
 
         expectedResults = [
@@ -5683,7 +5683,7 @@ class FunctionsTest(TestCase):
             data=[14.5, 15.5, 16.5, 17.5, 18.5, 19.5, 20.5, 21.5, 22.5, 23.5, 24.5, 25.5, 26.5, 27.5, 28.5, 29.5, 30.5, 31.5, 32.5, 33.5, 34.5, 35.5, 36.5, 37.5, 38.5, 39.5, 40.5, 41.5, 42.5, 43.5, 44.5]
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return seriesList
 
         with patch('graphite.render.functions.evaluateTarget', mock_evaluateTarget):
@@ -5701,7 +5701,7 @@ class FunctionsTest(TestCase):
             data=[14.5, 15.5, 16.5, 17.5, 18.5, 19.5, 20.5, 21.5, 22.5, 23.5, 24.5, 25.5, 26.5, 27.5, 28.5, 29.5, 30.5, 31.5, 32.5, 33.5, 34.5, 35.5, 36.5, 37.5, 38.5, 39.5, 40.5, 41.5, 42.5, 43.5, 44.5]
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return seriesList
 
         with patch('graphite.render.functions.evaluateTarget', mock_evaluateTarget):
@@ -5714,7 +5714,7 @@ class FunctionsTest(TestCase):
         seriesList = self._gen_series_list_with_data(start=600, end=700, data=list(range(0, 100)))
         expectedResults = []
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return []
 
         with patch('graphite.render.functions.evaluateTarget', mock_evaluateTarget):
@@ -5732,7 +5732,7 @@ class FunctionsTest(TestCase):
             data=[0, 0.0, 0.181818, 0.512397, 0.964688, 1.516563, None, 2.149915, 2.849931, 3.604489, 4.403673]
         )
 
-        def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
+        def mock_evaluateTarget(requestContext, targets):
             return self._gen_series_list_with_data(key='collectd.test-db0.load.value',start=10, end=30, data=([None] * 10 + list(range(0, 5)) + [None] + list(range(5, 9))))
 
         with patch('graphite.render.functions.evaluateTarget', mock_evaluateTarget):

--- a/webapp/tests/test_readers_remote.py
+++ b/webapp/tests/test_readers_remote.py
@@ -6,7 +6,7 @@ from urllib3.response import HTTPResponse
 
 from graphite.finders.remote import RemoteFinder
 from graphite.readers.remote import RemoteReader
-from graphite.util import pickle, StringIO, msgpack
+from graphite.util import pickle, BytesIO, msgpack
 from graphite.wsgi import application  # NOQA makes sure we have a working WSGI app
 
 
@@ -64,7 +64,7 @@ class RemoteReaderTests(TestCase):
                  'name': 'a.b.c.d'
                 }
                ]
-        responseObject = HTTPResponse(body=StringIO(pickle.dumps(data)), status=200, preload_content=False)
+        responseObject = HTTPResponse(body=BytesIO(pickle.dumps(data)), status=200, preload_content=False)
         http_request.return_value = responseObject
 
         result = reader.fetch_multi(startTime, endTime)
@@ -108,7 +108,7 @@ class RemoteReaderTests(TestCase):
                 }
                ]
         responseObject = HTTPResponse(
-          body=StringIO(msgpack.dumps(data)),
+          body=BytesIO(msgpack.dumps(data)),
           status=200,
           preload_content=False,
           headers={'Content-Type': 'application/x-msgpack'}
@@ -145,14 +145,14 @@ class RemoteReaderTests(TestCase):
         })
 
         # non-pickle response
-        responseObject = HTTPResponse(body=StringIO(b'error'), status=200, preload_content=False)
+        responseObject = HTTPResponse(body=BytesIO(b'error'), status=200, preload_content=False)
         http_request.return_value = responseObject
 
         with self.assertRaisesRegexp(Exception, 'Error decoding render response from http://[^ ]+: .+'):
           reader.fetch(startTime, endTime)
 
         # non-200 response
-        responseObject = HTTPResponse(body=StringIO(b'error'), status=500, preload_content=False)
+        responseObject = HTTPResponse(body=BytesIO(b'error'), status=500, preload_content=False)
         http_request.return_value = responseObject
 
         with self.assertRaisesRegexp(Exception, 'Error response 500 from http://[^ ]+'):
@@ -203,7 +203,7 @@ class RemoteReaderTests(TestCase):
                  'name': 'a.b.c.d'
                 }
                ]
-        responseObject = HTTPResponse(body=StringIO(pickle.dumps(data)), status=200, preload_content=False)
+        responseObject = HTTPResponse(body=BytesIO(pickle.dumps(data)), status=200, preload_content=False)
         http_request.return_value = responseObject
         result = reader.fetch(startTime, endTime)
         expected_response = ((1496262000, 1496262060, 60), [1.0, 0.0, 1.0, 0.0, 1.0])

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -205,6 +205,21 @@ class RenderTest(TestCase):
         self.assertEqual(response['Content-Type'], 'image/png')
         self.assertTrue(response.has_header('Expires'))
 
+        # png format returns image/png
+        response = self.client.get(url, {'target': 'test', 'format': 'png'})
+        self.assertEqual(response['Content-Type'], 'image/png')
+        self.assertTrue(response.has_header('Expires'))
+
+        # svg format returns image/svg+xml
+        response = self.client.get(url, {'target': 'test', 'format': 'svg'})
+        self.assertEqual(response['Content-Type'], 'image/svg+xml')
+        self.assertTrue(response.has_header('Expires'))
+
+        # pdf format returns application/x-pdf
+        response = self.client.get(url, {'target': 'test', 'format': 'pdf'})
+        self.assertEqual(response['Content-Type'], 'application/x-pdf')
+        self.assertTrue(response.has_header('Expires'))
+
         # Verify graphType=pie returns
         response = self.client.get(url, {'target': 'a:50', 'graphType': 'pie'})
         self.assertEqual(response['Content-Type'], 'image/png')


### PR DESCRIPTION
This PR implements support for distributed tag databases in a clustered graphite scenario, forwarding `seriesByTag` expressions to cluster hosts that support tags.  This will allow tagged graphite to scale out across a cluster horizontally the same way that non-tagged graphite does.

It is currently functional, but needs work on test coverage and cleaning up any rough edges.

The basic concept is that `seriesByTag` handling is moved into the `STORE.fetch()` method, and it can look up per-finder whether the finder supports tags and if so send the `seriesByTag()` expression through to the finder.  For finders that don't support tags the TagDB is used to look up the matching series and the resulting series are fetched.