### PR TITLE
Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,21 @@ sudo: false
 
 matrix:
   include:
+    - python: pypy
+      env:
+        - TOXENV=pypy-django111-pyparsing2
+    - python: 3.4
+      env:
+        - TOXENV=py34-django111-pyparsing2
+    - python: 3.5
+      env:
+        - TOXENV=py35-django111-pyparsing2
     - python: 3.6
       env:
         - TOXENV=py36-django111-pyparsing2
+    - python: 3.6
+      env:
+        - TOXENV=lint
 
 env:
   - TOXENV=py27-django18-pyparsing2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: python
 python: 2.7
 sudo: false
 
+matrix:
+  include:
+    - python: 3.6
+    - env:
+      - TOXENV=py36-django111-pyparsing2
+
 env:
   - TOXENV=py27-django18-pyparsing2
   - TOXENV=py27-django19-pyparsing2
@@ -10,7 +16,6 @@ env:
   - TOXENV=py27-django111-pyparsing2-msgpack
   - TOXENV=py27-django111-pyparsing2-mysql TEST_MYSQL_PASSWORD=graphite
   - TOXENV=py27-django111-pyparsing2-postgresql TEST_POSTGRESQL_PASSWORD=graphite
-  - TOXENV=py36-django111-pyparsing2
   - TOXENV=docs
   - TOXENV=lint
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - TOXENV=py27-django111-pyparsing2-msgpack
   - TOXENV=py27-django111-pyparsing2-mysql TEST_MYSQL_PASSWORD=graphite
   - TOXENV=py27-django111-pyparsing2-postgresql TEST_POSTGRESQL_PASSWORD=graphite
+  - TOXENV=py36-django111-pyparsing2
   - TOXENV=docs
   - TOXENV=lint
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ sudo: false
 matrix:
   include:
     - python: 3.6
-    - env:
-      - TOXENV=py36-django111-pyparsing2
+      env:
+        - TOXENV=py36-django111-pyparsing2
 
 env:
   - TOXENV=py27-django18-pyparsing2

--- a/check-dependencies.py
+++ b/check-dependencies.py
@@ -100,17 +100,6 @@ if django and django.VERSION[:2] < (1,8):
   required += 1
 
 
-# Test for a json module
-try:
-  import json
-except ImportError:
-  try:
-    import simplejson
-  except ImportError:
-    sys.stderr.write("[REQUIRED] Unable to import either the 'json' or 'simplejson' module, at least one is required.\n")
-    required += 1
-
-
 # Test for python-memcached
 try:
   import memcache

--- a/contrib/memcache_whisper.py
+++ b/contrib/memcache_whisper.py
@@ -336,7 +336,7 @@ points is a list of (timestamp,value) points
   header = __readHeader(fh)
   now = int( time.time() )
   archives = iter( header['archives'] )
-  currentArchive = archives.next()
+  currentArchive = next(archives)
   #debug('  update_many currentArchive=%s' % str(currentArchive))
   currentPoints = []
   for point in points:
@@ -349,7 +349,7 @@ points is a list of (timestamp,value) points
         __archive_update_many(fh,header,currentArchive,currentPoints)
         currentPoints = []
       try:
-        currentArchive = archives.next()
+        currentArchive = next(archives)
         #debug('  update_many using next archive %s' % str(currentArchive))
       except StopIteration:
         #debug('  update_many no more archives!')

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -209,7 +209,6 @@ Despair Not!  Even though running Graphite on Windows is completely unsupported 
 .. _python-sqlite2: https://github.com/ghaering/pysqlite
 .. _pytz: https://pypi.python.org/pypi/pytz/
 .. _scandir: https://pypi.python.org/pypi/scandir
-.. _simplejson: http://simplejson.readthedocs.io/
 .. _txAMQP: https://launchpad.net/txamqp/
 .. _uWSGI: http://uwsgi-docs.readthedocs.io/
 .. _docker_repo: https://github.com/graphite-project/docker-graphite-statsd

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,10 +38,10 @@
 #
 
 Django>=1.8,<1.11.99
-python-memcached==1.47
-txAMQP==0.4
-simplejson==2.1.6
-django-tagging==0.4.3
+python-memcached==1.58
+txAMQP==0.7
+simplejson==3.13.2
+django-tagging==0.4.6
 gunicorn
 pytz
 pyparsing

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,6 @@
 Django>=1.8,<1.11.99
 python-memcached==1.58
 txAMQP==0.7
-simplejson==3.13.2
 django-tagging==0.4.6
 gunicorn
 pytz

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,8 @@ try:
           'Programming Language :: Python',
           'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.7',
-          'Programming Language :: Python :: 2 :: Only',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.6',
           ],
       **setup_kwargs
     )

--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,8 @@ try:
           'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.4',
+          'Programming Language :: Python :: 3.5',
           'Programming Language :: Python :: 3.6',
           ],
       **setup_kwargs

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ except ImportError:
 from glob import glob
 from collections import defaultdict
 
+# io.StringIO is strictly unicode only. Python 2 StringIO.StringIO accepts
+# bytes, so we'll conveniently ignore decoding and reencoding the file there.
 try:
     from StringIO import StringIO  # Python 2
 except ImportError:

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,9 @@ setenv =
 	mysql: TEST_MYSQL=true
 	postgresql: TEST_POSTGRESQL=true
 passenv = TEST_MYSQL_* TEST_POSTGRESQL_*
