### PR TITLE
add .backportrc.json

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,22 @@
+{
+  "upstream": "graphite-project/graphite-web",
+
+  // You can pre-select branches you use often
+  "branches": [
+    { "name": "1.1.x", "checked": true },
+    { "name": "1.0.x", "checked": false },
+    { "name": "0.9.x", "checked": false }
+  ],
+
+  // Only allow picking own commits to backport
+  "own": false,
+
+  // Backport multiple commits
+  "multipleCommits": true,
+
+  // Backport to multiple branches
+  "multipleBranches": true,
+
+  // Labels will be added to the PR
+  "labels": ["backport"]
+}


### PR DESCRIPTION
This PR adds a `.backportrc.json` configuration file for https://github.com/sqren/backport

If there is a better/simpler/otherwise preferred process for backporting please let me know.