### PR TITLE
ensure that msgpack strings are properly encoded and decoded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
         - TOXENV=py36-django111-pyparsing2
     - python: 3.6
       env:
+        - TOXENV=py36-django111-pyparsing2-msgpack
+    - python: 3.6
+      env:
         - TOXENV=lint
 
 env:

--- a/webapp/graphite/finders/remote.py
+++ b/webapp/graphite/finders/remote.py
@@ -109,7 +109,7 @@ class RemoteFinder(BaseFinder):
             try:
                 if result.getheader('content-type') == 'application/x-msgpack':
                   results = msgpack.load(BufferedHTTPReader(
-                    result, buffer_size=settings.REMOTE_BUFFER_SIZE))
+                    result, buffer_size=settings.REMOTE_BUFFER_SIZE), encoding='utf-8')
                 else:
                   results = unpickle.load(BufferedHTTPReader(
                     result, buffer_size=settings.REMOTE_BUFFER_SIZE))

--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -14,6 +14,7 @@ limitations under the License."""
 
 from functools import reduce
 import pytz
+from six import text_type
 from six.moves.urllib.parse import unquote_plus
 
 from datetime import datetime
@@ -335,18 +336,13 @@ def msgpack_nodes(nodes):
   nodes_info = []
 
   # make sure everything is unicode in python 2.x and 3.x
-  try:
-    unicode = str
-  except:
-    pass
-
   for node in nodes:
     info = {
-      unicode('path'): unicode(node.path),
-      unicode('is_leaf'): node.is_leaf,
+      text_type('path'): text_type(node.path),
+      text_type('is_leaf'): node.is_leaf,
     }
     if node.is_leaf:
-      info[unicode('intervals')] = [interval.tuple for interval in node.intervals]
+      info[text_type('intervals')] = [interval.tuple for interval in node.intervals]
 
     nodes_info.append(info)
 

--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -334,14 +334,23 @@ def pickle_nodes(nodes):
 def msgpack_nodes(nodes):
   nodes_info = []
 
+  # make sure everything is unicode in python 2.x and 3.x
+  try:
+    unicode = str
+  except:
+    pass
+
   for node in nodes:
-    info = dict(path=node.path, is_leaf=node.is_leaf)
+    info = {
+      unicode('path'): unicode(node.path),
+      unicode('is_leaf'): node.is_leaf,
+    }
     if node.is_leaf:
-      info['intervals'] = [interval.tuple for interval in node.intervals]
+      info[unicode('intervals')] = [interval.tuple for interval in node.intervals]
 
     nodes_info.append(info)
 
-  return msgpack.dumps(nodes_info)
+  return msgpack.dumps(nodes_info, use_bin_type=True)
 
 
 def json_nodes(nodes):

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -16,6 +16,7 @@ from __future__ import division
 import collections
 import re
 import time
+from six import text_type
 
 from django.conf import settings
 
@@ -121,21 +122,16 @@ class TimeSeries(list):
   def getInfo(self):
     """Pickle-friendly representation of the series"""
     # make sure everything is unicode in python 2.x and 3.x
-    try:
-      unicode = str
-    except:
-      pass
-
     return {
-      unicode('name') : unicode(self.name),
-      unicode('start') : self.start,
-      unicode('end') : self.end,
-      unicode('step') : self.step,
-      unicode('values') : list(self),
-      unicode('pathExpression') : unicode(self.pathExpression),
-      unicode('valuesPerPoint') : self.valuesPerPoint,
-      unicode('consolidationFunc'): unicode(self.consolidationFunc),
-      unicode('xFilesFactor') : self.xFilesFactor,
+      text_type('name') : text_type(self.name),
+      text_type('start') : self.start,
+      text_type('end') : self.end,
+      text_type('step') : self.step,
+      text_type('values') : list(self),
+      text_type('pathExpression') : text_type(self.pathExpression),
+      text_type('valuesPerPoint') : self.valuesPerPoint,
+      text_type('consolidationFunc'): text_type(self.consolidationFunc),
+      text_type('xFilesFactor') : self.xFilesFactor,
     }
 
 

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -120,16 +120,22 @@ class TimeSeries(list):
 
   def getInfo(self):
     """Pickle-friendly representation of the series"""
+    # make sure everything is unicode in python 2.x and 3.x
+    try:
+      unicode = str
+    except:
+      pass
+
     return {
-      'name' : self.name,
-      'start' : self.start,
-      'end' : self.end,
-      'step' : self.step,
-      'values' : list(self),
-      'pathExpression' : self.pathExpression,
-      'valuesPerPoint' : self.valuesPerPoint,
-      'consolidationFunc': self.consolidationFunc,
-      'xFilesFactor' : self.xFilesFactor,
+      unicode('name') : unicode(self.name),
+      unicode('start') : self.start,
+      unicode('end') : self.end,
+      unicode('step') : self.step,
+      unicode('values') : list(self),
+      unicode('pathExpression') : unicode(self.pathExpression),
+      unicode('valuesPerPoint') : self.valuesPerPoint,
+      unicode('consolidationFunc'): unicode(self.consolidationFunc),
+      unicode('xFilesFactor') : self.xFilesFactor,
     }
 
 

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -324,7 +324,7 @@ def renderViewPickle(requestOptions, data):
 def renderViewMsgPack(requestOptions, data):
   response = HttpResponse(content_type='application/x-msgpack')
   seriesInfo = [series.getInfo() for series in data]
-  msgpack.dump(seriesInfo, response)
+  msgpack.dump(seriesInfo, response, use_bin_type=True)
   return response
 
 

--- a/webapp/tests/test_metrics.py
+++ b/webapp/tests/test_metrics.py
@@ -203,14 +203,14 @@ class MetricsTester(TestCase):
             request['format']='msgpack'
             request['query']='*'
             content = test_find_view_basics(request)
-            data = msgpack.loads(content)
+            data = msgpack.loads(content, encoding='utf-8')
             self.assertEqual(len(data), 1)
             self.assertEqual(data[0]['path'], 'hosts')
             self.assertEqual(data[0]['is_leaf'], False)
 
             request['query']='hosts.*.cpu'
             content = test_find_view_basics(request)
-            data = msgpack.loads(content)
+            data = msgpack.loads(content, encoding='utf-8')
             self.assertEqual(len(data), 2)
 
             data = sorted(data, key=_path_key)

--- a/webapp/tests/test_readers_remote.py
+++ b/webapp/tests/test_readers_remote.py
@@ -108,7 +108,7 @@ class RemoteReaderTests(TestCase):
                 }
                ]
         responseObject = HTTPResponse(
-          body=BytesIO(msgpack.dumps(data)),
+          body=BytesIO(msgpack.dumps(data, use_bin_type=True)),
           status=200,
           preload_content=False,
           headers={'Content-Type': 'application/x-msgpack'}
@@ -149,6 +149,21 @@ class RemoteReaderTests(TestCase):
         http_request.return_value = responseObject
 
         with self.assertRaisesRegexp(Exception, 'Error decoding render response from http://[^ ]+: .+'):
+          reader.fetch(startTime, endTime)
+
+        # invalid response data
+        data = [
+          {},
+        ]
+        responseObject = HTTPResponse(
+          body=BytesIO(msgpack.dumps(data, use_bin_type=True)),
+          status=200,
+          preload_content=False,
+          headers={'Content-Type': 'application/x-msgpack'}
+        )
+        http_request.return_value = responseObject
+
+        with self.assertRaisesRegexp(Exception, 'Invalid render response from http://[^ ]+: KeyError\(\'name\',\)'):
           reader.fetch(startTime, endTime)
 
         # non-200 response

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -387,7 +387,7 @@ class RenderTest(TestCase):
         # test msgpack format
         response = self.client.get(url, {'target': 'test', 'format': 'msgpack', 'from': ts-50, 'now': ts})
         self.assertEqual(response['content-type'], 'application/x-msgpack')
-        unpickled = msgpack.loads(response.content)
+        unpickled = msgpack.loads(response.content, encoding='utf-8')
         # special handling for NaN value, otherwise assertEqual fails
         self.assertTrue(math.isnan(unpickled[0]['values'][-1]))
         unpickled[0]['values'][-1] = 'NaN'


### PR DESCRIPTION
By default `msgpack-python` will decode string values to binary strings under python 3.x, which causes issues when trying to use the decoded dicts.  In addition, non-unicode strings (eg string literals in python 2.x) are encoded as the `bin` type rather than the `str` type.

This PR fixes those issues by ensuring that all strings that we encode are unicode, and that we use the right options when calling msgpack functions.  `umsgpack` already does the right thing, and it ignores the new parameters.

I also added python3.6 with `msgpack-python` to the build matrix, and added some better error handling if the remote render response doesn't contain the items we're looking for.

I opted to use `unicode` vs `u''` for the literals to treat them the same way as we do the string vars, under python 3 it'll be a no-op (casting `str` to `str`) and under 2.x it'll make sure they're unicode strings.