### PR TITLE
Fix hash position computation of fnv1a_ch.

### DIFF
--- a/webapp/graphite/render/hashing.py
+++ b/webapp/graphite/render/hashing.py
@@ -73,11 +73,8 @@ class ConsistentHashRing:
 
   def compute_ring_position(self, key):
     if self.hash_type == 'fnv1a_ch':
-      big_hash = '{:x}'.format(int(fnv32a( str(key) )))
-      if len(big_hash) > 4:
-          small_hash = int(big_hash[:4], 16) ^ int(big_hash[4:], 16)
-      else:
-          small_hash = int(big_hash, 16)
+      big_hash = int(fnv32a(str(key)))
+      small_hash = (big_hash >> 16) ^ (big_hash & 0xffff)
     else:
       big_hash = compactHash(str(key))
       small_hash = int(big_hash[:4], 16)

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -979,7 +979,11 @@ class ConsistentHashRingTestFNV1A(TestCase):
         ("127.0.0.3", "866a18b81f2dc4649517a1df13e26f28")]
         hashring = ConsistentHashRing(hosts, hash_type='fnv1a_ch')
         self.assertEqual(hashring.compute_ring_position('hosts.worker1.cpu'), 59573)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker1.load'), 57163)
         self.assertEqual(hashring.compute_ring_position('hosts.worker2.cpu'), 35749)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker2.network'), 43584)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker3.cpu'), 12600)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker3.irq'), 10052)
 
     def test_chr_get_node_fnv1a(self):
         hosts = [("127.0.0.1", "ba603c36342304ed77953f84ac4d357b"), ("127.0.0.2", "5dd63865534f84899c6e5594dba6749a"),


### PR DESCRIPTION
If the fnv1a hash of a given key returns a value less than 0x10000000, then the high and low parts of the hash would be split incorrectly, resulting in a wrongly computed hash position.

This removes the hex formatting and splitting of the fnv1a hash, and just calculates the position using bit manipulation.

Patch taken from graphite-project/carbon#715.