### PR TITLE
 use _DOT_ to replace literal . in tagged series filenames 

### DIFF
--- a/webapp/graphite/tags/utils.py
+++ b/webapp/graphite/tags/utils.py
@@ -95,7 +95,7 @@ class TaggedSeries(object):
     """
     if ';' in metric:
       metric_hash = sha256(metric.encode('utf8')).hexdigest()
-      return sep.join(['_tagged', metric_hash[0:3], metric_hash[3:6], metric.replace('.', '-')])
+      return sep.join(['_tagged', metric_hash[0:3], metric_hash[3:6], metric.replace('.', '_DOT_')])
 
     # metric isn't tagged, just replace dots with the separator and trim any leading separator
     return metric.replace('.', sep).lstrip(sep)

--- a/webapp/graphite/tags/utils.py
+++ b/webapp/graphite/tags/utils.py
@@ -100,6 +100,17 @@ class TaggedSeries(object):
     # metric isn't tagged, just replace dots with the separator and trim any leading separator
     return metric.replace('.', sep).lstrip(sep)
 
+  @staticmethod
+  def decode(path, sep='.'):
+    """
+    Helper function to decode tagged series from storage in whisper etc
+    """
+    if path.startswith('_tagged'):
+      return path.split(sep, 3)[-1].replace('_DOT_', '.')
+
+    # metric isn't tagged, just replace the separator with dots
+    return path.replace(sep, '.')
+
   def __init__(self, metric, tags, series_id=None):
     self.metric = metric
     self.tags = tags

--- a/webapp/tests/test_tags.py
+++ b/webapp/tests/test_tags.py
@@ -28,7 +28,7 @@ class TagsTest(TestCase):
     self.assertEqual(parsed.path, 'test.a;blah=blah;hello=tiger')
 
     # test encoding
-    self.assertEqual(TaggedSeries.encode(parsed.path), '_tagged.2b0.2af.test-a;blah=blah;hello=tiger')
+    self.assertEqual(TaggedSeries.encode(parsed.path), '_tagged.2b0.2af.test_DOT_a;blah=blah;hello=tiger')
 
     # test path without tags
     parsed = TaggedSeries.parse('test.a')

--- a/webapp/tests/test_tags.py
+++ b/webapp/tests/test_tags.py
@@ -30,6 +30,9 @@ class TagsTest(TestCase):
     # test encoding
     self.assertEqual(TaggedSeries.encode(parsed.path), '_tagged.2b0.2af.test_DOT_a;blah=blah;hello=tiger')
 
+    # test decoding
+    self.assertEqual(TaggedSeries.decode('_tagged.2b0.2af.test_DOT_a;blah=blah;hello=tiger'), parsed.path)
+
     # test path without tags
     parsed = TaggedSeries.parse('test.a')
     self.assertIsInstance(parsed, TaggedSeries)
@@ -40,7 +43,10 @@ class TagsTest(TestCase):
     self.assertEqual(parsed.path, 'test.a')
 
     # test encoding
-    self.assertEqual(TaggedSeries.encode(parsed.path), 'test.a')
+    self.assertEqual(TaggedSeries.encode('test.a', sep='/'), 'test/a')
+
+    # test encoding
+    self.assertEqual(TaggedSeries.decode('test/a', sep='/'), 'test.a')
 
     # test parsing openmetrics
     parsed = TaggedSeries.parse(r'test.a{hello="tiger",blah="bla\"h"}')


### PR DESCRIPTION
This PR changes the behavior of the `TaggedSeries.encode` function to replace `.` characters with `_DOT_` rather than `-` when encoding filenames.  This allows us to implement a more reliable `decode` method, since series will be much less likely to include the string `_DOT_`.  Decode is not yet used, but could be useful if we want to allow the whisper/ceres finders to return more friendly names in their find output.

NB that this is a breaking change to the file naming scheme.