### PR TITLE
fix interval end test error

### DIFF
--- a/webapp/tests/test_readers_multi.py
+++ b/webapp/tests/test_readers_multi.py
@@ -86,8 +86,8 @@ class MultiReaderTests(TestCase):
         reader = MultiReader([node1, node2])
         intervals = reader.get_intervals()
         for interval in intervals:
-          self.assertEqual(int(interval.start), self.start_ts-60)
-          self.assertEqual(int(interval.end), self.start_ts)
+          self.assertEqual(int(interval.start), self.start_ts - 60)
+          self.assertIn(int(interval.end), [self.start_ts, self.start_ts - 1])
 
     # Confirm fetch works.
     def test_MultiReader_fetch(self):


### PR DESCRIPTION
This PR updates the last remaining place where `interval.end` is compared with a timestamp, which can cause timing-related test failures.