### PR TITLE
Add a README and examples for invoking test harness by hand

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ setenv =
 passenv = TEST_MYSQL_* TEST_POSTGRESQL_*
 changedir = webapp
 commands =
-	coverage run --branch --source=graphite manage.py test
+	coverage run --branch --source=graphite manage.py test {posargs}
 	coverage xml
 	coverage report
 deps =

--- a/webapp/tests/README.md
+++ b/webapp/tests/README.md
@@ -23,7 +23,7 @@ Passing multiple environments to tox can be done by separating with commas:
 `tox -e py27-django111-pyparsing2,py35-django111-pyparsing2,lint`
 
 To run only a specific test suite run (aka. run the file tests/test_finders.py):
-`tox -e py27-django111-pyparsing2,py35-django111-pyparsing2,lint-- tests.test_finders`
+`tox -e py27-django111-pyparsing2,py35-django111-pyparsing2,lint -- tests.test_finders`
 
 To run only a specific class in a test suite run (aka. run the MetricsTester class inside of test/test_metrics.py):
 

--- a/webapp/tests/README.md
+++ b/webapp/tests/README.md
@@ -41,7 +41,7 @@ Run `coverage html` from the webapp directory.  Afterwards, the webapp/htmlcov/i
 
 ### Setting up an environment to test
 
-There may need to be additional system packages or python dependencies installed in order for tox to successfully install the required packages for the tests.  Additionally, there may be additional system services needed to be running locally for the unit tests to complete successfully.
+There may need to be additional system packages or python dependencies installed in order for tox to successfully install the required packages for the tests.  Also, there may be system services running locally that are needed for the unit tests to complete successfully.
 
 ## License
 

--- a/webapp/tests/README.md
+++ b/webapp/tests/README.md
@@ -4,7 +4,7 @@
 
 These Graphite-Web unit tests are for the Django portions of the graphite-web code base.  They utilize the Django test framework and run via `manage.py test`.
 
-For pull-requests, the tests run inside of Travic-ci using Python tox (https://pypi.python.org/pypi/tox) to invoke the tests across all the environments defined in tox.ini.
+For pull-requests, the tests run inside of Travis-ci using Python tox (https://pypi.python.org/pypi/tox) to invoke the tests across all the environments defined in tox.ini.
 
 The current tox.ini configuration uses Python coverage (http://coverage.readthedocs.io/en/latest/) to invoke `manage.py` and capture the code coverage levels.
 
@@ -18,7 +18,7 @@ Invoke `tox` in the root of the tree and all tests across all environments will 
 To run only a specific test suite run (aka. run the file tests/test_finders.py):
 `tox -- tests.test_finders`
 
-To run only a specific class in that test suite run:
+To run only a specific class in a test suite run:
 
 `tox -- tests.test_metrics.MetricsTester`
 

--- a/webapp/tests/README.md
+++ b/webapp/tests/README.md
@@ -1,0 +1,42 @@
+# Graphite-Web Test Framework
+
+## Overview
+
+These Graphite-Web unit tests are for the Django portions of the graphite-web code base.  They utilize the Django test framework and run via `manage.py test`.
+
+For pull-requests, the tests run inside of Travic-ci using Python tox (https://pypi.python.org/pypi/tox) to invoke the tests across all the environments defined in tox.ini.
+
+The current tox.ini configuration uses Python coverage (http://coverage.readthedocs.io/en/latest/) to invoke `manage.py` and capture the code coverage levels.
+
+## Installation, Configuration and Usage
+
+
+### Example Tox invocations to run unit tests manually
+
+Invoke `tox` in the root of the tree and all tests across all environments will be run serially.
+
+To run only a specific test suite run (aka. run the file tests/test_finders.py):
+`tox -- tests.test_finders`
+
+To run only a specific class in that test suite run:
+
+`tox -- tests.test_metrics.MetricsTester`
+
+To run only a specific test within a test suite's class run:
+
+`tox -- tests.test_metrics.MetricsTester.test_index_json`
+
+The environment can be pass in the above examples.
+`tox -e py27-django19-pyparsing2 -- tests.test_metrics.MetricsTester.test_index_json`
+
+### Generating html coverage report
+
+Run `coverage html` from the webapp directory.  Afterwards, the webapp/htmlcov/index.html file can be loaded in a browser and the coverage map for the tested code can be evaluated.
+
+### Setting up an environment to test in
+There may need to be additional system packages or python dependencies installed in order for tox to successfully install the required packages for the tests.
+
+
+## License
+
+Graphite-Web is licensed under version 2.0 of the Apache License. See the [LICENSE](https://github.com/graphite-project/graphite-web/blob/master/LICENSE) file for details.

--- a/webapp/tests/README.md
+++ b/webapp/tests/README.md
@@ -10,32 +10,38 @@ The current tox.ini configuration uses Python coverage (http://coverage.readthed
 
 ## Installation, Configuration and Usage
 
-
 ### Example Tox invocations to run unit tests manually
 
-Invoke `tox` in the root of the tree and all tests across all environments will be run serially.
+Invoke `tox` in the root of the tree and all tests across all environments will be run serially.  There are currently 122 environment combinations (`tox -l` lists them all), so running tox without specifying an environment will take a while to run.
+
+A set of minimum environments to run tests against are:
+`py27-django111-pyparsing2`
+`py35-django111-pyparsing2`
+`lint`
+
+Passing multiple environments to tox can be done by separating with commas:
+`tox -e py27-django111-pyparsing2,py35-django111-pyparsing2,lint`
 
 To run only a specific test suite run (aka. run the file tests/test_finders.py):
-`tox -- tests.test_finders`
+`tox -e py27-django111-pyparsing2,py35-django111-pyparsing2,lint-- tests.test_finders`
 
-To run only a specific class in a test suite run:
+To run only a specific class in a test suite run (aka. run the MetricsTester class inside of test/test_metrics.py):
 
-`tox -- tests.test_metrics.MetricsTester`
+`tox -e py27-django111-pyparsing2,py35-django111-pyparsing2,lint -- tests.test_metrics.MetricsTester`
 
 To run only a specific test within a test suite's class run:
 
-`tox -- tests.test_metrics.MetricsTester.test_index_json`
+`tox -e py27-django111-pyparsing2,py35-django111-pyparsing2,lint -- tests.test_metrics.MetricsTester.test_index_json`
 
-The environment can be pass in the above examples.
-`tox -e py27-django19-pyparsing2 -- tests.test_metrics.MetricsTester.test_index_json`
+### Minimum tests to verify
 
 ### Generating html coverage report
 
 Run `coverage html` from the webapp directory.  Afterwards, the webapp/htmlcov/index.html file can be loaded in a browser and the coverage map for the tested code can be evaluated.
 
-### Setting up an environment to test in
-There may need to be additional system packages or python dependencies installed in order for tox to successfully install the required packages for the tests.
+### Setting up an environment to test
 
+There may need to be additional system packages or python dependencies installed in order for tox to successfully install the required packages for the tests.  Additionally, there may be additional system services needed to be running locally for the unit tests to complete successfully.
 
 ## License
 


### PR DESCRIPTION
It's been a little while since I wrote some tests and had to remember how to invoke the test harness and verify the test coverage, so I wrote it down.  Wording and everything open for discussion/adjustment and I may not be describing the optimal ways to do any of this.

* Add README for how the Django-based tests are run.
* Also adjust the coverage invocation so that manual runs can pass in specific test classes or test methods to run during debugging/testing.