### PR TITLE
work around timing issue in whisper reader interval tests

### DIFF
--- a/webapp/tests/test_readers_whisper.py
+++ b/webapp/tests/test_readers_whisper.py
@@ -79,14 +79,14 @@ class WhisperReadersTests(TestCase):
         ts = int(time.time())
         intervals = reader.get_intervals()
         for interval in intervals:
-          self.assertEqual(int(interval.start), ts-60)
-          self.assertEqual(int(interval.end), ts)
+          self.assertEqual(int(interval.start), ts - 60)
+          self.assertIn(int(interval.end), [ts, ts - 1])
 
         # read it again to validate cache works
         intervals = reader.get_intervals()
         for interval in intervals:
-          self.assertEqual(int(interval.start),ts-60)
-          self.assertEqual(int(interval.end), ts)
+          self.assertEqual(int(interval.start),ts - 60)
+          self.assertIn(int(interval.end), [ts, ts - 1])
 
     # Confirm fetch works.
     def test_GzippedWhisperReader_fetch(self):
@@ -120,14 +120,14 @@ class WhisperReadersTests(TestCase):
         ts = int(time.time())
         intervals = reader.get_intervals()
         for interval in intervals:
-          self.assertEqual(int(interval.start),ts-60)
-          self.assertEqual(int(interval.end), ts)
+          self.assertEqual(int(interval.start),ts - 60)
+          self.assertIn(int(interval.end), [ts, ts - 1])
 
         # read it again to validate cache works
         intervals = reader.get_intervals()
         for interval in intervals:
-          self.assertEqual(int(interval.start),ts-60)
-          self.assertEqual(int(interval.end), ts)
+          self.assertEqual(int(interval.start),ts - 60)
+          self.assertIn(int(interval.end), [ts, ts - 1])
 
     # Confirm get_raw_step works
     def test_WhisperReader_get_raw_step(self):


### PR DESCRIPTION
This PR aims to decrease the random errors we get from the whisper intervals tests.  As far as I can see it's a timing issue making the tests sometimes return a timestamp 1 less than we were expecting, so this just stops treating that as an error.

I'd like to do some work on whisper to make it less sensitive to wall-clock time, but for now this should stop the random annoying test failures.