### PR TITLE
Fix issue when finder doesn't respect FindQuery leaves_only flag

### DIFF
--- a/webapp/graphite/finders/utils.py
+++ b/webapp/graphite/finders/utils.py
@@ -2,6 +2,7 @@
 import time
 import abc
 
+from graphite.node import BranchNode, LeafNode  # noqa
 from graphite.util import is_pattern
 from graphite.intervals import Interval
 
@@ -129,6 +130,9 @@ class BaseFinder(object):
         result = []
 
         for node, query in self.find_multi(queries):
+            if not isinstance(node, LeafNode):
+                continue
+
             time_info, values = node.fetch(
                 start_time, end_time,
                 now=now, requestContext=requestContext

--- a/webapp/tests/test_storage.py
+++ b/webapp/tests/test_storage.py
@@ -18,10 +18,10 @@ from graphite.worker_pool.pool import PoolTimeoutError
 class StorageTest(TestCase):
 
   def test_fetch(self):
-    disabled_finder = DisabledFinder()
-    legacy_finder = LegacyFinder()
-    test_finder = TestFinder()
-    remote_finder = RemoteFinder()
+    disabled_finder = get_finders('tests.test_storage.DisabledFinder')[0]
+    legacy_finder = get_finders('tests.test_storage.LegacyFinder')[0]
+    test_finder = get_finders('tests.test_storage.TestFinder')[0]
+    remote_finder = get_finders('tests.test_storage.RemoteFinder')[0]
 
     store = Store(
       finders=[disabled_finder, legacy_finder, test_finder, remote_finder],
@@ -42,6 +42,17 @@ class StorageTest(TestCase):
     # fetch with empty patterns
     result = store.fetch([], 1, 2, 3, {})
     self.assertEqual(result, [])
+
+    # fetch
+    result = store.fetch(['a.**'], 1, 2, 3, {})
+    self.assertEqual(len(result), 3)
+    result.sort(key=lambda node: node['name'])
+    self.assertEqual(result[0]['name'], 'a.b.c.d')
+    self.assertEqual(result[0]['pathExpression'], 'a.**')
+    self.assertEqual(result[1]['name'], 'a.b.c.d')
+    self.assertEqual(result[1]['pathExpression'], 'a.**')
+    self.assertEqual(result[2]['name'], 'a.b.c.e')
+    self.assertEqual(result[2]['pathExpression'], 'a.**')
 
   def test_fetch_pool_timeout(self):
     # pool timeout


### PR DESCRIPTION
Currently if a find query returns nodes that are not `LeafNode` objects then `fetch` will fail when it tries to call `.fetch()` on them.  This can happen if the pattern provided matches a branch node and the finder doesn't respect the `leaves_only` attribute on the `FindQuery` object.

This PR updates `BaseFinder.fetch` to check whether nodes are `LeafNode` objects before calling `.fetch()` on them.