-basepython = python2.7
+basepython =
+           py27: python2.7
+           py36: python3.6
 changedir = webapp
 commands =
 	coverage run --branch --include=graphite/* manage.py test

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ deps =
 	pytz
 	git+git://github.com/graphite-project/whisper.git#egg=whisper
 	git+git://github.com/graphite-project/ceres.git#egg=ceres
-	Django
+	Django<2.0
 	pyparsing
 	Sphinx<1.4
 	sphinx_rtd_theme

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-	py27-django1{8,9,10,11}-pyparsing2{,-mysql,-postgresql,-rrdtool,-msgpack},
+	py{27,36}-django1{8,9,10,11}-pyparsing2{,-mysql,-postgresql,-rrdtool,-msgpack},
 	lint, docs
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-	py{27,36}-django1{8,9,10,11}-pyparsing2{,-mysql,-postgresql,-rrdtool,-msgpack},
+	py{27,34,35,36,py}-django1{8,9,10,11}-pyparsing2{,-mysql,-postgresql,-rrdtool,-msgpack},
 	lint, docs
 
 [testenv]
@@ -13,9 +13,6 @@ setenv =
 	mysql: TEST_MYSQL=true
 	postgresql: TEST_POSTGRESQL=true
 passenv = TEST_MYSQL_* TEST_POSTGRESQL_*
-basepython =
-           py27: python2.7
-           py36: python3.6
 changedir = webapp
 commands =
 	coverage run --branch --include=graphite/* manage.py test

--- a/webapp/graphite/compat.py
+++ b/webapp/graphite/compat.py
@@ -1,9 +1,9 @@
-import json
 
 from django import VERSION
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import (HttpResponse as BaseHttpResponse,
                          HttpResponseBadRequest as Base400)
+from graphite.util import json
 
 
 class ContentTypeMixin(object):

--- a/webapp/graphite/dashboard/models.py
+++ b/webapp/graphite/dashboard/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from graphite.account.models import Profile
 from graphite.util import json
+import six
 
 class Dashboard(models.Model):
   name = models.CharField(primary_key=True, max_length=128)
@@ -22,7 +23,7 @@ class Template(models.Model):
   def setState(self, state, key):
     #XXX Might not need this
     def replace_string(s):
-      if isinstance(s, unicode):
+      if isinstance(s, six.text_type):
         s = s.replace(key, '__VALUE__')
       return s
 

--- a/webapp/graphite/dashboard/views.py
+++ b/webapp/graphite/dashboard/views.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import json
 import re
 import errno
@@ -15,7 +14,7 @@ from django.utils.safestring import mark_safe
 from graphite.compat import HttpResponse
 from graphite.dashboard.models import Dashboard, Template
 from graphite.render.views import renderView
-from .send_graph import send_graph_email
+from graphite.dashboard.send_graph import send_graph_email
 
 
 fieldRegex = re.compile(r'<([^>]+)>')

--- a/webapp/graphite/dashboard/views.py
+++ b/webapp/graphite/dashboard/views.py
@@ -1,4 +1,3 @@
-import json
 import re
 import errno
 
@@ -13,9 +12,9 @@ from django.contrib.staticfiles import finders
 from django.utils.safestring import mark_safe
 from graphite.compat import HttpResponse
 from graphite.dashboard.models import Dashboard, Template
-from graphite.render.views import renderView
 from graphite.dashboard.send_graph import send_graph_email
-
+from graphite.render.views import renderView
+from graphite.util import json
 
 fieldRegex = re.compile(r'<([^>]+)>')
 defaultScheme = {

--- a/webapp/graphite/events/views.py
+++ b/webapp/graphite/events/views.py
@@ -1,4 +1,5 @@
 import datetime
+import six
 
 try:
     from django.contrib.sites.requests import RequestSite
@@ -59,7 +60,7 @@ def post_event(request):
         if tags is not None:
             if isinstance(tags, list):
                 tags = ' '.join(tags)
-            elif not isinstance(tags, basestring):
+            elif not isinstance(tags, six.string_types):
                 return HttpResponse(
                     json.dumps({'error': '"tags" must be an array or space-separated string'}),
                     status=400)

--- a/webapp/graphite/finders/remote.py
+++ b/webapp/graphite/finders/remote.py
@@ -1,8 +1,7 @@
 import codecs
 import time
 
-from six.moves.urllib.parse import urlencode
-from six.moves.urllib.parse import urlsplit, parse_qs
+from six.moves.urllib.parse import urlencode, urlsplit, parse_qs
 
 from django.conf import settings
 from django.core.cache import cache

--- a/webapp/graphite/intervals.py
+++ b/webapp/graphite/intervals.py
@@ -89,8 +89,23 @@ class Interval:
   def __eq__(self, other):
     return self.tuple == other.tuple
 
+  def __ne__(self, other):
+    return self.tuple != other.tuple
+
   def __hash__(self):
     return hash( self.tuple )
+
+  def __lt__(self, other):
+    return self.start < self.start
+
+  def __le__(self, other):
+    return self.start <= self.start
+
+  def __gt__(self, other):
+    return self.start > self.start
+
+  def __ge__(self, other):
+    return self.start >= self.start
 
   def __cmp__(self, other):
     return cmp(self.start, other.start)
@@ -98,7 +113,10 @@ class Interval:
   def __len__(self):
     raise TypeError("len() doesn't support infinite values, use the 'size' attribute instead")
 
-  def __nonzero__(self):
+  def __nonzero__(self):  # Python 2
+    return self.size != 0
+
+  def __bool__(self):  # Python 3
     return self.size != 0
 
   def __repr__(self):

--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -11,6 +11,8 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
+
+from functools import reduce
 import pytz
 from six.moves.urllib.parse import unquote_plus
 

--- a/webapp/graphite/node.py
+++ b/webapp/graphite/node.py
@@ -18,7 +18,7 @@ class BranchNode(Node):
 
 
 class LeafNode(Node):
-  __slots__ = ('reader', 'is_leaf')
+  __slots__ = ('reader', )
 
   def __init__(self, path, reader):
     Node.__init__(self, path)

--- a/webapp/graphite/readers/multi.py
+++ b/webapp/graphite/readers/multi.py
@@ -56,7 +56,7 @@ class MultiReader(BaseReader):
         t = start
         while t < end:
             # Look for the finer precision value first if available
-            i1 = (t - start1) / step1
+            i1 = (t - start1) // step1
 
             if len(values1) > i1:
                 v1 = values1[i1]
@@ -64,7 +64,7 @@ class MultiReader(BaseReader):
                 v1 = None
 
             if v1 is None:
-                i2 = (t - start2) / step2
+                i2 = (t - start2) // step2
 
                 if len(values2) > i2:
                     v2 = values2[i2]

--- a/webapp/graphite/readers/rrd.py
+++ b/webapp/graphite/readers/rrd.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import time
+import six
 
 # Use the built-in version of scandir/stat if possible, otherwise
 # use the scandir module version
@@ -24,7 +25,7 @@ class RRDReader(BaseReader):
 
     @staticmethod
     def _convert_fs_path(fs_path):
-        if isinstance(fs_path, unicode):
+        if isinstance(fs_path, six.text_type):
             fs_path = fs_path.encode(sys.getfilesystemencoding())
         return os.path.realpath(fs_path)
 

--- a/webapp/graphite/readers/utils.py
+++ b/webapp/graphite/readers/utils.py
@@ -53,7 +53,7 @@ def merge_with_cache(cached_datapoints, start, step, values, func=None, raw_step
         raise Exception("Invalid consolidation function: '%s'" % func)
 
     # if we have a raw_step, start by taking only the last data point for each interval to match what whisper will do
-    if raw_step > 1:
+    if raw_step is not None and raw_step > 1:
         consolidated_dict = {}
         for (timestamp, value) in cached_datapoints:
             interval = timestamp - (timestamp % raw_step)

--- a/webapp/graphite/readers/utils.py
+++ b/webapp/graphite/readers/utils.py
@@ -76,7 +76,7 @@ def merge_with_cache(cached_datapoints, start, step, values, func=None, raw_step
 
     for (interval, value) in consolidated:
         try:
-            i = int(interval - start) / step
+            i = int(interval - start) // step
             if i < 0:
                 # cached data point is earlier then the requested data point.
                 # meaning we can definitely ignore the cache result.

--- a/webapp/graphite/readers/utils.py
+++ b/webapp/graphite/readers/utils.py
@@ -58,7 +58,7 @@ def merge_with_cache(cached_datapoints, start, step, values, func=None, raw_step
         for (timestamp, value) in cached_datapoints:
             interval = timestamp - (timestamp % raw_step)
             consolidated_dict[interval] = value
-        cached_datapoints = consolidated_dict.items()
+        cached_datapoints = list(consolidated_dict.items())
 
     # if we have a consolidation function and the step is not the default interval, consolidate to the requested step
     if func and step != raw_step:
@@ -109,7 +109,7 @@ def merge_with_carbonlink(metric, start, step, values, aggregation_method=None, 
         cached_datapoints = []
 
     if isinstance(cached_datapoints, dict):
-        cached_datapoints = cached_datapoints.items()
+        cached_datapoints = list(cached_datapoints.items())
 
     return merge_with_cache(
         cached_datapoints, start, step, values,

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -3,6 +3,7 @@ import re
 from graphite.render.grammar import grammar
 from graphite.render.datalib import fetchData, TimeSeries, prefetchData
 from graphite.storage import STORE
+import six
 
 
 def evaluateTarget(requestContext, targets, noPrefetch=False):
@@ -19,7 +20,7 @@ def evaluateTarget(requestContext, targets, noPrefetch=False):
     if not target:
       continue
 
-    if isinstance(target, basestring):
+    if isinstance(target, six.string_types):
       if not target.strip():
         continue
       target = grammar.parseString(target)
@@ -61,7 +62,7 @@ def evaluateTokens(requestContext, tokens, replacements=None, pipedArg=None):
       for name in replacements:
         if expression == '$'+name:
           val = replacements[name]
-          if not isinstance(val, str) and not isinstance(val, basestring):
+          if not isinstance(val, six.string_types):
             return val
           elif re.match('^-?[\d.]+$', val):
             return float(val)
@@ -160,7 +161,7 @@ def extractPathExpressions(requestContext, targets):
     if not target:
       continue
 
-    if isinstance(target, basestring):
+    if isinstance(target, six.string_types):
       if not target.strip():
         continue
       target = grammar.parseString(target)

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2557,7 +2557,7 @@ def removeAbovePercentile(requestContext, seriesList, n):
     except IndexError:
       continue
     for (index, val) in enumerate(s):
-      if val > percentile:
+      if val is not None and val > percentile:
         s[index] = None
 
   return seriesList
@@ -2571,7 +2571,7 @@ def removeAboveValue(requestContext, seriesList, n):
     s.name = 'removeAboveValue(%s, %g)' % (s.name, n)
     s.pathExpression = s.name
     for (index, val) in enumerate(s):
-      if val > n:
+      if val is not None and val > n:
         s[index] = None
 
   return seriesList
@@ -2589,7 +2589,7 @@ def removeBelowPercentile(requestContext, seriesList, n):
     except IndexError:
       continue
     for (index, val) in enumerate(s):
-      if val < percentile:
+      if val is None or val < percentile:
         s[index] = None
 
   return seriesList
@@ -2603,7 +2603,7 @@ def removeBelowValue(requestContext, seriesList, n):
     s.name = 'removeBelowValue(%s, %g)' % (s.name, n)
     s.pathExpression = s.name
     for (index, val) in enumerate(s):
-      if val < n:
+      if val is None or val < n:
         s[index] = None
 
   return seriesList

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -65,7 +65,7 @@ def safeSum(values):
 def safeDiff(values):
   safeValues = [v for v in values if v is not None]
   if safeValues:
-    values = map(lambda x: x*-1, safeValues[1:])
+    values = list(map(lambda x: x*-1, safeValues[1:]))
     values.insert(0, safeValues[0])
     return sum(values)
 

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -205,7 +205,7 @@ class NormalizeEmptyResultError(Exception):
 
 def matchSeries(seriesList1, seriesList2):
   assert len(seriesList2) == len(seriesList1), "The number of series in each argument must be the same"
-  return izip(sorted(seriesList1, lambda a,b: cmp(a.name, b.name)), sorted(seriesList2, lambda a,b: cmp(a.name, b.name)))
+  return izip(sorted(seriesList1, key=lambda a: a.name), sorted(seriesList2, key=lambda a: a.name))
 
 def formatPathExpressions(seriesList):
    # remove duplicates
@@ -2636,16 +2636,13 @@ def sortByName(requestContext, seriesList, natural=False):
   def paddedName(name):
     return re.sub("(\d+)", lambda x: "{0:010}".format(int(x.group(0))), name)
 
-  def compare(x,y):
-    return cmp(x.name, y.name)
-
-  def natSortCompare(x,y):
-    return cmp(paddedName(x.name), paddedName(y.name))
+  def natSortKey(x):
+    return paddedName(x.name)
 
   if natural:
-    seriesList.sort(natSortCompare)
+    seriesList.sort(key=natSortKey)
   else:
-    seriesList.sort(compare)
+    seriesList.sort(key=lambda x: x.name)
 
   return seriesList
 
@@ -2656,10 +2653,7 @@ def sortByTotal(requestContext, seriesList):
   Sorts the list of metrics by the sum of values across the time period
   specified.
   """
-  def compare(x,y):
-    return cmp(safeSum(y), safeSum(x))
-
-  seriesList.sort(compare)
+  seriesList.sort(key=safeSum)
   return seriesList
 
 def sortByMaxima(requestContext, seriesList):
@@ -2677,9 +2671,7 @@ def sortByMaxima(requestContext, seriesList):
     &target=sortByMaxima(server*.instance*.memory.free)
 
   """
-  def compare(x,y):
-    return cmp(max(y), max(x))
-  seriesList.sort(compare)
+  seriesList.sort(key=max)
   return seriesList
 
 def sortByMinima(requestContext, seriesList):
@@ -2696,10 +2688,8 @@ def sortByMinima(requestContext, seriesList):
     &target=sortByMinima(server*.instance*.memory.free)
 
   """
-  def compare(x,y):
-    return cmp(min(x), min(y))
   newSeries = [series for series in seriesList if max(series) > 0]
-  newSeries.sort(compare)
+  newSeries.sort(key=min)
   return newSeries
 
 def useSeriesAbove(requestContext, seriesList, value, search, replace):

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -23,9 +23,8 @@ import time
 
 from datetime import datetime, timedelta
 from functools import reduce
-from six.moves import range
+from six.moves import range, zip
 import six
-from six.moves import zip
 try:
   from itertools import izip, izip_longest
 except ImportError:

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -23,6 +23,7 @@ import time
 
 from datetime import datetime, timedelta
 from functools import reduce
+from six.moves import range
 try:
   from itertools import izip, izip_longest
 except ImportError:
@@ -557,14 +558,14 @@ def keepLastValue(requestContext, seriesList, limit = INF):
          if 0 < consecutiveNones <= limit:
            # If a non-None value is seen before the limit of Nones is hit,
            # backfill all the missing datapoints with the last known value.
-           for index in xrange(i - consecutiveNones, i):
+           for index in range(i - consecutiveNones, i):
              series[index] = series[i - consecutiveNones - 1]
 
          consecutiveNones = 0
 
     # If the series ends with some None values, try to backfill a bit to cover it.
     if 0 < consecutiveNones <= limit:
-      for index in xrange(len(series) - consecutiveNones, len(series)):
+      for index in range(len(series) - consecutiveNones, len(series)):
         series[index] = series[len(series) - consecutiveNones - 1]
 
   return seriesList
@@ -605,7 +606,7 @@ def interpolate(requestContext, seriesList, limit = INF):
         # If a non-None value is seen before the limit of Nones is hit,
         # backfill all the missing datapoints with the last known value.
         if 0 < consecutiveNones <= limit:
-          for index in xrange(i - consecutiveNones, i):
+          for index in range(i - consecutiveNones, i):
             series[index] = series[i - consecutiveNones - 1] + (index - (i - consecutiveNones -1)) * (value - series[i - consecutiveNones - 1]) / (consecutiveNones + 1)
 
         consecutiveNones = 0
@@ -3598,7 +3599,7 @@ def identity(requestContext, name):
   delta = timedelta(seconds=step)
   start = int(epoch(requestContext["startTime"]))
   end = int(epoch(requestContext["endTime"]))
-  values = range(start, end, step)
+  values = list(range(start, end, step))
   series = TimeSeries(name, start, end, step, values, xFilesFactor=requestContext.get('xFilesFactor'))
   series.pathExpression = 'identity("%s")' % name
 
@@ -3998,7 +3999,7 @@ def _summarizeValues(series, func, interval, newStart=None, newEnd=None):
   if newEnd is None:
     newEnd = series.end
 
-  timestamps = range( int(series.start), int(series.end), int(series.step) )
+  timestamps = list(range( int(series.start), int(series.end), int(series.step)))
   datapoints = list(series)
   intervalPoints = interval / series.step
 

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -25,6 +25,7 @@ from datetime import datetime, timedelta
 from functools import reduce
 from six.moves import range
 import six
+from six.moves import zip
 try:
   from itertools import izip, izip_longest
 except ImportError:
@@ -2535,7 +2536,7 @@ def removeBetweenPercentile(requestContext, seriesList, n):
   if n < 50:
     n = 100 - n
 
-  transposed = zip(*seriesList)
+  transposed = list(zip(*seriesList))
 
   lowPercentiles = [_getPercentile(col, 100-n) for col in transposed]
   highPercentiles = [_getPercentile(col, n) for col in transposed]

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2653,7 +2653,7 @@ def sortByTotal(requestContext, seriesList):
   Sorts the list of metrics by the sum of values across the time period
   specified.
   """
-  seriesList.sort(key=safeSum)
+  seriesList.sort(key=safeSum, reverse=True)
   return seriesList
 
 def sortByMaxima(requestContext, seriesList):
@@ -2671,7 +2671,7 @@ def sortByMaxima(requestContext, seriesList):
     &target=sortByMaxima(server*.instance*.memory.free)
 
   """
-  seriesList.sort(key=max)
+  seriesList.sort(key=max, reverse=True)
   return seriesList
 
 def sortByMinima(requestContext, seriesList):

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -24,6 +24,7 @@ import time
 from datetime import datetime, timedelta
 from functools import reduce
 from six.moves import range
+import six
 try:
   from itertools import izip, izip_longest
 except ImportError:
@@ -1008,7 +1009,7 @@ def movingWindow(requestContext, seriesList, windowSize, func='average', xFilesF
   if not seriesList:
     return []
 
-  if isinstance(windowSize, basestring):
+  if isinstance(windowSize, six.string_types):
     delta = parseTimeOffset(windowSize)
     previewSeconds = abs(delta.seconds + (delta.days * 86400))
   else:
@@ -1037,7 +1038,7 @@ def movingWindow(requestContext, seriesList, windowSize, func='average', xFilesF
   tagName = 'moving' + func.capitalize()
 
   for series in previewList:
-    if isinstance(windowSize, basestring):
+    if isinstance(windowSize, six.string_types):
       newName = '%s(%s,"%s")' % (tagName, series.name, windowSize)
       windowPoints = previewSeconds // series.step
     else:
@@ -1090,7 +1091,7 @@ def exponentialMovingAverage(requestContext, seriesList, windowSize):
   if not seriesList:
     return []
   # set previewSeconds and constant based on windowSize string or integer
-  if isinstance(windowSize, basestring):
+  if isinstance(windowSize, six.string_types):
     delta = parseTimeOffset(windowSize)
     previewSeconds = abs(delta.seconds + (delta.days * 86400))
     constant = (float(2) / (int(previewSeconds) + 1))
@@ -1106,7 +1107,7 @@ def exponentialMovingAverage(requestContext, seriesList, windowSize):
   result = []
 
   for series in previewList:
-    if isinstance(windowSize, basestring):
+    if isinstance(windowSize, six.string_types):
       newName = 'exponentialMovingAverage(%s,"%s")' % (series.name, windowSize)
       windowPoints = previewSeconds // series.step
     else:

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -13,8 +13,16 @@ See the License for the specific language governing permissions and
 limitations under the License."""
 
 import math, itertools, re, sys
-from six.moves import range
-from six.moves import zip
+from datetime import datetime, timedelta
+from six.moves import range, zip
+from six.moves.urllib.parse import unquote_plus
+from six.moves.configparser import SafeConfigParser
+from django.conf import settings
+import pytz
+
+from graphite.render.datalib import TimeSeries
+from graphite.util import json
+
 try:
     import cairocffi as cairo
 except ImportError:
@@ -29,14 +37,7 @@ else:
     from cStringIO import StringIO
   except ImportError:
     from StringIO import StringIO
-from datetime import datetime, timedelta
-from six.moves.urllib.parse import unquote_plus
-from six.moves.configparser import SafeConfigParser
-from django.conf import settings
-from graphite.render.datalib import TimeSeries
-from graphite.util import json
 
-import pytz
 
 INFINITY = float('inf')
 

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1049,7 +1049,7 @@ class LineGraph(Graph):
 
     for series in self.data:
       if not hasattr(series, 'color'):
-        series.color = self.colors.next()
+        series.color = next(self.colors)
 
     titleSize = self.defaultFontParams['size'] + math.floor( math.log(self.defaultFontParams['size']) )
     self.setFont( size=titleSize )
@@ -1802,7 +1802,7 @@ class PieGraph(Graph):
         'name' : name,
         'value' : value,
         'percent' : value / self.total,
-        'color' : self.colors.next(),
+        'color' : next(self.colors),
         'alpha' : self.alpha,
       })
 

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License."""
 
 import math, itertools, re, sys
+from six.moves import range
 try:
     import cairocffi as cairo
 except ImportError:
@@ -1940,7 +1941,7 @@ def dataLimits(data, drawNullAsZero=False, stacked=False):
     length = safeMin(len(series) for series in finiteData)
     sumSeries = []
 
-    for i in xrange(0, length):
+    for i in range(0, length):
       sumSeries.append( safeSum(series[i] for series in finiteData) )
     yMaxValue = safeMax( sumSeries )
   else:

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -996,7 +996,7 @@ class LineGraph(Graph):
       params['yUnitSystem'] = 'si'
     else:
       params['yUnitSystem'] = unicode(params['yUnitSystem']).lower()
-      if params['yUnitSystem'] not in UnitSystems.keys():
+      if params['yUnitSystem'] not in UnitSystems:
         params['yUnitSystem'] = 'si'
 
     self.params = params

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -14,6 +14,7 @@ limitations under the License."""
 
 import math, itertools, re, sys
 from six.moves import range
+from six.moves import zip
 try:
     import cairocffi as cairo
 except ImportError:

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -299,14 +299,14 @@ class _AxisTics:
       return "%g %s" % (float(value), prefix)
     elif value < 1.0:
       return "%.2f %s" % (float(value), prefix)
-    if span > 10 or spanPrefix != prefix:
+    if (span is not None and span > 10) or spanPrefix != prefix:
       if type(value) is float:
         return "%.1f %s" % (value, prefix)
       else:
         return "%d %s" % (int(value), prefix)
-    elif span > 3:
+    elif span is not None and span > 3:
       return "%.1f %s" % (float(value), prefix)
-    elif span > 0.1:
+    elif span is not None and span > 0.1:
       return "%.2f %s" % (float(value), prefix)
     else:
       return "%g %s" % (float(value), prefix)

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -33,11 +33,7 @@ except ImportError:
 if sys.version_info >= (3, 0):
   from io import BytesIO as StringIO
 else:
-  try:
-    from cStringIO import StringIO
-  except ImportError:
-    from StringIO import StringIO
-
+  from cStringIO import StringIO
 
 INFINITY = float('inf')
 

--- a/webapp/graphite/render/hashing.py
+++ b/webapp/graphite/render/hashing.py
@@ -79,7 +79,7 @@ class ConsistentHashRing:
       else:
           small_hash = int(big_hash, 16)
     else:
-      big_hash = md5(str(key)).hexdigest()
+      big_hash = compactHash(str(key))
       small_hash = int(big_hash[:4], 16)
     return small_hash
 

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -19,8 +19,7 @@ import six.moves.http_client
 from datetime import datetime
 from time import time
 from random import shuffle
-from six.moves.urllib.parse import urlencode
-from six.moves.urllib.parse import urlsplit, urlunsplit
+from six.moves.urllib.parse import urlencode, urlsplit, urlunsplit
 from cgi import parse_qs
 
 from graphite.compat import HttpResponse

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -336,7 +336,9 @@ def parseOptions(request):
   requestOptions = {}
 
   graphType = queryParams.get('graphType','line')
-  assert graphType in GraphTypes, "Invalid graphType '%s', must be one of %s" % (graphType,list(GraphTypes.keys()))
+  if graphType not in GraphTypes:
+    raise AssertionError("Invalid graphType '%s', must be one of %s"
+                         % (graphType,list(GraphTypes)))
   graphClass = GraphTypes[graphType]
 
   # Fill in the requestOptions

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -41,6 +41,7 @@ from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
 from django.utils.cache import add_never_cache_headers, patch_response_headers
+from six.moves import zip
 
 
 def renderView(request):
@@ -194,7 +195,7 @@ def renderViewJson(requestOptions, data):
     if maxDataPoints == 1:
       for series in data:
         series.consolidate(len(series))
-        datapoints = zip(series, [int(series.start)])
+        datapoints = list(zip(series, [int(series.start)]))
         series_data.append(dict(target=series.name, tags=series.tags, datapoints=datapoints))
     else:
       startTime = min([series.start for series in data])
@@ -216,7 +217,7 @@ def renderViewJson(requestOptions, data):
           timestamps = range(int(series.start), int(series.end) + 1, int(secondsPerPoint))
         else:
           timestamps = range(int(series.start), int(series.end) + 1, int(series.step))
-        datapoints = zip(series, timestamps)
+        datapoints = list(zip(series, timestamps))
         series_data.append(dict(target=series.name, tags=series.tags, datapoints=datapoints))
   elif 'noNullPoints' in requestOptions and any(data):
     for series in data:
@@ -230,7 +231,7 @@ def renderViewJson(requestOptions, data):
   else:
     for series in data:
       timestamps = range(int(series.start), int(series.end) + 1, int(series.step))
-      datapoints = zip(series, timestamps)
+      datapoints = list(zip(series, timestamps))
       series_data.append(dict(target=series.name, tags=series.tags, datapoints=datapoints))
 
   output = json.dumps(series_data, indent=(2 if requestOptions.get('pretty') else None)).replace('None,', 'null,').replace('NaN,', 'null,').replace('Infinity,', '1e9999,')

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -335,7 +335,7 @@ def parseOptions(request):
   requestOptions = {}
 
   graphType = queryParams.get('graphType','line')
-  assert graphType in GraphTypes, "Invalid graphType '%s', must be one of %s" % (graphType,GraphTypes.keys())
+  assert graphType in GraphTypes, "Invalid graphType '%s', must be one of %s" % (graphType,list(GraphTypes.keys()))
   graphClass = GraphTypes[graphType]
 
   # Fill in the requestOptions

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -1,5 +1,6 @@
 import time
 import random
+import sys
 import types
 
 from collections import defaultdict
@@ -30,9 +31,14 @@ def get_finders(finder_path):
 
     # monkey patch so legacy finders will work
     finder = cls()
-    finder.fetch = types.MethodType(BaseFinder.fetch.__func__, finder)
-    finder.find_multi = types.MethodType(BaseFinder.find_multi.__func__, finder)
-    finder.get_index = types.MethodType(BaseFinder.get_index.__func__, finder)
+    if sys.version_info[0] >= 3:
+        finder.fetch = types.MethodType(BaseFinder.fetch, finder)
+        finder.find_multi = types.MethodType(BaseFinder.find_multi, finder)
+        finder.get_index = types.MethodType(BaseFinder.get_index, finder)
+    else:
+        finder.fetch = types.MethodType(BaseFinder.fetch.__func__, finder)
+        finder.find_multi = types.MethodType(BaseFinder.find_multi.__func__, finder)
+        finder.get_index = types.MethodType(BaseFinder.get_index.__func__, finder)
 
     return [finder]
 

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import time
 import random
 import sys
@@ -7,6 +8,7 @@ from collections import defaultdict
 
 from django.conf import settings
 from django.core.cache import cache
+import six
 
 try:
     from importlib import import_module
@@ -229,7 +231,7 @@ class Store(object):
         # Reduce matching nodes for each path to a minimal set
         found_branch_nodes = set()
 
-        items = list(nodes_by_path.iteritems())
+        items = list(six.iteritems(nodes_by_path))
         random.shuffle(items)
 
         for path, nodes in items:

--- a/webapp/graphite/tags/http.py
+++ b/webapp/graphite/tags/http.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import
 
 from binascii import b2a_base64
-import json
 import sys
 
 from graphite.http_pool import http
+from graphite.util import json
 
 from graphite.tags.base import BaseTagDB
 

--- a/webapp/graphite/tags/http.py
+++ b/webapp/graphite/tags/http.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
+from binascii import b2a_base64
 import json
+import sys
 
 from graphite.http_pool import http
 
@@ -21,7 +23,12 @@ class HttpTagDB(BaseTagDB):
   def request(self, method, url, fields, requestContext=None):
     headers = requestContext.get('forwardHeaders') if requestContext else {}
     if 'Authorization' not in headers and self.username and self.password:
-      headers['Authorization'] = 'Basic ' + ('%s:%s' % (self.username, self.password)).encode('base64')
+      user_pw = '%s:%s' % (self.username, self.password)
+      if sys.version_info[0] >= 3:
+        user_pw_b64 = b2a_base64(user_pw.encode('utf-8')).decode('ascii')
+      else:
+        user_pw_b64 = user_pw.encode('base64')
+      headers['Authorization'] = 'Basic ' + user_pw_b64
 
     req_fields = []
     for (field, value) in fields.items():

--- a/webapp/graphite/tags/redis.py
+++ b/webapp/graphite/tags/redis.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import re
 import bisect
+import sys
 
 from graphite.tags.base import BaseTagDB, TaggedSeries
 
@@ -30,7 +31,8 @@ class RedisTagDB(BaseTagDB):
     self.r = Redis(
       host=settings.TAGDB_REDIS_HOST,
       port=settings.TAGDB_REDIS_PORT,
-      db=settings.TAGDB_REDIS_DB
+      db=settings.TAGDB_REDIS_DB,
+      decode_responses=(sys.version_info[0] >= 3),
     )
 
   def _find_series(self, tags, requestContext=None):

--- a/webapp/graphite/tags/redis.py
+++ b/webapp/graphite/tags/redis.py
@@ -127,7 +127,7 @@ class RedisTagDB(BaseTagDB):
 
     # apply filters
     operators = ['=','!=','=~','!=~']
-    filters.sort(lambda a, b: operators.index(a[1]) - operators.index(b[1]))
+    filters.sort(key=lambda a: operators.index(a[1]))
 
     for series in self.r.sunion(*['tags:' + tag + ':values:' + value for value in values]):
       parsed = self.parse(series)

--- a/webapp/graphite/tags/views.py
+++ b/webapp/graphite/tags/views.py
@@ -18,9 +18,9 @@ def jsonResponse(f):
     try:
       return _jsonResponse(f(request, queryParams, *args, **kwargs), queryParams)
     except ValueError as err:
-      return _jsonError(err.message, queryParams, getattr(err, 'status', 400))
+      return _jsonError(str(err), queryParams, getattr(err, 'status', 400))
     except Exception as err:
-      return _jsonError(err.message, queryParams, getattr(err, 'status', 500))
+      return _jsonError(str(err), queryParams, getattr(err, 'status', 500))
 
   return wrapped_f
 

--- a/webapp/graphite/templates/events.html
+++ b/webapp/graphite/templates/events.html
@@ -26,7 +26,7 @@
                       <tr>
                           <td>{{event.when|date:"H:i:s D d M Y" }}</td>
                           <td><a href="{% url "events_detail" event.id %}">{{event.what}}</a></td>
-                          <td>{{event.tags}}</td>
+                          <td>[&#39;{{ event.tags|join:"&#39;, &#39;"}}&#39;]</td>
                       </tr>
                   {% endfor %}
               {% else %}

--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -24,6 +24,10 @@ from datetime import datetime
 from functools import wraps
 from os.path import splitext, basename
 
+from django.conf import settings
+from django.utils.timezone import make_aware
+from graphite.logger import log
+
 try:
   import cPickle as pickle
   USING_CPICKLE = True
@@ -47,10 +51,6 @@ try:
 # otherwise fall back to bundled https://github.com/vsergeev/u-msgpack-python
 except ImportError:
   import graphite.umsgpack as msgpack  # NOQA
-
-from django.conf import settings
-from django.utils.timezone import make_aware
-from graphite.logger import log
 
 
 # There are a couple different json modules floating around out there with

--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -14,6 +14,7 @@ limitations under the License."""
 
 import imp
 import io
+import json
 import socket
 import time
 import sys
@@ -51,20 +52,6 @@ try:
 # otherwise fall back to bundled https://github.com/vsergeev/u-msgpack-python
 except ImportError:
   import graphite.umsgpack as msgpack  # NOQA
-
-
-# There are a couple different json modules floating around out there with
-# different APIs. Hide the ugliness here.
-try:
-  import json
-except ImportError:
-  import simplejson as json
-
-if hasattr(json, 'read') and not hasattr(json, 'loads'):
-  json.loads = json.read
-  json.dumps = json.write
-  json.load = lambda file: json.read( file.read() )
-  json.dump = lambda obj, file: file.write( json.write(obj) )
 
 def epoch(dt):
   """

--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -274,7 +274,7 @@ class BufferedHTTPReader(io.IOBase):
   def __init__(self, response, buffer_size=1048576):
     self.response = response
     self.buffer_size = buffer_size
-    self.buffer = ''
+    self.buffer = b''
     self.pos = 0
 
   def read(self, amt=None):
@@ -288,5 +288,5 @@ class BufferedHTTPReader(io.IOBase):
     self.pos += amt
     if self.pos >= len(self.buffer):
       self.pos = 0
-      self.buffer = ''
+      self.buffer = b''
     return data

--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -41,10 +41,7 @@ except:
 if sys.version_info >= (3, 0):
   from io import BytesIO as StringIO
 else:
-  try:
-    from cStringIO import StringIO
-  except ImportError:
-    from StringIO import StringIO
+  from cStringIO import StringIO
 
 # use https://github.com/msgpack/msgpack-python if available
 try:

--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -25,7 +25,7 @@ from functools import wraps
 from os.path import splitext, basename
 
 try:
-  import six.moves.cPickle as pickle
+  import cPickle as pickle
   USING_CPICKLE = True
 except:
   import pickle
@@ -196,10 +196,15 @@ if USING_CPICKLE:
   unpickle = SafeUnpickler
 
 else:
+  if sys.version_info[0] >= 3:
+    builtins_mod = 'builtins'
+  else:
+    builtins_mod = '__builtin__'
+
   class SafeUnpickler(pickle.Unpickler):
     PICKLE_SAFE = {
       'copy_reg': set(['_reconstructor']),
-      '__builtin__': set(['object', 'list', 'set']),
+      builtins_mod: set(['object', 'list', 'set']),
       'collections': set(['deque']),
       'graphite.render.datalib': set(['TimeSeries']),
       'graphite.intervals': set(['Interval', 'IntervalSet']),

--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -14,13 +14,15 @@ limitations under the License."""
 
 import imp
 import io
-import json
+import json as _json
 import socket
 import time
 import sys
 import calendar
 import pytz
+import six
 import traceback
+
 from datetime import datetime
 from functools import wraps
 from os.path import splitext, basename
@@ -203,6 +205,29 @@ else:
     @staticmethod
     def load(file):
       return SafeUnpickler(file).load()
+
+
+class json(object):
+  JSONEncoder = _json.JSONEncoder
+  JSONDecoder = _json.JSONDecoder
+
+  @staticmethod
+  def dump(*args, **kwargs):
+    return _json.dump(*args, **kwargs)
+
+  @staticmethod
+  def dumps(*args, **kwargs):
+    return _json.dumps(*args, **kwargs)
+
+  @staticmethod
+  def load(fp, *args, **kwargs):
+    return _json.load(fp, *args, **kwargs)
+
+  @staticmethod
+  def loads(s, *args, **kwargs):
+    if isinstance(s, six.binary_type):
+      return _json.loads(s.decode('utf-8'), *args, **kwargs)
+    return _json.loads(s, *args, **kwargs)
 
 
 class Timer(object):

--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -29,18 +29,15 @@ from django.conf import settings
 from django.utils.timezone import make_aware
 from graphite.logger import log
 
-try:
-  import cPickle as pickle
-  USING_CPICKLE = True
-except:
-  import pickle
-  USING_CPICKLE = False
-
 # BytesIO is needed on py3 as StringIO does not operate on byte input anymore
 # We could use BytesIO on py2 as well but it is slower than StringIO
 if sys.version_info >= (3, 0):
+  PY3 = True
+  import pickle
   from io import BytesIO as StringIO
 else:
+  PY3 = False
+  import cPickle as pickle
   from cStringIO import StringIO
 
 # use https://github.com/msgpack/msgpack-python if available
@@ -145,7 +142,7 @@ def deltaseconds(timedelta):
 # The SafeUnpickler classes were largely derived from
 # http://nadiana.com/python-pickle-insecure
 # This code also lives in carbon.util
-if USING_CPICKLE:
+if not PY3:
   class SafeUnpickler(object):
     PICKLE_SAFE = {
       'copy_reg': set(['_reconstructor']),
@@ -180,15 +177,10 @@ if USING_CPICKLE:
   unpickle = SafeUnpickler
 
 else:
-  if sys.version_info[0] >= 3:
-    builtins_mod = 'builtins'
-  else:
-    builtins_mod = '__builtin__'
-
   class SafeUnpickler(pickle.Unpickler):
     PICKLE_SAFE = {
       'copy_reg': set(['_reconstructor']),
-      builtins_mod: set(['object', 'list', 'set']),
+      'builtins': set(['object', 'list', 'set']),
       'collections': set(['deque']),
       'graphite.render.datalib': set(['TimeSeries']),
       'graphite.intervals': set(['Interval', 'IntervalSet']),

--- a/webapp/tests/settings.py
+++ b/webapp/tests/settings.py
@@ -58,7 +58,7 @@ def atexit_tmpremover(dirname):
     """ Utility to remove a temporary directory during program exit. """
     try:
         shutil.rmtree(dirname)
-        print(("Removed temporary directory: %s" % dirname))
+        print("Removed temporary directory: %s" % dirname)
     except OSError:
         # if the temp dir was removed already by other means
         pass

--- a/webapp/tests/test_browser.py
+++ b/webapp/tests/test_browser.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import json
 import os
 
 from django.contrib.auth.models import User
@@ -9,6 +8,7 @@ except ImportError:  # Django < 1.10
     from django.core.urlresolvers import reverse
 from .base import TestCase
 from django.test.utils import override_settings
+from graphite.util import json
 
 from . import DATA_DIR
 

--- a/webapp/tests/test_browser.py
+++ b/webapp/tests/test_browser.py
@@ -36,22 +36,22 @@ class BrowserTest(TestCase):
         url = reverse('browser_search')
 
         response = self.client.post(url)
-        self.assertEqual(response.content, '')
+        self.assertEqual(response.content, b'')
 
         # simple query
         response = self.client.post(url, {'query': 'collectd'})
-        self.assertEqual(response.content.split(',')[0],
-                         'collectd.test.df-root.df_complex-free')
+        self.assertEqual(response.content.split(b',')[0],
+                         b'collectd.test.df-root.df_complex-free')
 
         # No match
         response = self.client.post(url, {'query': 'other'})
-        self.assertEqual(response.content, '')
+        self.assertEqual(response.content, b'')
 
         # Multiple terms (OR)
         response = self.client.post(url, {'query': 'midterm shortterm'})
-        self.assertEqual(response.content.split(','),
-                         ['collectd.test.load.load.midterm',
-                          'collectd.test.load.load.shortterm'])
+        self.assertEqual(response.content.split(b','),
+                         [b'collectd.test.load.load.midterm',
+                          b'collectd.test.load.load.shortterm'])
 
     def test_unicode_graph_name(self):
         url = reverse('browser_my_graph')

--- a/webapp/tests/test_dashboard.py
+++ b/webapp/tests/test_dashboard.py
@@ -121,7 +121,7 @@ class DashboardTest(TestCase):
         request = {"query": ""}
         response = self.client.get(url, request)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"dashboards": []}')
+        self.assertEqual(response.content, b'{"dashboards": []}')
 
     def test_dashboard_save_empty(self):
         url = reverse('dashboard_save', args=['testdashboard'])
@@ -148,7 +148,7 @@ class DashboardTest(TestCase):
         request = {"query": "test"}
         response = self.client.get(url, request)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"dashboards": [{"name": "testdashboard"}]}')
+        self.assertEqual(response.content, b'{"dashboards": [{"name": "testdashboard"}]}')
 
     def test_dashboard_find_not_existing(self):
         url = reverse('dashboard_save', args=['testdashboard'])
@@ -160,13 +160,13 @@ class DashboardTest(TestCase):
         request = {"query": "not here"}
         response = self.client.get(url, request)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"dashboards": []}')
+        self.assertEqual(response.content, b'{"dashboards": []}')
 
     def test_dashboard_load_not_existing(self):
         url = reverse('dashboard_load', args=['bogusdashboard'])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"error": "Dashboard \'bogusdashboard\' does not exist. "}')
+        self.assertEqual(response.content, b'{"error": "Dashboard \'bogusdashboard\' does not exist. "}')
 
     def test_dashboard_load_existing(self):
         url = reverse('dashboard_save', args=['testdashboard'])
@@ -177,13 +177,13 @@ class DashboardTest(TestCase):
         url = reverse('dashboard_load', args=['testdashboard'])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"state": {}}')
+        self.assertEqual(response.content, b'{"state": {}}')
 
     def test_dashboard_delete_nonexisting(self):
         url = reverse('dashboard_delete', args=['bogusdashboard'])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"error": "Dashboard \'bogusdashboard\' does not exist. "}')
+        self.assertEqual(response.content, b'{"error": "Dashboard \'bogusdashboard\' does not exist. "}')
 
     def test_dashboard_delete_existing(self):
         # Create a dashboard entry
@@ -196,31 +196,31 @@ class DashboardTest(TestCase):
         url = reverse('dashboard_delete', args=['testdashboard'])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"success": true}')
+        self.assertEqual(response.content, b'{"success": true}')
 
         # Confirm it was deleted
         url = reverse('dashboard_find')
         request = {"query": ""}
         response = self.client.get(url, request)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"dashboards": []}')
+        self.assertEqual(response.content, b'{"dashboards": []}')
 
     def test_dashboard_create_temporary(self):
         url = reverse('dashboard_create_temporary')
         request = {"state": '{}'}
         response = self.client.post(url, request)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"name": "temporary-0"}')
+        self.assertEqual(response.content, b'{"name": "temporary-0"}')
 
         response = self.client.post(url, request)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"name": "temporary-1"}')
+        self.assertEqual(response.content, b'{"name": "temporary-1"}')
 
         url = reverse('dashboard_find')
         request = {"query": ""}
         response = self.client.get(url, request)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"dashboards": []}')
+        self.assertEqual(response.content, b'{"dashboards": []}')
 
     def test_dashboard_template_pass_invalid(self):
         url = reverse('dashboard_template', args=['bogustemplate', 'testkey'])
@@ -242,7 +242,7 @@ class DashboardTest(TestCase):
         request = {"query": ""}
         response = self.client.get(url, request)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"templates": []}')
+        self.assertEqual(response.content, b'{"templates": []}')
 
     def test_dashboard_save_template(self):
         url = reverse('dashboard_save_template', args=['testtemplate', 'testkey'])
@@ -272,7 +272,7 @@ class DashboardTest(TestCase):
         request = {"query": "test"}
         response = self.client.get(url, request)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"templates": [{"name": "testtemplate"}]}')
+        self.assertEqual(response.content, b'{"templates": [{"name": "testtemplate"}]}')
 
     def test_dashboard_find_template_nonexistent(self):
         url = reverse('dashboard_save_template', args=['testtemplate', 'testkey'])
@@ -284,7 +284,7 @@ class DashboardTest(TestCase):
         request = {"query": "not here"}
         response = self.client.get(url, request)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"templates": []}')
+        self.assertEqual(response.content, b'{"templates": []}')
 
     def test_dashboard_load_template_nonexistent(self):
         url = reverse('dashboard_save_template', args=['testtemplate', 'testkey'])
@@ -295,7 +295,7 @@ class DashboardTest(TestCase):
         url = reverse('dashboard_load_template', args=['bogustemplate', 'testkey'])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"error": "Template \'bogustemplate\' does not exist. "}')
+        self.assertEqual(response.content, b'{"error": "Template \'bogustemplate\' does not exist. "}')
 
     def test_dashboard_load_template_existing(self):
         url = reverse('dashboard_save_template', args=['testtemplate', 'testkey'])
@@ -315,7 +315,7 @@ class DashboardTest(TestCase):
         url = reverse('dashboard_delete_template', args=['bogustemplate'])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"error": "Template \'bogustemplate\' does not exist. "}')
+        self.assertEqual(response.content, b'{"error": "Template \'bogustemplate\' does not exist. "}')
 
     def test_dashboard_delete_template_existing(self):
         url = reverse('dashboard_save_template', args=['testtemplate', 'testkey'])
@@ -332,7 +332,7 @@ class DashboardTest(TestCase):
         request = {"query": ""}
         response = self.client.get(url, request)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"templates": []}')
+        self.assertEqual(response.content, b'{"templates": []}')
 
     def test_dashboard_help(self):
         url = reverse('dashboard_help')
@@ -348,7 +348,7 @@ class DashboardTest(TestCase):
                    "message": "Here is the test graph",
                    "graph_params": '{"target":["sumSeries(a.b.c.d)"],"title":"Test","width":"500","from":"-55minutes","until":"now","height":"400"}'}
         response = self.client.post(url, request)
-        self.assertEqual(response.content, '{"success": true}')
+        self.assertEqual(response.content, b'{"success": true}')
 
     @mock.patch('graphite.dashboard.views.renderView')
     def test_dashboard_email_mock_renderView(self, rv):
@@ -362,7 +362,7 @@ class DashboardTest(TestCase):
         responseObject.content = ''
         rv.return_value = responseObject
         response = self.client.post(url, request)
-        self.assertEqual(response.content, '{"success": true}')
+        self.assertEqual(response.content, b'{"success": true}')
 
     def test_dashboard_login_invalid_authenticate(self):
         url = reverse('dashboard_login')
@@ -411,7 +411,7 @@ class DashboardTest(TestCase):
         request = {"state": '{}'}
         response = self.client.post(url, request)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"error": "Must be logged in with appropriate permissions to save"}')
+        self.assertEqual(response.content, b'{"error": "Must be logged in with appropriate permissions to save"}')
 
     @mock.patch('graphite.dashboard.views.getPermissions')
     def test_dashboard_delete_no_permissions(self, gp):
@@ -419,7 +419,7 @@ class DashboardTest(TestCase):
         url = reverse('dashboard_delete', args=['testdashboard'])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"error": "Must be logged in with appropriate permissions to delete"}')
+        self.assertEqual(response.content, b'{"error": "Must be logged in with appropriate permissions to delete"}')
 
     @mock.patch('graphite.dashboard.views.getPermissions')
     def test_dashboard_save_template_no_permissions(self, gp):
@@ -428,7 +428,7 @@ class DashboardTest(TestCase):
         request = copy.deepcopy(self.testtemplate)
         response = self.client.post(url, request)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"error": "Must be logged in with appropriate permissions to save the template"}')
+        self.assertEqual(response.content, b'{"error": "Must be logged in with appropriate permissions to save the template"}')
 
     @mock.patch('graphite.dashboard.views.getPermissions')
     def test_dashboard_delete_template_no_permissions(self, gp):
@@ -436,7 +436,7 @@ class DashboardTest(TestCase):
         url = reverse('dashboard_delete_template', args=['testtemplate'])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"error": "Must be logged in with appropriate permissions to delete the template"}')
+        self.assertEqual(response.content, b'{"error": "Must be logged in with appropriate permissions to delete the template"}')
 
     def test_getPermissions_no_user(self):
         settings.DASHBOARD_REQUIRE_AUTHENTICATION=False

--- a/webapp/tests/test_dashboard.py
+++ b/webapp/tests/test_dashboard.py
@@ -326,7 +326,7 @@ class DashboardTest(TestCase):
         url = reverse('dashboard_delete_template', args=['testtemplate'])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"success": true}')
+        self.assertEqual(response.content, b'{"success": true}')
 
         url = reverse('dashboard_find_template')
         request = {"query": ""}

--- a/webapp/tests/test_dashboard.py
+++ b/webapp/tests/test_dashboard.py
@@ -1,6 +1,5 @@
 import copy
 import errno
-import json
 import mock
 import os
 
@@ -14,6 +13,7 @@ except ImportError:  # Django < 1.10
 from django.http import HttpResponse
 from .base import TestCase
 from django.test.utils import override_settings
+from graphite.util import json
 try:
     from django.contrib.auth import get_user_model
     User = get_user_model()

--- a/webapp/tests/test_events.py
+++ b/webapp/tests/test_events.py
@@ -79,7 +79,7 @@ class EventTest(TestCase):
 
         response = self.client.get(creation_url)
         self.assertEqual(response.status_code, 200)
-        self.assertRegexpMatches(response.content, re.compile('^<html>.+<title>Events</title>.+Something happened.+<td>\\[u&#39;foo&#39;, u&#39;bar&#39;\\]</td>.+</html>$', re.DOTALL))
+        self.assertRegexpMatches(response.content, re.compile(b'^<html>.+<title>Events</title>.+Something happened.+<td>\\[u&#39;foo&#39;, u&#39;bar&#39;\\]</td>.+</html>$', re.DOTALL))
 
     def test_tag_as_str(self):
         creation_url = reverse('events')
@@ -99,7 +99,7 @@ class EventTest(TestCase):
         url = reverse('events_get_data')
         response = self.client.get(url, {'until': 'now+5min', 'jsonp': 'test'})
         self.assertEqual(response.status_code, 200)
-        self.assertRegexpMatches(response.content, '^test[(].+[)]$')
+        self.assertRegexpMatches(response.content, b'^test[(].+[)]$')
         events = json.loads(response.content[5:-1])
         self.assertEqual(len(events), 1)
         event = events[0]
@@ -211,7 +211,7 @@ class EventTest(TestCase):
         url = reverse('events_detail', args=[events[0]['id']])
         response = self.client.get(url, {})
         self.assertEqual(response.status_code, 200)
-        self.assertRegexpMatches(response.content, re.compile('^<html>.+<title>Something happened</title>.+<h1>Something happened</h1>.+<td>tags</td><td>foo bar baz</td>.+</html>$', re.DOTALL))
+        self.assertRegexpMatches(response.content, re.compile(b'^<html>.+<title>Something happened</title>.+<h1>Something happened</h1>.+<td>tags</td><td>foo bar baz</td>.+</html>$', re.DOTALL))
 
     def test_get_detail_json_object_does_not_exist(self):
         url = reverse('events_detail', args=[1])
@@ -223,7 +223,7 @@ class EventTest(TestCase):
         url = reverse('events_detail', args=[1])
         response = self.client.get(url, {})
         self.assertEqual(response.status_code, 404)
-        self.assertRegexpMatches(response.content, '<h1>Not Found</h1>')
+        self.assertRegexpMatches(response.content, b'<h1>Not Found</h1>')
 
     def test_render_events_issue_1749(self):
         url = reverse('render')

--- a/webapp/tests/test_events.py
+++ b/webapp/tests/test_events.py
@@ -1,6 +1,7 @@
 import time
 import json
 import re
+import sys
 
 from datetime import timedelta
 
@@ -79,7 +80,13 @@ class EventTest(TestCase):
 
         response = self.client.get(creation_url)
         self.assertEqual(response.status_code, 200)
-        self.assertRegexpMatches(response.content, re.compile(b'^<html>.+<title>Events</title>.+Something happened.+<td>\\[u&#39;foo&#39;, u&#39;bar&#39;\\]</td>.+</html>$', re.DOTALL))
+        if sys.version_info[0] >= 3:
+            # Python 3: 'strings'
+            expected_re = b'^<html>.+<title>Events</title>.+Something happened.+<td>\\[&#39;foo&#39;, &#39;bar&#39;\\]</td>.+</html>$'
+        else:
+            # Python 2: u'strings'
+            expected_re = b'^<html>.+<title>Events</title>.+Something happened.+<td>\\[u&#39;foo&#39;, u&#39;bar&#39;\\]</td>.+</html>$'
+        self.assertRegexpMatches(response.content, re.compile(expected_re, re.DOTALL))
 
     def test_tag_as_str(self):
         creation_url = reverse('events')

--- a/webapp/tests/test_events.py
+++ b/webapp/tests/test_events.py
@@ -1,5 +1,4 @@
 import time
-import json
 import re
 import sys
 
@@ -13,6 +12,7 @@ from .base import TestCase
 from django.utils import timezone
 
 from graphite.events.models import Event
+from graphite.util import json
 
 
 class EventTest(TestCase):

--- a/webapp/tests/test_events.py
+++ b/webapp/tests/test_events.py
@@ -1,6 +1,5 @@
 import time
 import re
-import sys
 
 from datetime import timedelta
 

--- a/webapp/tests/test_events.py
+++ b/webapp/tests/test_events.py
@@ -80,12 +80,7 @@ class EventTest(TestCase):
 
         response = self.client.get(creation_url)
         self.assertEqual(response.status_code, 200)
-        if sys.version_info[0] >= 3:
-            # Python 3: 'strings'
-            expected_re = b'^<html>.+<title>Events</title>.+Something happened.+<td>\\[&#39;foo&#39;, &#39;bar&#39;\\]</td>.+</html>$'
-        else:
-            # Python 2: u'strings'
-            expected_re = b'^<html>.+<title>Events</title>.+Something happened.+<td>\\[u&#39;foo&#39;, u&#39;bar&#39;\\]</td>.+</html>$'
+        expected_re = b'^<html>.+<title>Events</title>.+Something happened.+<td>\\[&#39;foo&#39;, &#39;bar&#39;\\]</td>.+</html>$'
         self.assertRegexpMatches(response.content, re.compile(expected_re, re.DOTALL))
 
     def test_tag_as_str(self):

--- a/webapp/tests/test_finders.py
+++ b/webapp/tests/test_finders.py
@@ -74,7 +74,7 @@ class DummyReader(BaseReader):
         self.path = path
 
     def fetch(self, start_time, end_time):
-        npoints = (end_time - start_time) / 10
+        npoints = (end_time - start_time) // 10
         return (start_time, end_time, 10), [
             random.choice([None, 1, 2, 3]) for i in range(npoints)
         ]

--- a/webapp/tests/test_finders.py
+++ b/webapp/tests/test_finders.py
@@ -297,9 +297,6 @@ class StandardFinderTest(TestCase):
         self.assertEqual(output_metric_path, expected_metric_path)
 
 class CeresFinderTest(TestCase):
-    _listdir_counter = 0
-    _original_listdir = os.listdir
-
     unittest.skipIf(not ceres, 'ceres not installed')
     def test_ceres_finder(self):
         test_dir = join(settings.CERES_DIR)
@@ -320,56 +317,36 @@ class CeresFinderTest(TestCase):
             except OSError:
                 pass
 
-        def listdir_mock(d):
-            self._listdir_counter += 1
-            return self._original_listdir(d)
+        self.addCleanup(wipe_ceres)
 
-        try:
-            os.listdir = listdir_mock
-            create_ceres('foo')
-            create_ceres('foo.bar.baz')
-            create_ceres('bar.baz.foo')
+        create_ceres('foo')
+        create_ceres('foo.bar.baz')
+        create_ceres('bar.baz.foo')
 
-            finder = get_finders('graphite.finders.ceres.CeresFinder')[0]
+        finder = get_finders('graphite.finders.ceres.CeresFinder')[0]
 
-            self._listdir_counter = 0
-            nodes = finder.find_nodes(FindQuery('foo', None, None))
-            self.assertEqual(len(list(nodes)), 1)
-            self.assertEqual(self._listdir_counter, 1)
+        nodes = finder.find_nodes(FindQuery('foo', None, None))
+        self.assertEqual(len(list(nodes)), 1)
 
-            self._listdir_counter = 0
-            nodes = finder.find_nodes(FindQuery('foo.bar.baz', None, None))
-            self.assertEqual(len(list(nodes)), 1)
-            self.assertEqual(self._listdir_counter, 1)
+        nodes = finder.find_nodes(FindQuery('foo.bar.baz', None, None))
+        self.assertEqual(len(list(nodes)), 1)
 
-            # No data in the expected time period
-            self._listdir_counter = 0
-            nodes = finder.find_nodes(FindQuery('foo.bar.baz', 10000, 10060))
-            self.assertEqual(len(list(nodes)), 0)
-            self.assertEqual(self._listdir_counter, 1)
+        # No data in the expected time period
+        nodes = finder.find_nodes(FindQuery('foo.bar.baz', 10000, 10060))
+        self.assertEqual(len(list(nodes)), 0)
 
-            self._listdir_counter = 0
-            nodes = finder.find_nodes(FindQuery('foo.bar', None, None))
-            self.assertEqual(len(list(nodes)), 1)
-            self.assertEqual(self._listdir_counter, 0)
+        nodes = finder.find_nodes(FindQuery('foo.bar', None, None))
+        self.assertEqual(len(list(nodes)), 1)
 
-            self._listdir_counter = 0
-            nodes = finder.find_nodes(FindQuery('*.ba?.{baz,foo}', None, None))
-            self.assertEqual(len(list(nodes)), 2)
-            self.assertEqual(self._listdir_counter, 8)
+        nodes = finder.find_nodes(FindQuery('*.ba?.{baz,foo}', None, None))
+        self.assertEqual(len(list(nodes)), 2)
 
-            # Search for something that isn't valid Ceres content
-            fh = open(join(test_dir, 'foo', 'blah'), 'wb')
-            fh.close()
-            self._listdir_counter = 0
-            nodes = finder.find_nodes(FindQuery('foo.blah', None, None))
-            self.assertEqual(len(list(nodes)), 0)
-            self.assertEqual(self._listdir_counter, 0)
+        # Search for something that isn't valid Ceres content
+        fh = open(join(test_dir, 'foo', 'blah'), 'wb')
+        fh.close()
+        nodes = finder.find_nodes(FindQuery('foo.blah', None, None))
+        self.assertEqual(len(list(nodes)), 0)
 
-            # get index
-            result = finder.get_index({})
-            self.assertEqual(result, ['bar.baz.foo', 'foo', 'foo.bar.baz'])
-
-        finally:
-            os.listdir = self._original_listdir
-            wipe_ceres()
+        # get index
+        result = finder.get_index({})
+        self.assertEqual(result, ['bar.baz.foo', 'foo', 'foo.bar.baz'])

--- a/webapp/tests/test_finders.py
+++ b/webapp/tests/test_finders.py
@@ -7,6 +7,7 @@ import random
 import shutil
 import time
 import unittest
+from six.moves import range
 
 try:
     from unittest.mock import patch
@@ -88,7 +89,7 @@ class DummyFinder(BaseFinder):
             yield BranchNode('foo')
 
         elif query.pattern == 'bar.*':
-            for i in xrange(10):
+            for i in range(10):
                 path = 'bar.{0}'.format(i)
                 yield LeafNode(path, DummyReader(path))
 
@@ -99,7 +100,7 @@ class LegacyFinder(object):
             yield BranchNode('foo')
 
         elif query.pattern == 'bar.*':
-            for i in xrange(10):
+            for i in range(10):
                 path = 'bar.{0}'.format(i)
                 yield LeafNode(path, DummyReader(path))
 

--- a/webapp/tests/test_finders_remote.py
+++ b/webapp/tests/test_finders_remote.py
@@ -164,7 +164,7 @@ class RemoteFinderTest(TestCase):
       self.assertEqual(nodes[1].path, 'a.b.c.d')
 
       # non-pickle response
-      responseObject = HTTPResponse(body=StringIO('error'), status=200, preload_content=False)
+      responseObject = HTTPResponse(body=StringIO(b'error'), status=200, preload_content=False)
       http_request.return_value = responseObject
 
       result = finder.find_nodes(query)
@@ -278,7 +278,7 @@ class RemoteFinderTest(TestCase):
         'a.b.c',
         'a.b.c.d',
       ]
-      responseObject = HTTPResponse(body=StringIO(json.dumps(data)), status=200, preload_content=False)
+      responseObject = HTTPResponse(body=StringIO(json.dumps(data).encode('ascii')), status=200, preload_content=False)
       http_request.return_value = responseObject
 
       result = finder.get_index({})
@@ -304,7 +304,7 @@ class RemoteFinderTest(TestCase):
       self.assertEqual(result[1], 'a.b.c.d')
 
       # non-json response
-      responseObject = HTTPResponse(body=StringIO('error'), status=200, preload_content=False)
+      responseObject = HTTPResponse(body=StringIO(b'error'), status=200, preload_content=False)
       http_request.return_value = responseObject
 
       with self.assertRaisesRegexp(Exception, 'Error decoding index response from http://[^ ]+: .+'):

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -5856,8 +5856,8 @@ class FunctionsTest(TestCase):
             data=[
                 list(range(start_secs_from_epoch, end_secs_from_epoch, step)),
                 list(range(start_secs_from_epoch, -end_secs_from_epoch, -step)),
-                [None] * (end_minus_start_secs / step),
-                list(range(0, end_minus_start_secs / step))
+                [None] * (end_minus_start_secs // step),
+                list(range(0, end_minus_start_secs // step))
             ]
         )
 

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -1,6 +1,7 @@
 import copy
 import math
 import pytz
+import six
 
 from datetime import datetime
 from fnmatch import fnmatch
@@ -5815,7 +5816,7 @@ class FunctionsTest(TestCase):
 
         """
         seriesList = []
-        if isinstance(key, (str, unicode)):
+        if isinstance(key, six.string_types):
             seriesList = [
                 TimeSeries(key, start, end, step, data)
             ]

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -15,6 +15,7 @@ from graphite.render.functions import NormalizeEmptyResultError
 from graphite.render.evaluator import evaluateTarget
 from graphite.tags.utils import TaggedSeries
 from graphite.render.grammar import grammar
+from six.moves import range
 
 
 def return_greater(series, value):
@@ -415,8 +416,8 @@ class FunctionsTest(TestCase):
 
     def test_normalize_different_steps(self):
         seriesList = [
-          TimeSeries("test.1", 0, 120 * 31, 120, values=range(1, 32)),
-          TimeSeries("test.2", 0, 30 * 120, 30, values=range(1, 121)),
+          TimeSeries("test.1", 0, 120 * 31, 120, values=list(range(1, 32))),
+          TimeSeries("test.2", 0, 30 * 120, 30, values=list(range(1, 121))),
         ]
 
         self.assertEqual(seriesList[0].start, 0)
@@ -569,7 +570,7 @@ class FunctionsTest(TestCase):
 
     def test_sumSeries(self):
         seriesList = self._generate_series_list()
-        data = range(0,202,2)
+        data = list(range(0,202,2))
         expected_name = "sumSeries(collectd.test-db1.load.value,collectd.test-db2.load.value)"
         expectedList = [TimeSeries(expected_name, 0, len(data), 1, data)]
         result = functions.sumSeries({}, [seriesList[0], seriesList[1]])
@@ -580,7 +581,7 @@ class FunctionsTest(TestCase):
 
     def test_sumSeriesWithWildcards(self):
         seriesList = self._generate_series_list()
-        data = range(0,202,2)
+        data = list(range(0,202,2))
         expected_name = "load.value"
         expectedList = [TimeSeries(expected_name, 0, len(data), 1, data)]
         result = functions.sumSeriesWithWildcards({}, [seriesList[0], seriesList[1]], 0,1)
@@ -591,7 +592,7 @@ class FunctionsTest(TestCase):
 
     def test_averageSeriesWithWildcards(self):
         seriesList = self._generate_series_list()
-        data = range(0,101,1)
+        data = list(range(0,101,1))
         expected_name = "load.value"
         expectedList = [TimeSeries(expected_name, 0, len(data), 1, data)]
         result = functions.averageSeriesWithWildcards({}, [seriesList[0], seriesList[1]], 0,1)
@@ -650,7 +651,7 @@ class FunctionsTest(TestCase):
 
     def test_aggregate_median(self):
         seriesList = self._generate_series_list()
-        data = range(0,101)
+        data = list(range(0,101))
         expected_name = "medianSeries(collectd.test-db1.load.value,collectd.test-db2.load.value)"
         expectedList = [TimeSeries(expected_name, 0, len(data), 1, data)]
         result = functions.aggregate({}, [seriesList[0], seriesList[1]], 'median')
@@ -658,7 +659,7 @@ class FunctionsTest(TestCase):
 
     def test_aggregate_stripSeries(self):
         seriesList = self._generate_series_list()
-        data = range(0,101)
+        data = list(range(0,101))
         expected_name = "medianSeries(collectd.test-db1.load.value,collectd.test-db2.load.value)"
         expectedList = [TimeSeries(expected_name, 0, len(data), 1, data)]
         result = functions.aggregate({}, [seriesList[0], seriesList[1]], 'medianSeries')
@@ -674,7 +675,7 @@ class FunctionsTest(TestCase):
 
     def test_averageSeries(self):
         seriesList = self._generate_series_list()
-        data = range(0,101)
+        data = list(range(0,101))
         expected_name = "averageSeries(collectd.test-db1.load.value,collectd.test-db2.load.value)"
         expectedList = [TimeSeries(expected_name, 0, len(data), 1, data)]
         result = functions.averageSeries({}, [seriesList[0], seriesList[1]])
@@ -690,7 +691,7 @@ class FunctionsTest(TestCase):
 
     def test_minSeries(self):
         seriesList = self._generate_series_list()
-        data = range(0,101)
+        data = list(range(0,101))
         expected_name = "minSeries(collectd.test-db1.load.value,collectd.test-db2.load.value)"
         expectedList = [TimeSeries(expected_name, 0, len(data), 1, data)]
         result = functions.minSeries({}, [seriesList[0], seriesList[1]])
@@ -698,7 +699,7 @@ class FunctionsTest(TestCase):
 
     def test_maxSeries(self):
         seriesList = self._generate_series_list()
-        data = range(0,101)
+        data = list(range(0,101))
         expected_name = "maxSeries(collectd.test-db1.load.value,collectd.test-db2.load.value)"
         expectedList = [TimeSeries(expected_name, 0, len(data), 1, data)]
         result = functions.maxSeries({}, [seriesList[0], seriesList[1]])
@@ -724,7 +725,7 @@ class FunctionsTest(TestCase):
 
     def test_percentileOfSeries(self):
         seriesList = self._generate_series_list()
-        data = range(0,101)
+        data = list(range(0,101))
         expected_name = "percentileOfSeries(collectd.test-db1.load.value,90)"
         expectedList = [TimeSeries(expected_name, 0, len(data), 1, data)]
         result = functions.percentileOfSeries({}, [seriesList[0], seriesList[1]], 90)
@@ -736,15 +737,15 @@ class FunctionsTest(TestCase):
     def testGetPercentile_percentile_0(self):
         seriesList = [
             ([None, None, 15, 20, 35, 40, 50], 15),
-            (range(100), 0),
-            (range(200), 0),
-            (range(300), 0),
-            (range(1, 101), 1),
-            (range(1, 201), 1),
-            (range(1, 301), 1),
-            (range(0, 102), 0),
-            (range(1, 203), 1),
-            (range(1, 303), 1),
+            (list(range(100)), 0),
+            (list(range(200)), 0),
+            (list(range(300)), 0),
+            (list(range(1, 101)), 1),
+            (list(range(1, 201)), 1),
+            (list(range(1, 301)), 1),
+            (list(range(0, 102)), 0),
+            (list(range(1, 203)), 1),
+            (list(range(1, 303)), 1),
         ]
         for index, conf in enumerate(seriesList):
             series, expected = conf
@@ -755,15 +756,15 @@ class FunctionsTest(TestCase):
     def testGetPercentile_interpolated(self):
         seriesList = [
             ([None, None, 15, 20, 35, 40, 50], 19.0),
-            (range(100), 29.3),
-            (range(200), 59.3),
-            (range(300), 89.3),
-            (range(1, 101), 30.3),
-            (range(1, 201), 60.3),
-            (range(1, 301), 90.3),
-            (range(0, 102), 29.9),
-            (range(1, 203), 60.9),
-            (range(1, 303), 90.9),
+            (list(range(100)), 29.3),
+            (list(range(200)), 59.3),
+            (list(range(300)), 89.3),
+            (list(range(1, 101)), 30.3),
+            (list(range(1, 201)), 60.3),
+            (list(range(1, 301)), 90.3),
+            (list(range(0, 102)), 29.9),
+            (list(range(1, 203)), 60.9),
+            (list(range(1, 303)), 90.9),
         ]
         for index, conf in enumerate(seriesList):
             series, expected = conf
@@ -773,15 +774,15 @@ class FunctionsTest(TestCase):
     def testGetPercentile(self):
         seriesList = [
             ([None, None, 15, 20, 35, 40, 50], 20),
-            (range(100), 30),
-            (range(200), 60),
-            (range(300), 90),
-            (range(1, 101), 31),
-            (range(1, 201), 61),
-            (range(1, 301), 91),
-            (range(0, 102), 30),
-            (range(1, 203), 61),
-            (range(1, 303), 91),
+            (list(range(100)), 30),
+            (list(range(200)), 60),
+            (list(range(300)), 90),
+            (list(range(1, 101)), 31),
+            (list(range(1, 201)), 61),
+            (list(range(1, 301)), 91),
+            (list(range(0, 102)), 30),
+            (list(range(1, 203)), 61),
+            (list(range(1, 303)), 91),
         ]
         for index, conf in enumerate(seriesList):
             series, expected = conf
@@ -860,11 +861,11 @@ class FunctionsTest(TestCase):
 
     def test_delay(self):
         source = [
-            TimeSeries('collectd.test-db1.load.value',0,1,1,[range(18)] + [None, None]),
+            TimeSeries('collectd.test-db1.load.value',0,1,1,[list(range(18))] + [None, None]),
         ]
         delay = 2
         expectedList = [
-            TimeSeries('delay(collectd.test-db1.load.value,2)',0,1,1,[None, None] + [range(18)]),
+            TimeSeries('delay(collectd.test-db1.load.value,2)',0,1,1,[None, None] + [list(range(18))]),
         ]
         gotList = functions.delay({}, source, delay)
         self.assertEqual(len(gotList), len(expectedList))
@@ -1864,14 +1865,14 @@ class FunctionsTest(TestCase):
     def test_n_percentile(self):
         config = [
             [15, 35, 20, 40, 50],
-            range(1, 101),
-            range(1, 201),
-            range(1, 301),
-            range(0, 100),
-            range(0, 200),
-            range(0, 300),
+            list(range(1, 101)),
+            list(range(1, 201)),
+            list(range(1, 301)),
+            list(range(0, 100)),
+            list(range(0, 200)),
+            list(range(0, 300)),
             # Ensure None values in list has no effect.
-            [None, None, None] + range(0, 300),
+            [None, None, None] + list(range(0, 300)),
         ]
 
         def n_percentile(perc, expect):
@@ -3297,7 +3298,7 @@ class FunctionsTest(TestCase):
 
     def test_highest_max(self):
         config = [20, 50, 30, 40]
-        seriesList = [range(max_val) for max_val in config]
+        seriesList = [list(range(max_val)) for max_val in config]
 
         # Expect the test results to be returned in descending order
         expected = [
@@ -4190,7 +4191,7 @@ class FunctionsTest(TestCase):
             key='collectd.test-db0.load.value',
             start=20,
             end=25,
-            data=range(20, 25)
+            data=list(range(20, 25))
         )
 
         def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
@@ -4198,7 +4199,7 @@ class FunctionsTest(TestCase):
                 key='collectd.test-db0.load.value',
                 start=10,
                 end=25,
-                data=range(10, 25)
+                data=list(range(10, 25))
             )
 
         with patch('graphite.render.functions.evaluateTarget', mock_evaluateTarget):
@@ -4210,7 +4211,7 @@ class FunctionsTest(TestCase):
             key='collectd.test-db0.load.value',
             start=20,
             end=30,
-            data=range(0, 10)
+            data=list(range(0, 10))
         )
 
         def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
@@ -4218,7 +4219,7 @@ class FunctionsTest(TestCase):
                 key='collectd.test-db0.load.value',
                 start=10,
                 end=30,
-                data=[None] * 10 + range(0, 10)
+                data=[None] * 10 + list(range(0, 10))
             )
 
         expectedResults = [
@@ -4244,7 +4245,7 @@ class FunctionsTest(TestCase):
             key='collectd.test-db0.load.value',
             start=20,
             end=25,
-            data=range(10, 25)
+            data=list(range(10, 25))
         )
 
         def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
@@ -4274,7 +4275,7 @@ class FunctionsTest(TestCase):
             key='collectd.test-db0.load.value',
             start=20,
             end=30,
-            data=range(10, 110)
+            data=list(range(10, 110))
         )
 
         def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
@@ -4282,7 +4283,7 @@ class FunctionsTest(TestCase):
                 key='collectd.test-db0.load.value',
                 start=10,
                 end=30,
-                data=[None] * 10 + range(0, 10)
+                data=[None] * 10 + list(range(0, 10))
             )
 
         expectedResults = [
@@ -4304,7 +4305,7 @@ class FunctionsTest(TestCase):
             key='collectd.test-db0.load.value',
             start=610,
             end=710,
-            data=range(10, 110)
+            data=list(range(10, 110))
         )
 
         def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
@@ -4327,7 +4328,7 @@ class FunctionsTest(TestCase):
             key='collectd.test-db0.load.value',
             start=610,
             end=710,
-            data=range(10, 110)
+            data=list(range(10, 110))
         )
 
         def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
@@ -4335,11 +4336,11 @@ class FunctionsTest(TestCase):
                 key='collectd.test-db0.load.value',
                 start=600,
                 end=700,
-                data=range(0, 100)
+                data=list(range(0, 100))
             )
 
         expectedResults = [
-            TimeSeries('movingMedian(collectd.test-db0.load.value,60)', 660, 700, 1, range(30, 70)),
+            TimeSeries('movingMedian(collectd.test-db0.load.value,60)', 660, 700, 1, list(range(30, 70))),
         ]
 
         with patch('graphite.render.functions.evaluateTarget', mock_evaluateTarget):
@@ -4357,7 +4358,7 @@ class FunctionsTest(TestCase):
             key='collectd.test-db0.load.value',
             start=610,
             end=710,
-            data=range(10, 610)
+            data=list(range(10, 610))
         )
 
         def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
@@ -4365,11 +4366,11 @@ class FunctionsTest(TestCase):
                 key='collectd.test-db0.load.value',
                 start=600,
                 end=700,
-                data=range(0, 100)
+                data=list(range(0, 100))
             )
 
         expectedResults = [
-            TimeSeries('movingMedian(collectd.test-db0.load.value,"-1min")', 660, 700, 1, range(30, 70)),
+            TimeSeries('movingMedian(collectd.test-db0.load.value,"-1min")', 660, 700, 1, list(range(30, 70))),
         ]
 
         with patch('graphite.render.functions.evaluateTarget', mock_evaluateTarget):
@@ -4390,7 +4391,7 @@ class FunctionsTest(TestCase):
             key='collectd.test-db0.load.value',
             start=20,
             end=25,
-            data=range(0, 25)
+            data=list(range(0, 25))
         )
 
         def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
@@ -4420,7 +4421,7 @@ class FunctionsTest(TestCase):
             key='collectd.test-db0.load.value',
             start=20,
             end=30,
-            data=range(0, 10)
+            data=list(range(0, 10))
         )
 
         def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
@@ -4428,7 +4429,7 @@ class FunctionsTest(TestCase):
                 key='collectd.test-db0.load.value',
                 start=10,
                 end=30,
-                data=[None] * 10 + range(0, 10)
+                data=[None] * 10 + list(range(0, 10))
             )
 
         expectedResults = [
@@ -4451,7 +4452,7 @@ class FunctionsTest(TestCase):
             key='collectd.test-db0.load.value',
             start=610,
             end=710,
-            data=range(10, 110)
+            data=list(range(10, 110))
         )
 
         def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
@@ -4474,7 +4475,7 @@ class FunctionsTest(TestCase):
             key='collectd.test-db0.load.value',
             start=610,
             end=710,
-            data=range(10, 110)
+            data=list(range(10, 110))
         )
 
         def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
@@ -4482,7 +4483,7 @@ class FunctionsTest(TestCase):
                 key='collectd.test-db0.load.value',
                 start=600,
                 end=700,
-                data=range(0, 100)
+                data=list(range(0, 100))
             )
 
         def frange(x,y,jump):
@@ -4508,7 +4509,7 @@ class FunctionsTest(TestCase):
             key='collectd.test-db0.load.value',
             start=610,
             end=710,
-            data=range(10, 110)
+            data=list(range(10, 110))
         )
 
         def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
@@ -4516,7 +4517,7 @@ class FunctionsTest(TestCase):
                 key='collectd.test-db0.load.value',
                 start=600,
                 end=700,
-                data=range(0, 100)
+                data=list(range(0, 100))
             )
 
         def frange(x,y,jump):
@@ -4548,7 +4549,7 @@ class FunctionsTest(TestCase):
             key='collectd.test-db0.load.value',
             start=start + 10,
             end=end,
-            data=range(start, end)
+            data=list(range(start, end))
         )
 
         def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
@@ -4608,7 +4609,7 @@ class FunctionsTest(TestCase):
             key='collectd.test-db0.load.value',
             start=610,
             end=710,
-            data=range(10, 10 + 100)
+            data=list(range(10, 10 + 100))
         )
 
         def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
@@ -4696,7 +4697,7 @@ class FunctionsTest(TestCase):
             key='collectd.test-db0.load.value',
             start=start + 10,
             end=end,
-            data=range(start, end)
+            data=list(range(start, end))
         )
 
         def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
@@ -4756,7 +4757,7 @@ class FunctionsTest(TestCase):
             key='collectd.test-db0.load.value',
             start=610,
             end=710,
-            data=range(10, 10 + 100)
+            data=list(range(10, 10 + 100))
         )
 
         def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
@@ -4857,7 +4858,7 @@ class FunctionsTest(TestCase):
             key='collectd.test-db0.load.value',
             start=start + 10,
             end=end,
-            data=range(start, end)
+            data=list(range(start, end))
         )
 
         def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
@@ -4887,12 +4888,12 @@ class FunctionsTest(TestCase):
             key='collectd.test-db0.load.value',
             start=20,
             end=30,
-            data=range(0, 10)
+            data=list(range(0, 10))
         )
 
         def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
             seriesList = [
-                TimeSeries('collectd.test-db0.load.value', 10, 30, 1, [None] * 10 + range(0, 10))
+                TimeSeries('collectd.test-db0.load.value', 10, 30, 1, [None] * 10 + list(range(0, 10)))
             ]
             for series in seriesList:
                 series.pathExpression = series.name
@@ -4917,7 +4918,7 @@ class FunctionsTest(TestCase):
             key='collectd.test-db0.load.value',
             start=610,
             end=710,
-            data=range(10, 10 + 100)
+            data=list(range(10, 10 + 100))
         )
 
         def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
@@ -4988,7 +4989,7 @@ class FunctionsTest(TestCase):
     def test_holtWintersForecast(self):
         def gen_seriesList(start=0):
             seriesList = [
-                TimeSeries('collectd.test-db0.load.value', start+600, start+700, 1, range(start, start+100)),
+                TimeSeries('collectd.test-db0.load.value', start+600, start+700, 1, list(range(start, start+100))),
             ]
             for series in seriesList:
                 series.pathExpression = series.name
@@ -5445,7 +5446,7 @@ class FunctionsTest(TestCase):
             start=0,
             end=endTime,
             step=60,
-            data=[range(0, endTime, 60), range(0, -endTime, -60), [None] * 1440, range(0, 1440)]
+            data=[list(range(0, endTime, 60)), list(range(0, -endTime, -60)), [None] * 1440, list(range(0, 1440))]
         )
 
         expectedResults = [
@@ -5468,7 +5469,7 @@ class FunctionsTest(TestCase):
             key=['servers.s1.disk.bytes_used', 'servers.s1.disk.bytes_free', 'servers.s2.disk.bytes_used', 'servers.s2.disk.bytes_free'],
             start=0,
             end=endTime,
-            data=[range(0, endTime), range(0, -endTime, -1), [None] * endTime, range(0, endTime*2, 2)]
+            data=[list(range(0, endTime)), list(range(0, -endTime, -1)), [None] * endTime, list(range(0, endTime*2, 2))]
         )
 
         expectedResults = [
@@ -5492,7 +5493,7 @@ class FunctionsTest(TestCase):
             key=['servers.s1.disk.bytes_used', 'servers.s1.disk.bytes_free', 'servers.s2.disk.bytes_used', 'servers.s2.disk.bytes_free'],
             start=0,
             end=240,
-            data=[range(0, 240), range(0, -240, -1), [None] * 240, range(0, 480, 2)]
+            data=[list(range(0, 240)), list(range(0, -240, -1)), [None] * 240, list(range(0, 480, 2))]
         )
 
         expectedResults = [
@@ -5516,7 +5517,7 @@ class FunctionsTest(TestCase):
             key=['servers.s1.disk.bytes_used', 'servers.s1.disk.bytes_free', 'servers.s2.disk.bytes_used', 'servers.s2.disk.bytes_free'],
             start=0,
             end=240,
-            data=[range(0, 240), range(0, -240, -1), [None] * 240, range(0, 480, 2)]
+            data=[list(range(0, 240)), list(range(0, -240, -1)), [None] * 240, list(range(0, 480, 2))]
         )
 
         expectedResults = [
@@ -5540,7 +5541,7 @@ class FunctionsTest(TestCase):
             key=['servers.s1.disk.bytes_used', 'servers.s1.disk.bytes_free', 'servers.s2.disk.bytes_used', 'servers.s2.disk.bytes_free'],
             start=0,
             end=240,
-            data=[range(0, 240), range(0, -240, -1), [None] * 240, range(0, 480, 2)]
+            data=[list(range(0, 240)), list(range(0, -240, -1)), [None] * 240, list(range(0, 480, 2))]
         )
 
         expectedResults = {'sum' : [
@@ -5591,7 +5592,7 @@ class FunctionsTest(TestCase):
             key=['servers.s1.disk.bytes_used', 'servers.s1.disk.bytes_free', 'servers.s2.disk.bytes_used', 'servers.s2.disk.bytes_free'],
             start=0,
             end=240,
-            data=[range(0, 240), range(0, -240, -1), [None] * 240, range(0, 480, 2)]
+            data=[list(range(0, 240)), list(range(0, -240, -1)), [None] * 240, list(range(0, 480, 2))]
         )
 
         expectedResults = {'sum' : [
@@ -5673,7 +5674,7 @@ class FunctionsTest(TestCase):
         self.assertEqual(functions.exponentialMovingAverage({},[],""), [])
 
     def test_exponentialMovingAverage_integerWindowSize(self):
-        seriesList = self._gen_series_list_with_data(start=0, end=60, data=range(0, 60))
+        seriesList = self._gen_series_list_with_data(start=0, end=60, data=list(range(0, 60)))
         expectedResults = self._gen_series_list_with_data(
             key='exponentialMovingAverage(collectd.test-db0.load.value,30)',
             start=30,
@@ -5691,7 +5692,7 @@ class FunctionsTest(TestCase):
         self.assertEqual(result, expectedResults)
 
     def test_exponentialMovingAverage_stringWindowSize(self):
-        seriesList = self._gen_series_list_with_data(start=0, end=60, data=range(0, 60))
+        seriesList = self._gen_series_list_with_data(start=0, end=60, data=list(range(0, 60)))
         expectedResults = self._gen_series_list_with_data(
             key='exponentialMovingAverage(collectd.test-db0.load.value,"-30s")',
             start=30,
@@ -5709,7 +5710,7 @@ class FunctionsTest(TestCase):
         self.assertEqual(result, expectedResults)
 
     def test_exponentialMovingAverage_evaluateTarget_returns_empty_list(self):
-        seriesList = self._gen_series_list_with_data(start=600, end=700, data=range(0, 100))
+        seriesList = self._gen_series_list_with_data(start=600, end=700, data=list(range(0, 100)))
         expectedResults = []
 
         def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
@@ -5731,7 +5732,7 @@ class FunctionsTest(TestCase):
         )
 
         def mock_evaluateTarget(requestContext, targets, noPrefetch=False):
-            return self._gen_series_list_with_data(key='collectd.test-db0.load.value',start=10, end=30, data=([None] * 10 + range(0, 5) + [None] + range(5, 9)))
+            return self._gen_series_list_with_data(key='collectd.test-db0.load.value',start=10, end=30, data=([None] * 10 + list(range(0, 5)) + [None] + list(range(5, 9))))
 
         with patch('graphite.render.functions.evaluateTarget', mock_evaluateTarget):
             result = functions.exponentialMovingAverage(self._build_requestContext(endTime=datetime(1970, 1, 1, 0, 9, 0, 0, pytz.timezone(settings.TIME_ZONE))), seriesList, 10)
@@ -5852,10 +5853,10 @@ class FunctionsTest(TestCase):
             end=end_secs_from_epoch,
             step=step,
             data=[
-                range(start_secs_from_epoch, end_secs_from_epoch, step),
-                range(start_secs_from_epoch, -end_secs_from_epoch, -step),
+                list(range(start_secs_from_epoch, end_secs_from_epoch, step)),
+                list(range(start_secs_from_epoch, -end_secs_from_epoch, -step)),
                 [None] * (end_minus_start_secs / step),
-                range(0, end_minus_start_secs / step)
+                list(range(0, end_minus_start_secs / step))
             ]
         )
 
@@ -5863,7 +5864,7 @@ class FunctionsTest(TestCase):
 
     def _generate_series_list(self):
         seriesList = []
-        config = [range(101), range(101), [1, None, None, None, None]]
+        config = [list(range(101)), list(range(101)), [1, None, None, None, None]]
 
         for i, c in enumerate(config):
             name = "collectd.test-db{0}.load.value".format(i + 1)

--- a/webapp/tests/test_metrics.py
+++ b/webapp/tests/test_metrics.py
@@ -1,5 +1,4 @@
 import copy
-import json
 import os
 import shutil
 import time
@@ -15,7 +14,7 @@ from .base import TestCase
 
 import whisper
 
-from graphite.util import unpickle, msgpack
+from graphite.util import unpickle, msgpack, json
 
 
 class MetricsTester(TestCase):

--- a/webapp/tests/test_metrics.py
+++ b/webapp/tests/test_metrics.py
@@ -79,7 +79,7 @@ class MetricsTester(TestCase):
         request = {'jsonp': 'callback'}
         response = self.client.post(url, request)
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content.split("(")[1].strip(")"))
+        data = json.loads(response.content.split(b"(")[1].strip(b")"))
         self.assertEqual(data[0], 'hosts.worker1.cpu')
         self.assertEqual(data[1], 'hosts.worker2.cpu')
 

--- a/webapp/tests/test_metrics.py
+++ b/webapp/tests/test_metrics.py
@@ -153,7 +153,7 @@ class MetricsTester(TestCase):
         request['format']='treejson'
         request['query']='other'
         content = test_find_view_basics(request)
-        self.assertEqual(content, '[]')
+        self.assertEqual(content, b'[]')
 
         request['query']='*'
         request['wildcards']=1

--- a/webapp/tests/test_readers_remote.py
+++ b/webapp/tests/test_readers_remote.py
@@ -145,14 +145,14 @@ class RemoteReaderTests(TestCase):
         })
 
         # non-pickle response
-        responseObject = HTTPResponse(body=StringIO('error'), status=200, preload_content=False)
+        responseObject = HTTPResponse(body=StringIO(b'error'), status=200, preload_content=False)
         http_request.return_value = responseObject
 
         with self.assertRaisesRegexp(Exception, 'Error decoding render response from http://[^ ]+: .+'):
           reader.fetch(startTime, endTime)
 
         # non-200 response
-        responseObject = HTTPResponse(body=StringIO('error'), status=500, preload_content=False)
+        responseObject = HTTPResponse(body=StringIO(b'error'), status=500, preload_content=False)
         http_request.return_value = responseObject
 
         with self.assertRaisesRegexp(Exception, 'Error response 500 from http://[^ ]+'):

--- a/webapp/tests/test_readers_util.py
+++ b/webapp/tests/test_readers_util.py
@@ -2,6 +2,7 @@ from .base import TestCase
 
 from graphite.readers import merge_with_cache
 from graphite.wsgi import application  # NOQA makes sure we have a working WSGI app
+from six.moves import range
 
 
 class MergeWithCacheTests(TestCase):
@@ -15,7 +16,7 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = range(0, window_size/2, step)
+        values = list(range(0, window_size/2, step))
         for i in range(0, window_size/2, step):
             values.append(None)
 
@@ -35,7 +36,7 @@ class MergeWithCacheTests(TestCase):
         )
 
         # Generate the expected values
-        expected_values = range(0, window_size/2, step)
+        expected_values = list(range(0, window_size/2, step))
         for i in range(0, window_size/2, step):
             expected_values.append(None)
 
@@ -48,7 +49,7 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = range(0, window_size/2, step)
+        values = list(range(0, window_size/2, step))
         for i in range(0, window_size/2, step):
             values.append(None)
 
@@ -69,7 +70,7 @@ class MergeWithCacheTests(TestCase):
         )
 
         # Generate the expected values
-        expected_values = range(0, window_size/2, step)
+        expected_values = list(range(0, window_size/2, step))
         for i in range(0, window_size/2, step):
             expected_values.append(60)
 
@@ -82,7 +83,7 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = range(0, window_size/2, step)
+        values = list(range(0, window_size/2, step))
         for i in range(0, window_size/2, step):
             values.append(None)
 
@@ -102,7 +103,7 @@ class MergeWithCacheTests(TestCase):
         )
 
         # Generate the expected values
-        expected_values = range(0, window_size/2, step)
+        expected_values = list(range(0, window_size/2, step))
         for i in range(0, window_size/2, step):
             expected_values.append(60)
 
@@ -115,7 +116,7 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = range(0, window_size/2, step)
+        values = list(range(0, window_size/2, step))
         for i in range(0, window_size/2, step):
             values.append(None)
 
@@ -135,7 +136,7 @@ class MergeWithCacheTests(TestCase):
         )
 
         # Generate the expected values
-        expected_values = range(0, window_size/2, step)
+        expected_values = list(range(0, window_size/2, step))
         for i in range(0, window_size/2, step):
             expected_values.append(60)
 
@@ -148,7 +149,7 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = range(0, window_size/2, step)
+        values = list(range(0, window_size/2, step))
         for i in range(0, window_size/2, step):
             values.append(None)
 
@@ -169,7 +170,7 @@ class MergeWithCacheTests(TestCase):
         )
 
         # Generate the expected values
-        expected_values = range(0, window_size/2, step)
+        expected_values = list(range(0, window_size/2, step))
         for i in range(0, window_size/2, step):
             expected_values.append(2)
 
@@ -182,7 +183,7 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = range(0, window_size/2, step)
+        values = list(range(0, window_size/2, step))
         for i in range(0, window_size/2, step):
             values.append(None)
 
@@ -202,7 +203,7 @@ class MergeWithCacheTests(TestCase):
         )
 
         # Generate the expected values
-        expected_values = range(0, window_size/2, step)
+        expected_values = list(range(0, window_size/2, step))
         for i in range(0, window_size/2, step):
             expected_values.append(1)
 
@@ -215,7 +216,7 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = range(0, window_size/2, step)
+        values = list(range(0, window_size/2, step))
         for i in range(0, window_size/2, step):
             values.append(None)
 
@@ -235,7 +236,7 @@ class MergeWithCacheTests(TestCase):
         )
 
         # Generate the expected values
-        expected_values = range(0, window_size/2, step)
+        expected_values = list(range(0, window_size/2, step))
         for i in range(0, window_size/2, step):
             expected_values.append(1)
 
@@ -248,7 +249,7 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = range(0, window_size/2, step)
+        values = list(range(0, window_size/2, step))
         for i in range(0, window_size/2, step):
             values.append(None)
 
@@ -268,7 +269,7 @@ class MergeWithCacheTests(TestCase):
         )
 
         # Generate the expected values
-        expected_values = range(0, window_size/2, step)
+        expected_values = list(range(0, window_size/2, step))
         for i in range(0, window_size/2, step):
             expected_values.append(1)
 
@@ -281,7 +282,7 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = range(0, window_size/2, step)
+        values = list(range(0, window_size/2, step))
         for i in range(0, window_size/2, step):
             values.append(None)
 
@@ -301,7 +302,7 @@ class MergeWithCacheTests(TestCase):
         )
 
         # Generate the expected values
-        expected_values = range(0, window_size/2, step)
+        expected_values = list(range(0, window_size/2, step))
         for i in range(0, window_size/2, step):
             expected_values.append(1)
 
@@ -314,7 +315,7 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = range(0, window_size/2, step)
+        values = list(range(0, window_size/2, step))
         for i in range(0, window_size/2, step):
             values.append(None)
 
@@ -344,7 +345,7 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = range(0, window_size/2, step)
+        values = list(range(0, window_size/2, step))
         for i in range(0, window_size/2, step):
             values.append(None)
 
@@ -364,7 +365,7 @@ class MergeWithCacheTests(TestCase):
         )
 
         # Generate the expected values
-        expected_values = range(0, window_size/2, step)
+        expected_values = list(range(0, window_size/2, step))
         for i in range(0, window_size/2, step):
             expected_values.append(None)
 

--- a/webapp/tests/test_readers_util.py
+++ b/webapp/tests/test_readers_util.py
@@ -16,14 +16,14 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = list(range(0, window_size/2, step))
-        for i in range(0, window_size/2, step):
+        values = list(range(0, window_size//2, step))
+        for i in range(0, window_size//2, step):
             values.append(None)
 
         # Generate data that would normally come from Carbon.
         # Step will be different since that is what we are testing
         cache_results = []
-        for i in range(start+window_size/2, start+window_size, 1):
+        for i in range(start+window_size//2, start+window_size, 1):
             cache_results.append((i, None))
 
         # merge the db results with the cached results
@@ -36,8 +36,8 @@ class MergeWithCacheTests(TestCase):
         )
 
         # Generate the expected values
-        expected_values = list(range(0, window_size/2, step))
-        for i in range(0, window_size/2, step):
+        expected_values = list(range(0, window_size//2, step))
+        for i in range(0, window_size//2, step):
             expected_values.append(None)
 
         self.assertEqual(expected_values, values)
@@ -49,14 +49,14 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = list(range(0, window_size/2, step))
-        for i in range(0, window_size/2, step):
+        values = list(range(0, window_size//2, step))
+        for i in range(0, window_size//2, step):
             values.append(None)
 
         # Generate data that would normally come from Carbon.
         # Step will be different since that is what we are testing
         cache_results = []
-        for i in range(start+window_size/2, start+window_size, 1):
+        for i in range(start+window_size//2, start+window_size, 1):
             cache_results.append((i, 1))
 
         # merge the db results with the cached results
@@ -70,8 +70,8 @@ class MergeWithCacheTests(TestCase):
         )
 
         # Generate the expected values
-        expected_values = list(range(0, window_size/2, step))
-        for i in range(0, window_size/2, step):
+        expected_values = list(range(0, window_size//2, step))
+        for i in range(0, window_size//2, step):
             expected_values.append(60)
 
         self.assertEqual(expected_values, values)
@@ -83,14 +83,14 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = list(range(0, window_size/2, step))
-        for i in range(0, window_size/2, step):
+        values = list(range(0, window_size//2, step))
+        for i in range(0, window_size//2, step):
             values.append(None)
 
         # Generate data that would normally come from Carbon.
         # Step will be different since that is what we are testing
         cache_results = []
-        for i in range(start+window_size/2, start+window_size, 1):
+        for i in range(start+window_size//2, start+window_size, 1):
             cache_results.append((i, 1))
 
         # merge the db results with the cached results
@@ -103,8 +103,8 @@ class MergeWithCacheTests(TestCase):
         )
 
         # Generate the expected values
-        expected_values = list(range(0, window_size/2, step))
-        for i in range(0, window_size/2, step):
+        expected_values = list(range(0, window_size//2, step))
+        for i in range(0, window_size//2, step):
             expected_values.append(60)
 
         self.assertEqual(expected_values, values)
@@ -116,14 +116,14 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = list(range(0, window_size/2, step))
-        for i in range(0, window_size/2, step):
+        values = list(range(0, window_size//2, step))
+        for i in range(0, window_size//2, step):
             values.append(None)
 
         # Generate data that would normally come from Carbon.
         # Step will be different since that is what we are testing
         cache_results = []
-        for i in range(start+window_size/2, start+window_size, 1):
+        for i in range(start+window_size//2, start+window_size, 1):
             cache_results.append((i, 1))
 
         # merge the db results with the cached results
@@ -136,8 +136,8 @@ class MergeWithCacheTests(TestCase):
         )
 
         # Generate the expected values
-        expected_values = list(range(0, window_size/2, step))
-        for i in range(0, window_size/2, step):
+        expected_values = list(range(0, window_size//2, step))
+        for i in range(0, window_size//2, step):
             expected_values.append(60)
 
         self.assertEqual(expected_values, values)
@@ -149,14 +149,14 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = list(range(0, window_size/2, step))
-        for i in range(0, window_size/2, step):
+        values = list(range(0, window_size//2, step))
+        for i in range(0, window_size//2, step):
             values.append(None)
 
         # Generate data that would normally come from Carbon.
         # Step will be different since that is what we are testing
         cache_results = []
-        for i in range(start+window_size/2, start+window_size, 1):
+        for i in range(start+window_size//2, start+window_size, 1):
             cache_results.append((i, 1))
 
         # merge the db results with the cached results
@@ -170,8 +170,8 @@ class MergeWithCacheTests(TestCase):
         )
 
         # Generate the expected values
-        expected_values = list(range(0, window_size/2, step))
-        for i in range(0, window_size/2, step):
+        expected_values = list(range(0, window_size//2, step))
+        for i in range(0, window_size//2, step):
             expected_values.append(2)
 
         self.assertEqual(expected_values, values)
@@ -183,14 +183,14 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = list(range(0, window_size/2, step))
-        for i in range(0, window_size/2, step):
+        values = list(range(0, window_size//2, step))
+        for i in range(0, window_size//2, step):
             values.append(None)
 
         # Generate data that would normally come from Carbon.
         # Step will be different since that is what we are testing
         cache_results = []
-        for i in range(start+window_size/2, start+window_size, 1):
+        for i in range(start+window_size//2, start+window_size, 1):
             cache_results.append((i, 1))
 
         # merge the db results with the cached results
@@ -203,8 +203,8 @@ class MergeWithCacheTests(TestCase):
         )
 
         # Generate the expected values
-        expected_values = list(range(0, window_size/2, step))
-        for i in range(0, window_size/2, step):
+        expected_values = list(range(0, window_size//2, step))
+        for i in range(0, window_size//2, step):
             expected_values.append(1)
 
         self.assertEqual(expected_values, values)
@@ -216,14 +216,14 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = list(range(0, window_size/2, step))
-        for i in range(0, window_size/2, step):
+        values = list(range(0, window_size//2, step))
+        for i in range(0, window_size//2, step):
             values.append(None)
 
         # Generate data that would normally come from Carbon.
         # Step will be different since that is what we are testing
         cache_results = []
-        for i in range(start+window_size/2, start+window_size, 1):
+        for i in range(start+window_size//2, start+window_size, 1):
             cache_results.append((i, 1))
 
         # merge the db results with the cached results
@@ -236,8 +236,8 @@ class MergeWithCacheTests(TestCase):
         )
 
         # Generate the expected values
-        expected_values = list(range(0, window_size/2, step))
-        for i in range(0, window_size/2, step):
+        expected_values = list(range(0, window_size//2, step))
+        for i in range(0, window_size//2, step):
             expected_values.append(1)
 
         self.assertEqual(expected_values, values)
@@ -249,14 +249,14 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = list(range(0, window_size/2, step))
-        for i in range(0, window_size/2, step):
+        values = list(range(0, window_size//2, step))
+        for i in range(0, window_size//2, step):
             values.append(None)
 
         # Generate data that would normally come from Carbon.
         # Step will be different since that is what we are testing
         cache_results = []
-        for i in range(start+window_size/2, start+window_size, 1):
+        for i in range(start+window_size//2, start+window_size, 1):
             cache_results.append((i, 1))
 
         # merge the db results with the cached results
@@ -269,8 +269,8 @@ class MergeWithCacheTests(TestCase):
         )
 
         # Generate the expected values
-        expected_values = list(range(0, window_size/2, step))
-        for i in range(0, window_size/2, step):
+        expected_values = list(range(0, window_size//2, step))
+        for i in range(0, window_size//2, step):
             expected_values.append(1)
 
         self.assertEqual(expected_values, values)
@@ -282,14 +282,14 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = list(range(0, window_size/2, step))
-        for i in range(0, window_size/2, step):
+        values = list(range(0, window_size//2, step))
+        for i in range(0, window_size//2, step):
             values.append(None)
 
         # Generate data that would normally come from Carbon.
         # Step will be different since that is what we are testing
         cache_results = []
-        for i in range(start+window_size/2, start+window_size, 1):
+        for i in range(start+window_size//2, start+window_size, 1):
             cache_results.append((i, 1))
 
         # merge the db results with the cached results
@@ -302,8 +302,8 @@ class MergeWithCacheTests(TestCase):
         )
 
         # Generate the expected values
-        expected_values = list(range(0, window_size/2, step))
-        for i in range(0, window_size/2, step):
+        expected_values = list(range(0, window_size//2, step))
+        for i in range(0, window_size//2, step):
             expected_values.append(1)
 
         self.assertEqual(expected_values, values)
@@ -315,14 +315,14 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = list(range(0, window_size/2, step))
-        for i in range(0, window_size/2, step):
+        values = list(range(0, window_size//2, step))
+        for i in range(0, window_size//2, step):
             values.append(None)
 
         # Generate data that would normally come from Carbon.
         # Step will be different since that is what we are testing
         cache_results = []
-        for i in range(start+window_size/2, start+window_size, 1):
+        for i in range(start+window_size//2, start+window_size, 1):
             cache_results.append((i, 1))
 
         # merge the db results with the cached results
@@ -345,8 +345,8 @@ class MergeWithCacheTests(TestCase):
         step = 60           # (1 minute)
 
         # Fill in half the data.  Nones for the rest.
-        values = list(range(0, window_size/2, step))
-        for i in range(0, window_size/2, step):
+        values = list(range(0, window_size//2, step))
+        for i in range(0, window_size//2, step):
             values.append(None)
 
         # Generate data that would normally come from Carbon.
@@ -365,8 +365,8 @@ class MergeWithCacheTests(TestCase):
         )
 
         # Generate the expected values
-        expected_values = list(range(0, window_size/2, step))
-        for i in range(0, window_size/2, step):
+        expected_values = list(range(0, window_size//2, step))
+        for i in range(0, window_size//2, step):
             expected_values.append(None)
 
         self.assertEqual(expected_values, values)

--- a/webapp/tests/test_readers_whisper.py
+++ b/webapp/tests/test_readers_whisper.py
@@ -171,7 +171,7 @@ class WhisperReadersTests(TestCase):
         # Test broken whisper file
         f = open(self.worker2, 'rb+')
         f.seek(10)
-        f.write('Bad Data')
+        f.write(b'Bad Data')
         f.close()
 
         reader = WhisperReader(self.worker2, 'hosts.worker2.cpu')

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -185,7 +185,7 @@ class RenderTest(TestCase):
 
         # Raw format
         response = self.client.get(url, {'target': 'test', 'format': 'raw'})
-        self.assertEqual(response.content, "")
+        self.assertEqual(response.content, b"")
         self.assertEqual(response['Content-Type'], 'text/plain')
 
         # json format

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -457,7 +457,8 @@ class RenderTest(TestCase):
         end = data['data'][-7:]
         self.assertEqual(end,
             [[(ts - 6) * 1000, None],
-            [(ts - 5) * 1000, 0.12345678901234568],
+             # Floats lose some precision on Py2. str() makes it match the tested code
+            [(ts - 5) * 1000, float(str(0.12345678901234568))],
             [(ts - 4) * 1000, 0.4],
             [(ts - 3) * 1000, 0.6],
             [(ts - 2) * 1000, float('inf')],

--- a/webapp/tests/test_render_datalib.py
+++ b/webapp/tests/test_render_datalib.py
@@ -9,6 +9,7 @@ from django.conf import settings
 
 from graphite.render.datalib import TimeSeries, fetchData, _merge_results, prefetchData
 from graphite.util import timebounds
+from six.moves import range
 
 
 class TimeSeriesTest(TestCase):
@@ -35,13 +36,13 @@ class TimeSeriesTest(TestCase):
       self.assertEqual(series.tags, {'name': 'collectd.test-db.load.value;'})
 
     def test_TimeSeries_equal_list(self):
-      values = range(0,100)
+      values = list(range(0,100))
       series = TimeSeries("collectd.test-db.load.value", 0, len(values), 1, values)
       with self.assertRaises(AssertionError):
         self.assertEqual(values, series)
 
     def test_TimeSeries_equal_list_color(self):
-      values = range(0,100)
+      values = list(range(0,100))
       series1 = TimeSeries("collectd.test-db.load.value", 0, len(values), 1, values)
       series1.color = 'white'
       series2 = TimeSeries("collectd.test-db.load.value", 0, len(values), 1, values)
@@ -49,7 +50,7 @@ class TimeSeriesTest(TestCase):
       self.assertEqual(series1, series2)
 
     def test_TimeSeries_equal_list_color_bad(self):
-      values = range(0,100)
+      values = list(range(0,100))
       series1 = TimeSeries("collectd.test-db.load.value", 0, len(values), 1, values)
       series2 = TimeSeries("collectd.test-db.load.value", 0, len(values), 1, values)
       series2.color = 'white'
@@ -57,7 +58,7 @@ class TimeSeriesTest(TestCase):
         self.assertEqual(series1, series2)
 
     def test_TimeSeries_equal_list_color_bad2(self):
-      values = range(0,100)
+      values = list(range(0,100))
       series1 = TimeSeries("collectd.test-db.load.value", 0, len(values), 1, values)
       series2 = TimeSeries("collectd.test-db.load.value", 0, len(values), 1, values)
       series1.color = 'white'
@@ -80,7 +81,7 @@ class TimeSeriesTest(TestCase):
       })
 
     def test_TimeSeries_consolidate(self):
-      values = range(0,100)
+      values = list(range(0,100))
 
       series = TimeSeries("collectd.test-db.load.value", 0, len(values)/2, 1, values)
       self.assertEqual(series.valuesPerPoint, 1)
@@ -89,7 +90,7 @@ class TimeSeriesTest(TestCase):
       self.assertEqual(series.valuesPerPoint, 2)
 
     def test_TimeSeries_iterate(self):
-      values = range(0,100)
+      values = list(range(0,100))
       series = TimeSeries("collectd.test-db.load.value", 0, len(values), 1, values)
       for i, val in enumerate(series):
         self.assertEqual(val, values[i])
@@ -127,7 +128,7 @@ class TimeSeriesTest(TestCase):
       self.assertEqual(list(series), list(expected))
 
     def test_TimeSeries_iterate_valuesPerPoint_2_avg(self):
-      values = range(0,100)
+      values = list(range(0,100))
 
       series = TimeSeries("collectd.test-db.load.value", 0, len(values)/2, 1, values)
       self.assertEqual(series.valuesPerPoint, 1)
@@ -139,95 +140,95 @@ class TimeSeriesTest(TestCase):
 
       series.consolidate(3)
       self.assertEqual(series.valuesPerPoint, 3)
-      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, map(float, range(1, 100, 3) + [99]))
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, map(float, list(range(1, 100, 3)) + [99]))
       self.assertEqual(list(series), list(expected))
 
     def test_TimeSeries_iterate_valuesPerPoint_2_sum(self):
-      values = range(0,100)
+      values = list(range(0,100))
 
       series = TimeSeries("collectd.test-db.load.value", 0, 5, 1, values, consolidate='sum')
       self.assertEqual(series.valuesPerPoint, 1)
 
       series.consolidate(2)
       self.assertEqual(series.valuesPerPoint, 2)
-      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(1,200,4))
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, list(range(1,200,4)))
       self.assertEqual(list(series), list(expected))
 
       series.consolidate(3)
       self.assertEqual(series.valuesPerPoint, 3)
-      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(3,300,9) + [99])
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, list(range(3,300,9)) + [99])
       self.assertEqual(list(series), list(expected))
 
       series.xFilesFactor = 0.4
-      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(3,300,9) + [None])
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, list(range(3,300,9)) + [None])
       self.assertEqual(list(series), list(expected))
 
     def test_TimeSeries_iterate_valuesPerPoint_2_max(self):
-      values = range(0,100)
+      values = list(range(0,100))
 
       series = TimeSeries("collectd.test-db.load.value", 0, 5, 1, values, consolidate='max')
       self.assertEqual(series.valuesPerPoint, 1)
 
       series.consolidate(2)
       self.assertEqual(series.valuesPerPoint, 2)
-      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(1,100,2))
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, list(range(1,100,2)))
       self.assertEqual(list(series), list(expected))
 
       series.consolidate(3)
       self.assertEqual(series.valuesPerPoint, 3)
-      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(2,100,3) + [99])
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, list(range(2,100,3)) + [99])
       self.assertEqual(list(series), list(expected))
 
     def test_TimeSeries_iterate_valuesPerPoint_2_min(self):
-      values = range(0,100)
+      values = list(range(0,100))
 
       series = TimeSeries("collectd.test-db.load.value", 0, 5, 1, values, consolidate='min')
       self.assertEqual(series.valuesPerPoint, 1)
 
       series.consolidate(2)
       self.assertEqual(series.valuesPerPoint, 2)
-      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(0,100,2))
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, list(range(0,100,2)))
       self.assertEqual(list(series), list(expected))
 
       series.consolidate(3)
       self.assertEqual(series.valuesPerPoint, 3)
-      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(0,100,3))
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, list(range(0,100,3)))
       self.assertEqual(list(series), list(expected))
 
     def test_TimeSeries_iterate_valuesPerPoint_2_first(self):
-      values = range(0,100)
+      values = list(range(0,100))
 
       series = TimeSeries("collectd.test-db.load.value", 0, 5, 1, values, consolidate='first')
       self.assertEqual(series.valuesPerPoint, 1)
 
       series.consolidate(2)
       self.assertEqual(series.valuesPerPoint, 2)
-      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(0,100,2))
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, list(range(0,100,2)))
       self.assertEqual(list(series), list(expected))
 
       series.consolidate(3)
       self.assertEqual(series.valuesPerPoint, 3)
-      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(0,100,3))
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, list(range(0,100,3)))
       self.assertEqual(list(series), list(expected))
 
     def test_TimeSeries_iterate_valuesPerPoint_2_last(self):
-      values = range(0,100)
+      values = list(range(0,100))
 
       series = TimeSeries("collectd.test-db.load.value", 0, 5, 1, values, consolidate='last')
       self.assertEqual(series.valuesPerPoint, 1)
 
       series.consolidate(2)
       self.assertEqual(series.valuesPerPoint, 2)
-      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(1,100,2))
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, list(range(1,100,2)))
       self.assertEqual(list(series), list(expected))
 
       series.consolidate(3)
       self.assertEqual(series.valuesPerPoint, 3)
-      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, range(2,100,3) + [99])
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, list(range(2,100,3)) + [99])
       self.assertEqual(list(series), list(expected))
 
     def test_TimeSeries_iterate_valuesPerPoint_2_invalid(self):
-      values = range(0,100)
+      values = list(range(0,100))
 
       series = TimeSeries("collectd.test-db.load.value", 0, 5, 1, values, consolidate='bogus')
       self.assertEqual(series.valuesPerPoint, 1)

--- a/webapp/tests/test_render_glyph.py
+++ b/webapp/tests/test_render_glyph.py
@@ -4,6 +4,7 @@ from .base import TestCase
 
 from graphite.render import glyph
 from graphite.render.datalib import TimeSeries
+from six.moves import range
 
 class glyphStandaloneFunctionTest(TestCase):
     from datetime import datetime, timedelta
@@ -14,7 +15,7 @@ class glyphStandaloneFunctionTest(TestCase):
     def _generate_series_list(self, config=None):
         seriesList = []
         if not config:
-            config = [range(101), range(101), [1, None, None, None, None]]
+            config = [list(range(101)), list(range(101)), [1, None, None, None, None]]
 
         for i, c in enumerate(config):
             name = "collectd.test-db{0}.load.value".format(i + 1)
@@ -178,7 +179,7 @@ class glyphStandaloneFunctionTest(TestCase):
         self.assertEqual(glyph.dataLimits(seriesList), (0,100))
 
     def test_dataLimits_defaults_ymin_positive(self):
-        config = [range(10, 101), range(10, 101), [1, None, None, None, None]]
+        config = [list(range(10, 101)), list(range(10, 101)), [1, None, None, None, None]]
         seriesList = self._generate_series_list(config)
         self.assertEqual(glyph.dataLimits(seriesList), (1,100))
 
@@ -198,17 +199,17 @@ class glyphStandaloneFunctionTest(TestCase):
         self.assertEqual(glyph.dataLimits(seriesList, True, True), (0, 8))
 
     def test_dataLimits_drawNull_stacked_no_missing(self):
-        config = [range(10, 101), range(10, 101), range(100,300)]
+        config = [list(range(10, 101)), list(range(10, 101)), list(range(100,300))]
         seriesList = self._generate_series_list(config)
         self.assertEqual(glyph.dataLimits(seriesList, True, True), (10, 390))
 
     def test_dataLimits_drawNull_ymin_positive_missing_data(self):
-        config = [range(10, 101), range(10, 101), [1, None, None, None, None]]
+        config = [list(range(10, 101)), list(range(10, 101)), [1, None, None, None, None]]
         seriesList = self._generate_series_list(config)
         self.assertEqual(glyph.dataLimits(seriesList, True, False), (0.0, 100))
 
     def test_dataLimits_drawNull_ymax_negative_missing_data(self):
-        config = [range(-10, -101), range(-10, -101), [-50, None, None, None, None]]
+        config = [list(range(-10, -101)), list(range(-10, -101)), [-50, None, None, None, None]]
         seriesList = self._generate_series_list(config)
         self.assertEqual(glyph.dataLimits(seriesList, True, False), (-50, 0.0))
 

--- a/webapp/tests/test_storage.py
+++ b/webapp/tests/test_storage.py
@@ -236,7 +236,7 @@ class DummyReader(BaseReader):
         self.path = path
 
     def fetch(self, startTime, endTime, now=None, requestContext=None):
-        npoints = (endTime - startTime) / 10
+        npoints = (endTime - startTime) // 10
         return (startTime, endTime, 10), [
             random.choice([None, 1, 2, 3]) for i in range(npoints)
         ]

--- a/webapp/tests/test_tags.py
+++ b/webapp/tests/test_tags.py
@@ -17,6 +17,12 @@ from graphite.util import json
 
 from tests.base import TestCase
 
+def json_bytes(obj, *args, **kwargs):
+  s = json.dumps(obj, *args, **kwargs)
+  if sys.version_info[0] >= 3:
+    return s.encode('utf-8')
+  return s
+
 class TagsTest(TestCase):
   def test_taggedseries(self):
     # test path with tags
@@ -377,11 +383,7 @@ class TagsTest(TestCase):
     response = self.client.post(url + '/tagSeries', {'path': 'test.a;hello=tiger;blah=blah'})
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    if sys.version_info[0] >= 3:
-      self.assertEqual(response.content,
-                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
-    else:
-      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
 
     ## list tags
 
@@ -451,11 +453,7 @@ class TagsTest(TestCase):
     response = self.client.get(url + '/findSeries?expr[]=name=test.a&expr[]=hello=tiger&expr[]=blah=blah&pretty=1')
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    if sys.version_info[0] >= 3:
-      self.assertEqual(response.content,
-                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
-    else:
-      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
 
     # tag another series
     expected = 'test.a;blah=blah;hello=lion'
@@ -463,11 +461,7 @@ class TagsTest(TestCase):
     response = self.client.post(url + '/tagSeries', {'path': 'test.a;hello=lion;blah=blah'})
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    if sys.version_info[0] >= 3:
-      self.assertEqual(response.content,
-                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
-    else:
-      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
 
     ## autocomplete tags
 
@@ -480,11 +474,7 @@ class TagsTest(TestCase):
 
     response = self.client.get(url + '/autoComplete/tags?tagPrefix=hello&pretty=1')
     self.assertEqual(response['Content-Type'], 'application/json')
-    if sys.version_info[0] >= 3:
-      self.assertEqual(response.content,
-                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
-    else:
-      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
 
     expected = [
       'blah',
@@ -493,11 +483,7 @@ class TagsTest(TestCase):
 
     response = self.client.get(url + '/autoComplete/tags?expr[]=name=test.a&pretty=1')
     self.assertEqual(response['Content-Type'], 'application/json')
-    if sys.version_info[0] >= 3:
-      self.assertEqual(response.content,
-                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
-    else:
-      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
 
     expected = [
       'hello',
@@ -506,11 +492,7 @@ class TagsTest(TestCase):
     response = self.client.get(url + '/autoComplete/tags?expr=name=test.a&tagPrefix=hell&pretty=1')
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    if sys.version_info[0] >= 3:
-      self.assertEqual(response.content,
-                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
-    else:
-      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
 
     ## autocomplete values
 
@@ -522,41 +504,26 @@ class TagsTest(TestCase):
     response = self.client.get(url + '/autoComplete/values', {})
     self.assertEqual(response.status_code, 400)
     self.assertEqual(response['Content-Type'], 'application/json')
-    if sys.version_info[0] >= 3:
-      self.assertEqual(response.content, json.dumps(expected).encode('utf-8'))
-    else:
-      self.assertEqual(response.content, json.dumps(expected))
+    self.assertEqual(response.content, json_bytes(expected))
 
     expected = ['lion','tiger']
 
     response = self.client.get(url + '/autoComplete/values?tag=hello&pretty=1')
     self.assertEqual(response['Content-Type'], 'application/json')
-    if sys.version_info[0] >= 3:
-      self.assertEqual(response.content,
-                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
-    else:
-      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
 
     expected = ['lion','tiger']
 
     response = self.client.get(url + '/autoComplete/values?expr[]=name=test.a&tag=hello&pretty=1')
     self.assertEqual(response['Content-Type'], 'application/json')
-    if sys.version_info[0] >= 3:
-      self.assertEqual(response.content,
-                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
-    else:
-      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
 
     expected = ['lion']
 
     response = self.client.get(url + '/autoComplete/values?expr=name=test.a&tag=hello&valuePrefix=li&pretty=1')
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    if sys.version_info[0] >= 3:
-      self.assertEqual(response.content,
-                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
-    else:
-      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
 
     ## delSeries
 
@@ -575,11 +542,7 @@ class TagsTest(TestCase):
     response = self.client.post(url + '/delSeries', {'path': 'test.a;blah=blah;hello=tiger'})
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    if sys.version_info[0] >= 3:
-      self.assertEqual(response.content,
-                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
-    else:
-      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
 
     # delete second series
     expected = True
@@ -587,11 +550,7 @@ class TagsTest(TestCase):
     response = self.client.post(url + '/delSeries', {'path': 'test.a;blah=blah;hello=lion'})
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    if sys.version_info[0] >= 3:
-      self.assertEqual(response.content,
-                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
-    else:
-      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
 
     # delete nonexistent series
 
@@ -600,11 +559,7 @@ class TagsTest(TestCase):
     response = self.client.post(url + '/delSeries', {'path': 'test.a;blah=blah;hello=lion'})
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    if sys.version_info[0] >= 3:
-      self.assertEqual(response.content,
-                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
-    else:
-      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
 
     # find nonexistent series
     expected = []
@@ -612,11 +567,7 @@ class TagsTest(TestCase):
     response = self.client.get(url + '/findSeries?expr=name=test.a&expr=hello=tiger&expr=blah=blah')
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    if sys.version_info[0] >= 3:
-      self.assertEqual(response.content,
-                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
-    else:
-      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
 
     # tag multiple series
 
@@ -644,11 +595,7 @@ class TagsTest(TestCase):
     })
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    if sys.version_info[0] >= 3:
-      self.assertEqual(response.content,
-                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
-    else:
-      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
 
     # multiple path[] should succeed
     expected = [
@@ -665,11 +612,7 @@ class TagsTest(TestCase):
     })
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    if sys.version_info[0] >= 3:
-      self.assertEqual(response.content,
-                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
-    else:
-      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
 
     # remove multiple series
     expected = True
@@ -683,11 +626,7 @@ class TagsTest(TestCase):
     })
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    if sys.version_info[0] >= 3:
-      self.assertEqual(response.content,
-                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
-    else:
-      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
 
     expected = True
 
@@ -700,8 +639,4 @@ class TagsTest(TestCase):
     })
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    if sys.version_info[0] >= 3:
-      self.assertEqual(response.content,
-                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
-    else:
-      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))

--- a/webapp/tests/test_tags.py
+++ b/webapp/tests/test_tags.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division
+import sys
 
 try:
   from django.urls import reverse
@@ -376,7 +377,11 @@ class TagsTest(TestCase):
     response = self.client.post(url + '/tagSeries', {'path': 'test.a;hello=tiger;blah=blah'})
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    if sys.version_info[0] >= 3:
+      self.assertEqual(response.content,
+                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
+    else:
+      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
     ## list tags
 
@@ -446,7 +451,11 @@ class TagsTest(TestCase):
     response = self.client.get(url + '/findSeries?expr[]=name=test.a&expr[]=hello=tiger&expr[]=blah=blah&pretty=1')
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    if sys.version_info[0] >= 3:
+      self.assertEqual(response.content,
+                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
+    else:
+      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
     # tag another series
     expected = 'test.a;blah=blah;hello=lion'
@@ -454,7 +463,11 @@ class TagsTest(TestCase):
     response = self.client.post(url + '/tagSeries', {'path': 'test.a;hello=lion;blah=blah'})
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    if sys.version_info[0] >= 3:
+      self.assertEqual(response.content,
+                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
+    else:
+      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
     ## autocomplete tags
 
@@ -467,7 +480,11 @@ class TagsTest(TestCase):
 
     response = self.client.get(url + '/autoComplete/tags?tagPrefix=hello&pretty=1')
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    if sys.version_info[0] >= 3:
+      self.assertEqual(response.content,
+                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
+    else:
+      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
     expected = [
       'blah',
@@ -476,7 +493,11 @@ class TagsTest(TestCase):
 
     response = self.client.get(url + '/autoComplete/tags?expr[]=name=test.a&pretty=1')
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    if sys.version_info[0] >= 3:
+      self.assertEqual(response.content,
+                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
+    else:
+      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
     expected = [
       'hello',
@@ -485,36 +506,57 @@ class TagsTest(TestCase):
     response = self.client.get(url + '/autoComplete/tags?expr=name=test.a&tagPrefix=hell&pretty=1')
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    if sys.version_info[0] >= 3:
+      self.assertEqual(response.content,
+                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
+    else:
+      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
     ## autocomplete values
 
     response = self.client.put(url + '/autoComplete/values', {})
     self.assertEqual(response.status_code, 405)
 
+    expected = {'error': 'no tag specified'}
+
     response = self.client.get(url + '/autoComplete/values', {})
     self.assertEqual(response.status_code, 400)
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps({'error': 'no tag specified'}))
+    if sys.version_info[0] >= 3:
+      self.assertEqual(response.content, json.dumps(expected).encode('utf-8'))
+    else:
+      self.assertEqual(response.content, json.dumps(expected))
 
     expected = ['lion','tiger']
 
     response = self.client.get(url + '/autoComplete/values?tag=hello&pretty=1')
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    if sys.version_info[0] >= 3:
+      self.assertEqual(response.content,
+                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
+    else:
+      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
     expected = ['lion','tiger']
 
     response = self.client.get(url + '/autoComplete/values?expr[]=name=test.a&tag=hello&pretty=1')
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    if sys.version_info[0] >= 3:
+      self.assertEqual(response.content,
+                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
+    else:
+      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
     expected = ['lion']
 
     response = self.client.get(url + '/autoComplete/values?expr=name=test.a&tag=hello&valuePrefix=li&pretty=1')
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    if sys.version_info[0] >= 3:
+      self.assertEqual(response.content,
+                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
+    else:
+      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
     ## delSeries
 
@@ -533,7 +575,11 @@ class TagsTest(TestCase):
     response = self.client.post(url + '/delSeries', {'path': 'test.a;blah=blah;hello=tiger'})
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected))
+    if sys.version_info[0] >= 3:
+      self.assertEqual(response.content,
+                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
+    else:
+      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
     # delete second series
     expected = True
@@ -541,7 +587,11 @@ class TagsTest(TestCase):
     response = self.client.post(url + '/delSeries', {'path': 'test.a;blah=blah;hello=lion'})
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected))
+    if sys.version_info[0] >= 3:
+      self.assertEqual(response.content,
+                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
+    else:
+      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
     # delete nonexistent series
 
@@ -550,7 +600,11 @@ class TagsTest(TestCase):
     response = self.client.post(url + '/delSeries', {'path': 'test.a;blah=blah;hello=lion'})
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected))
+    if sys.version_info[0] >= 3:
+      self.assertEqual(response.content,
+                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
+    else:
+      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
     # find nonexistent series
     expected = []
@@ -558,7 +612,11 @@ class TagsTest(TestCase):
     response = self.client.get(url + '/findSeries?expr=name=test.a&expr=hello=tiger&expr=blah=blah')
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    if sys.version_info[0] >= 3:
+      self.assertEqual(response.content,
+                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
+    else:
+      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
     # tag multiple series
 
@@ -586,7 +644,11 @@ class TagsTest(TestCase):
     })
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    if sys.version_info[0] >= 3:
+      self.assertEqual(response.content,
+                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
+    else:
+      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
     # multiple path[] should succeed
     expected = [
@@ -603,7 +665,11 @@ class TagsTest(TestCase):
     })
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    if sys.version_info[0] >= 3:
+      self.assertEqual(response.content,
+                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
+    else:
+      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
     # remove multiple series
     expected = True
@@ -617,7 +683,11 @@ class TagsTest(TestCase):
     })
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    if sys.version_info[0] >= 3:
+      self.assertEqual(response.content,
+                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
+    else:
+      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
 
     expected = True
 
@@ -630,4 +700,8 @@ class TagsTest(TestCase):
     })
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))
+    if sys.version_info[0] >= 3:
+      self.assertEqual(response.content,
+                 json.dumps(expected, indent=2, sort_keys=True).encode('utf-8'))
+    else:
+      self.assertEqual(response.content, json.dumps(expected, indent=2, sort_keys=True))

--- a/webapp/tests/test_tags.py
+++ b/webapp/tests/test_tags.py
@@ -383,7 +383,7 @@ class TagsTest(TestCase):
     response = self.client.post(url + '/tagSeries', {'path': 'test.a;hello=tiger;blah=blah'})
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, sort_keys=True))
 
     ## list tags
 
@@ -461,7 +461,7 @@ class TagsTest(TestCase):
     response = self.client.post(url + '/tagSeries', {'path': 'test.a;hello=lion;blah=blah'})
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, sort_keys=True))
 
     ## autocomplete tags
 
@@ -542,7 +542,7 @@ class TagsTest(TestCase):
     response = self.client.post(url + '/delSeries', {'path': 'test.a;blah=blah;hello=tiger'})
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, sort_keys=True))
 
     # delete second series
     expected = True
@@ -550,7 +550,7 @@ class TagsTest(TestCase):
     response = self.client.post(url + '/delSeries', {'path': 'test.a;blah=blah;hello=lion'})
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, sort_keys=True))
 
     # delete nonexistent series
 
@@ -559,7 +559,7 @@ class TagsTest(TestCase):
     response = self.client.post(url + '/delSeries', {'path': 'test.a;blah=blah;hello=lion'})
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, sort_keys=True))
 
     # find nonexistent series
     expected = []
@@ -567,7 +567,7 @@ class TagsTest(TestCase):
     response = self.client.get(url + '/findSeries?expr=name=test.a&expr=hello=tiger&expr=blah=blah')
     self.assertEqual(response.status_code, 200)
     self.assertEqual(response['Content-Type'], 'application/json')
-    self.assertEqual(response.content, json_bytes(expected, indent=2, sort_keys=True))
+    self.assertEqual(response.content, json_bytes(expected, sort_keys=True))
 
     # tag multiple series
 

--- a/webapp/tests/test_whitelist.py
+++ b/webapp/tests/test_whitelist.py
@@ -43,7 +43,7 @@ class WhitelistTester(TestCase):
         self.addCleanup(self.wipe_whitelist)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "a.b.c.d\ne.f.g.h")
+        self.assertEqual(response.content, b"a.b.c.d\ne.f.g.h")
 
     def test_whitelist_add(self):
         self.create_whitelist()
@@ -52,12 +52,12 @@ class WhitelistTester(TestCase):
         url = reverse('whitelist_add')
         response = self.client.post(url, {'metrics': ['i.j.k.l']})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
 
         url = reverse('whitelist_show')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "a.b.c.d\ne.f.g.h\ni.j.k.l")
+        self.assertEqual(response.content, b"a.b.c.d\ne.f.g.h\ni.j.k.l")
 
     def test_whitelist_add_existing(self):
         self.create_whitelist()
@@ -66,12 +66,12 @@ class WhitelistTester(TestCase):
         url = reverse('whitelist_add')
         response = self.client.post(url, {'metrics': ['a.b.c.d']})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
 
         url = reverse('whitelist_show')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "a.b.c.d\ne.f.g.h")
+        self.assertEqual(response.content, b"a.b.c.d\ne.f.g.h")
 
     def test_whitelist_remove(self):
         self.create_whitelist()
@@ -80,12 +80,12 @@ class WhitelistTester(TestCase):
         url = reverse('whitelist_remove')
         response = self.client.post(url, {'metrics': ['a.b.c.d']})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
 
         url = reverse('whitelist_show')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "e.f.g.h")
+        self.assertEqual(response.content, b"e.f.g.h")
 
     def test_whitelist_remove_missing(self):
         self.create_whitelist()
@@ -94,12 +94,12 @@ class WhitelistTester(TestCase):
         url = reverse('whitelist_remove')
         response = self.client.post(url, {'metrics': ['i.j.k.l']})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "OK")
+        self.assertEqual(response.content, b"OK")
 
         url = reverse('whitelist_show')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, "a.b.c.d\ne.f.g.h")
+        self.assertEqual(response.content, b"a.b.c.d\ne.f.g.h")
 
     def test_save_whitelist(self):
         try:


### PR DESCRIPTION
See #750. This adds Python 3 support while preserving Python 2.7 support. It adds the popular `six` compatibility library as a dependency.

Testing locally, I see one remaining test failure that's specific to Python 3. I think it's because the code under test is using `os.walk()`, and on Python 3 that uses `scandir()` rather than `listdir()`. But I'm not 100% confident, and I don't understand why the test is counting calls to `listdir()`, so I haven't changed it yet.

```
======================================================================
FAIL: test_ceres_finder (tests.test_finders.CeresFinderTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/takluyver/Code/graphite-web/webapp/tests/test_finders.py", line 359, in test_ceres_finder
    self.assertEqual(self._listdir_counter, 8)
AssertionError: 2 != 8
```

There are also a couple of other failures that I see under Python 2 and 3, but I assume they are issues with my system. They were there before I started changing anything.