### PR TITLE
Fix hash position computation of fnv1a_ch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ matrix:
         - TOXENV=py36-django111-pyparsing2-msgpack
     - python: 3.6
       env:
+        - TOXENV=py36-django111-pyparsing2-pyhash
+    - python: 3.6
+      env:
         - TOXENV=lint
 
 env:
@@ -30,6 +33,7 @@ env:
   - TOXENV=py27-django110-pyparsing2
   - TOXENV=py27-django111-pyparsing2-rrdtool
   - TOXENV=py27-django111-pyparsing2-msgpack
+  - TOXENV=py27-django111-pyparsing2-pyhash
   - TOXENV=py27-django111-pyparsing2-mysql TEST_MYSQL_PASSWORD=graphite
   - TOXENV=py27-django111-pyparsing2-postgresql TEST_POSTGRESQL_PASSWORD=graphite
   - TOXENV=docs
@@ -50,6 +54,7 @@ services:
 before_install:
   - bash -c "if [[ '$TOXENV' == *mysql* ]]; then mysql -e "'"'"GRANT ALL ON test_graphite.* TO 'graphite'@'localhost' IDENTIFIED BY 'graphite';"'"'"; fi"
   - bash -c "if [[ '$TOXENV' == *postgresql* ]]; then psql -c "'"'"CREATE USER graphite WITH CREATEDB PASSWORD 'graphite';"'"'" -U postgres; fi"
+  - bash -c "if [[ '$TOXENV' == *pyhash* ]]; then sudo apt-get -qq update; sudo apt-get install -y libboost-python-dev; fi"
 
 install:
   - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-	py{27,34,35,36,py}-django1{8,9,10,11}-pyparsing2{,-mysql,-postgresql,-rrdtool,-msgpack},
+	py{27,34,35,36,py}-django1{8,9,10,11}-pyparsing2{,-mysql,-postgresql,-rrdtool,-msgpack,-pyhash},
 	lint, docs
 
 [testenv]
@@ -38,6 +38,7 @@ deps =
 	postgresql: psycopg2
 	rrdtool: rrdtool
 	msgpack: msgpack-python
+	pyhash: pyhash
 
 [testenv:docs]
 basepython = python2.7

--- a/webapp/graphite/render/hashing.py
+++ b/webapp/graphite/render/hashing.py
@@ -66,9 +66,7 @@ def hashData(targets, startTime, endTime, xFilesFactor):
 
 
 def compactHash(string):
-  hash = md5()
-  hash.update(string.encode('utf-8'))
-  return hash.hexdigest()
+  return md5(string.encode('utf-8')).hexdigest()
 
 
 class ConsistentHashRing:
@@ -87,7 +85,7 @@ class ConsistentHashRing:
       big_hash = int(fnv32a(key.encode('utf-8')))
       small_hash = (big_hash >> 16) ^ (big_hash & 0xffff)
     else:
-      big_hash = compactHash(str(key))
+      big_hash = compactHash(key)
       small_hash = int(big_hash[:4], 16)
     return small_hash
 

--- a/webapp/graphite/render/hashing.py
+++ b/webapp/graphite/render/hashing.py
@@ -73,11 +73,8 @@ class ConsistentHashRing:
 
   def compute_ring_position(self, key):
     if self.hash_type == 'fnv1a_ch':
-      big_hash = '{:x}'.format(int(fnv32a( str(key) )))
-      if len(big_hash) > 4:
-          small_hash = int(big_hash[:4], 16) ^ int(big_hash[4:], 16)
-      else:
-          small_hash = int(big_hash, 16)
+      big_hash = int(fnv32a(str(key)))
+      small_hash = (big_hash >> 16) ^ (big_hash & 0xffff)
     else:
       big_hash = compactHash(str(key))
       small_hash = int(big_hash[:4], 16)

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -979,7 +979,11 @@ class ConsistentHashRingTestFNV1A(TestCase):
         ("127.0.0.3", "866a18b81f2dc4649517a1df13e26f28")]
         hashring = ConsistentHashRing(hosts, hash_type='fnv1a_ch')
         self.assertEqual(hashring.compute_ring_position('hosts.worker1.cpu'), 59573)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker1.load'), 57163)
         self.assertEqual(hashring.compute_ring_position('hosts.worker2.cpu'), 35749)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker2.network'), 43584)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker3.cpu'), 12600)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker3.irq'), 10052)
 
     def test_chr_get_node_fnv1a(self):
         hosts = [("127.0.0.1", "ba603c36342304ed77953f84ac4d357b"), ("127.0.0.2", "5dd63865534f84899c6e5594dba6749a"),

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -984,6 +984,7 @@ class ConsistentHashRingTestFNV1A(TestCase):
         self.assertEqual(hashring.compute_ring_position('hosts.worker2.network'), 43584)
         self.assertEqual(hashring.compute_ring_position('hosts.worker3.cpu'), 12600)
         self.assertEqual(hashring.compute_ring_position('hosts.worker3.irq'), 10052)
+        self.assertEqual(hashring.compute_ring_position(u'a\xac\u1234\u20ac\U00008000'), 38658)
 
     def test_chr_get_node_fnv1a(self):
         hosts = [("127.0.0.1", "ba603c36342304ed77953f84ac4d357b"), ("127.0.0.2", "5dd63865534f84899c6e5594dba6749a"),


### PR DESCRIPTION
This PR is an attempt to future-proof the fnv1a_ch hash computation by properly handling multi-byte characters in addition to applying the fix described in graphite-project/carbon#714 and #2165.

The way we use the `fnv32a` hash function is now consistent with other hash functions where any string is encoded into utf-8 before being hashed.  This produces consistent results across python 2.x and 3.x with or without the pyhash library, and should be consistent with any third-party implementations.

I added pyhash to tox and travis, and added a quick test with multibyte characters to verify that the behavior is now consistent (the previous code would just crash and burn with a `UnicodeEncodeError` without pyhash, and produce inconsistent results with pyhash).