### PR TITLE
use a buffered reader for http responses in remote finder/reader

### DIFF
--- a/webapp/graphite/finders/remote.py
+++ b/webapp/graphite/finders/remote.py
@@ -12,7 +12,7 @@ from graphite.intervals import Interval, IntervalSet
 from graphite.logger import log
 from graphite.node import LeafNode, BranchNode
 from graphite.render.hashing import compactHash
-from graphite.util import unpickle, logtime, is_local_interface, json, msgpack
+from graphite.util import unpickle, logtime, is_local_interface, json, msgpack, BufferedHTTPResponse
 
 from graphite.finders.utils import BaseFinder
 from graphite.readers.remote import RemoteReader
@@ -110,7 +110,7 @@ class RemoteFinder(BaseFinder):
                 if result.getheader('content-type') == 'application/x-msgpack':
                   results = msgpack.load(result)
                 else:
-                  results = unpickle.load(result)
+                  results = unpickle.load(BufferedHTTPResponse(result))
             except Exception as err:
                 self.fail()
                 log.exception(
@@ -207,4 +207,4 @@ class RemoteFinder(BaseFinder):
         self.last_failure = 0
 
         log.debug("RemoteFinder[%s] Fetched %s" % (self.host, url_full))
-        return result
+        return BufferedHTTPResponse(result)

--- a/webapp/graphite/readers/remote.py
+++ b/webapp/graphite/readers/remote.py
@@ -4,7 +4,7 @@ from django.conf import settings
 
 from graphite.logger import log
 from graphite.readers.utils import BaseReader
-from graphite.util import unpickle, msgpack
+from graphite.util import unpickle, msgpack, BufferedHTTPResponse
 
 
 class RemoteReader(BaseReader):
@@ -78,7 +78,7 @@ class RemoteReader(BaseReader):
             if result.getheader('content-type') == 'application/x-msgpack':
               data = msgpack.load(result)
             else:
-              data = unpickle.load(result)
+              data = unpickle.load(BufferedHTTPResponse(result))
         except Exception as err:
             self.finder.fail()
             log.exception(


### PR DESCRIPTION
- pickle.load() makes lots of very small reads.  When operating on
  a http response object this is really slow.  To improve performance
  we need to read from the response objects in chunks.

With internal testing a query loading 1.8Mb of pickle data was taking 45seconds.  It now takes 300ms.