### PR TITLE
[1.1.x] fix typo in aggregate arg definition

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -302,7 +302,7 @@ def aggregate(requestContext, seriesList, func, xFilesFactor=None):
 
 aggregate.group = 'Combine'
 aggregate.params = [
-  Param('seriesList', ParamTypes.seriesList, required=True, multiple=True),
+  Param('seriesList', ParamTypes.seriesList, required=True),
   Param('func', ParamTypes.aggFunc, required=True, options=aggFuncNames),
   Param('xFilesFactor', ParamTypes.float),
 ]


### PR DESCRIPTION
Backports the following commits to 1.1.x:
 - fix typo in aggregate arg definition (#2169)