### PR TITLE
fix fields handling in http tagdb

### DIFF
--- a/webapp/graphite/tags/http.py
+++ b/webapp/graphite/tags/http.py
@@ -23,10 +23,20 @@ class HttpTagDB(BaseTagDB):
     if 'Authorization' not in headers and self.username and self.password:
       headers['Authorization'] = 'Basic ' + ('%s:%s' % (self.username, self.password)).encode('base64')
 
+    req_fields = []
+    for (field, value) in fields.items():
+      if value is None:
+        continue
+
+      if isinstance(value, list) or isinstance(value, tuple):
+        req_fields.extend([(field, v) for v in value if v is not None])
+      else:
+        req_fields.append((field, value))
+
     result = http.request(
       method,
       self.base_url + url,
-      fields={field: value for (field, value) in fields.items() if value is not None},
+      fields=req_fields,
       headers=headers,
       timeout=self.settings.REMOTE_FIND_TIMEOUT,
     )

--- a/webapp/tests/test_tags.py
+++ b/webapp/tests/test_tags.py
@@ -308,10 +308,17 @@ class TagsTest(TestCase):
       else:
         self.assertEqual(headers, {})
 
+      req_fields = {}
+      for (field, value) in fields:
+        if field in req_fields:
+          req_fields[field].append(value)
+        else:
+          req_fields[field] = [value]
+
       if method == 'POST':
-        result = self.client.post(url, fields)
+        result = self.client.post(url, req_fields)
       elif method == 'GET':
-        result = self.client.get(url, fields)
+        result = self.client.get(url, req_fields)
       else:
         raise Exception('Invalid HTTP method %s' % method)
 


### PR DESCRIPTION
urllib3 doesn't properly handle field dicts, leading to errors when using the http tagdb,

This PR maps them into lists of `(field, value)` tuples instead, which are properly supported.