### PR TITLE
build-index

### DIFF
--- a/bin/build-index
+++ b/bin/build-index
@@ -7,7 +7,7 @@ import django
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "graphite.settings")
 django.setup()
 
-from graphite.util import write_index
+from graphite.storage import write_index
 
 
 if __name__ == "__main__":
@@ -20,11 +20,7 @@ if __name__ == "__main__":
         " defaults."
     parser = OptionParser(description=description, prog=prog, version=version,
         epilog=epilog)
-    parser.add_option("-c", "--ceres_dir", default=settings.CERES_DIR,
-        help="default: %default")
-    parser.add_option("-w", "--whisper_dir", default=settings.WHISPER_DIR,
-        help="default: %default")
     parser.add_option("-i", "--index", default=settings.INDEX_FILE,
         help="default: %default")
     (options, args) = parser.parse_args()
-    write_index(options.whisper_dir, options.ceres_dir, options.index)
+    write_index(options.index)

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+import os
 import time
 import random
 import sys
@@ -6,6 +7,8 @@ import types
 
 from collections import defaultdict
 from copy import deepcopy
+from shutil import move
+from tempfile import mkstemp
 
 from django.conf import settings
 from django.core.cache import cache
@@ -527,6 +530,26 @@ def extractForwardHeaders(request):
         if value is not None:
             headers[name] = value
     return headers
+
+
+def write_index(index=None):
+  if not index:
+    index = settings.INDEX_FILE
+  try:
+    fd, tmp = mkstemp()
+    try:
+      tmp_index = os.fdopen(fd, 'wt')
+      for metric in STORE.get_index():
+        tmp_index.write("{0}\n".format(metric))
+    finally:
+      tmp_index.close()
+    move(tmp, index)
+  finally:
+    try:
+      os.unlink(tmp)
+    except:
+      pass
+  return None
 
 
 STORE = Store()


### PR DESCRIPTION
This PR restores support for the `build-index` command, which now uses `STORE.get_index()` to get the list of defined metrics.

Note that the `--ceres-dir` and `--whisper-dir` args have been removed as they aren't applicable any more.