### PR TITLE
Rename release 1.1.0 to 1.1.1

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -5,7 +5,7 @@ Release Notes
    :maxdepth: 1
    :glob:
 
-   releases/1_1_0
+   releases/1_1_1
    releases/1_0_2
    releases/1_0_1
    releases/1_0_0

--- a/docs/releases/1_1_1.rst
+++ b/docs/releases/1_1_1.rst
@@ -1,17 +1,18 @@
-.. _1-1-0:
+.. _1-1-1:
 
-1.1.0
+1.1.1
 ===========================
 *12/21/2017*
 
-Graphite 1.1.0 is now available! This marks another major milestone on Graphite's releases.
+Graphite 1.1.1 is now available! This marks another major milestone on Graphite's releases.
+()
 
 Source bundles are available from GitHub:
 
-* https://github.com/graphite-project/graphite-web/archive/1.1.0.tar.gz
-* https://github.com/graphite-project/carbon/archive/1.1.0.tar.gz
-* https://github.com/graphite-project/whisper/archive/1.1.0.tar.gz
-* https://github.com/graphite-project/carbonate/archive/1.1.0.tar.gz
+* https://github.com/graphite-project/graphite-web/archive/1.1.1.tar.gz
+* https://github.com/graphite-project/carbon/archive/1.1.1.tar.gz
+* https://github.com/graphite-project/whisper/archive/1.1.1.tar.gz
+* https://github.com/graphite-project/carbonate/archive/1.1.1.tar.gz
 
 Graphite can also be installed from `PyPI <http://pypi.python.org/>`_ via
 `pip <http://www.pip-installer.org/en/latest/index.html>`_. PyPI bundles are here:


### PR DESCRIPTION
I found out that 1.1.0 release is broken for carbon on pypi. Will rename it to 1.1.1 and will hide 1.1.0