### PR TITLE
 Remove most undefined variables issues in javascript files

### DIFF
--- a/webapp/content/js/browser.js
+++ b/webapp/content/js/browser.js
@@ -12,6 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
+// From Ext library
+/*global Ext*/
+// Defined in composer.html
+/*global Browser Composer GraphiteConfig*/
+// Defined in composer.js
+/*global MetricCompleter*/
+
 function GraphiteBrowser () {
   this.rootNode = new Ext.tree.TreeNode({});
   this.treePanel = createTreePanel( this.rootNode );

--- a/webapp/content/js/completer.js
+++ b/webapp/content/js/completer.js
@@ -1,3 +1,6 @@
+// From Ext library
+/*global Ext*/
+
 var MetricCompleter;
 
 MetricCompleter = Ext.extend(Ext.form.ComboBox, {

--- a/webapp/content/js/composer.js
+++ b/webapp/content/js/composer.js
@@ -12,6 +12,13 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License. */
 
+// From Ext library
+/*global Ext*/
+// Defined in composer_widgets.js
+/*global createComposerWindow*/
+// Defined in composer.html
+/*global addTarget getTargetRecord TargetStore*/
+
 var RENDER_BASE_URL = window.location.protocol + '//' + window.location.host + document.body.dataset.baseUrl + 'render/?';
 
 /* GraphiteComposer encapsulates a set of Ext UI Panels,

--- a/webapp/content/js/composer_widgets.js
+++ b/webapp/content/js/composer_widgets.js
@@ -24,7 +24,12 @@
  *
 */
 
-
+// From Ext library
+/*global Ext*/
+// Defined in composer.html
+/*global addTarget Browser GraphiteConfig indexOfTarget insertTarget removeTarget replaceTarget TargetStore*/
+// Defined in composer.js
+/*global MetricCompleter*/
 
 var DEFAULT_WINDOW_WIDTH = 600;
 var DEFAULT_WINDOW_HEIGHT = 400;
@@ -185,14 +190,14 @@ function createCalendarWindow() {
   startDateControl.on('select', calendarSelectionMade);
   endDateControl.on('select', calendarSelectionMade);
   // Time controls
-  startTimeControl = new Ext.form.TimeField({
+  var startTimeControl = new Ext.form.TimeField({
     id: 'start-time',
     increment: 30,
     allowBlank: false,
     value: '12:00 AM',
     listeners: {select: calendarSelectionMade, specialkey: ifEnter(calendarSelectionMade)}
   });
-  endTimeControl = new Ext.form.TimeField({
+  var endTimeControl = new Ext.form.TimeField({
     id: 'end-time',
     allowBlank: false,
     value: '11:59 PM',
@@ -261,7 +266,7 @@ function asDateString(dateObj) {
 
 /* Short url window */
 function showShortUrl() {
-    showUrl = function(options, success, response) {
+    var showUrl = function(options, success, response) {
         if(success) {
             var win = new Ext.Window({
               title: 'Graph URL',
@@ -968,13 +973,13 @@ var GraphDataWindow = {
   },
 
   _moveTarget: function(direction) {
-    store = this.targetList.getStore();
-    selectedRecords = this.targetList.getSelectedRecords();
+    var store = this.targetList.getStore();
+    var selectedRecords = this.targetList.getSelectedRecords();
 
     // Don't move past boundaries
-    exit = false;
+    var exit = false;
     Ext.each(selectedRecords, function(record) {
-      index = store.indexOf(record);
+      var index = store.indexOf(record);
 
       if (direction == -1 && index == 0) {
         exit = true;
@@ -988,11 +993,11 @@ var GraphDataWindow = {
     if (exit)
       return;
 
-    newSelections = [];
+    var newSelections = [];
     Ext.each(selectedRecords, function(recordA) {
-      indexA = store.indexOf( recordA );
-      valueA = recordA.get('value');
-      recordB = store.getAt( indexA + direction );
+      var indexA = store.indexOf( recordA );
+      var valueA = recordA.get('value');
+      var recordB = store.getAt( indexA + direction );
 
       // swap
       recordA.set('value', recordB.get('value'));
@@ -1009,14 +1014,14 @@ var GraphDataWindow = {
   },
 
   _swapTargets: function() {
-    selectedRecords = this.targetList.getSelectedRecords();
+    var selectedRecords = this.targetList.getSelectedRecords();
     if (selectedRecords.length != 2)
       return;
 
-    recordA = selectedRecords[0];
-    recordB = selectedRecords[1];
+    var recordA = selectedRecords[0];
+    var recordB = selectedRecords[1];
 
-    valueA = recordA.get('value');
+    var valueA = recordA.get('value');
     recordA.set('value', recordB.get('value'));
     recordB.set('value', valueA);
 

--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -1,8 +1,19 @@
+// From Ext library
+/*global Ext*/
+// Defined in dashboard.html
+/*global AUTOCOMPLETE_DELAY CALENDAR_ICON CLOCK_ICON CONTEXT_FIELD_WIDTH FINDER_QUERY_DELAY*/
+/*global HELP_ICON NEW_DASHBOARD_REMOVE_GRAPHS REFRESH_ICON REMOVE_ICON RESIZE_ICON*/
+/*global SHARE_ICON UI_CONFIG initialState initialError permissions queryString userName*/
+/*global permissionsUnauthenticated schemes*/
+// Defined in composer_widgets.js
+/*global createFunctionsMenu createOptionsMenu updateCheckItems*/
+
 // Global object names
 var viewport;
 var contextSelector;
 var contextSelectorFields = [];
 var selectedScheme = null;
+var selectedRecord = null;
 var metricSelector;
 var metricSelectorMode;
 var metricSelectorGrid;
@@ -138,7 +149,7 @@ function isLoggedIn() {
 }
 
 function hasPermission(permission) {
-  for (i in permissions) {
+  for (const i in permissions) {
     if (permissions[i] === permission) {
       return true;
     }
@@ -1391,7 +1402,7 @@ function newEmptyGraph() {
    'height': GraphSize.height,
     });
   graphStore.add([record]);
-  canvasId = graphStore.indexOf(record);
+  var canvasId = graphStore.indexOf(record);
   graphStore.getAt(canvasId).data.index = canvasId;
   updateGraphRecords();
 }
@@ -2064,7 +2075,7 @@ function graphClicked(graphView, graphIndex, element, evt) {
       width: 100,
       handler: function () {
         menu.destroy();
-        showUrl = function(options, success, response) {
+        var showUrl = function(options, success, response) {
             if(success) {
               var win = new Ext.Window({
                 title: 'Graph URL',
@@ -2457,7 +2468,7 @@ function historyGraph(record){
         });
     }
 
-    graphHistoryView = new Ext.DataView({
+    var graphHistoryView = new Ext.DataView({
       store: graphHistoryStore,
       tpl: graphTemplate,
       overClass: 'graph-over',
@@ -2468,7 +2479,7 @@ function historyGraph(record){
       }
     });
 
-    win = new Ext.Window({
+    var win = new Ext.Window({
       title: 'Graph History',
       width: 800,
       height: 800,
@@ -2815,9 +2826,9 @@ function sendLoadRequest(name) {
 }
 
 function sendLoadTemplateRequest(name, value) {
-  urlparts = window.location.href.split('#')
+  var urlparts = window.location.href.split('#')
   if(urlparts[0].split('?')[1]) {
-    new_location = urlparts[0].split('?')[0] + '#'+name+'/'+value;
+    var new_location = urlparts[0].split('?')[0] + '#'+name+'/'+value;
     window.location.href = new_location;
   } else {
     Ext.Ajax.request({


### PR DESCRIPTION
Most were global variables defined in the templated html files or other included javascript files.
Others needed var/const declarations.

Only ones left are:
```
  2703:14  error  'ace' is not defined                                            no-undef
  2705:20  error  'require' is not defined                                        no-undef
  2802:19  error  'newURL' is not defined                                         no-undef
  2803:36  error  'newURL' is not defined                                         no-undef
  3333:55  error  'reset_params' is not defined                                   no-undef
```