### PR TITLE
readers: re-introduce FetchInProgress

### DIFF
--- a/webapp/graphite/readers/__init__.py
+++ b/webapp/graphite/readers/__init__.py
@@ -4,3 +4,4 @@ from graphite.readers.multi import MultiReader  # noqa # pylint: disable=unused-
 from graphite.readers.whisper import WhisperReader, GzippedWhisperReader  # noqa # pylint: disable=unused-import
 from graphite.readers.ceres import CeresReader  # noqa # pylint: disable=unused-import
 from graphite.readers.rrd import RRDReader  # noqa # pylint: disable=unused-import
+from graphite.finders.utils import FetchInProgress  # noqa # pylint: disable=unused-import


### PR DESCRIPTION
Previous readers would use FetchInProgress as a way
to run queries asynchrously. This leads to serious performance
regressions for plugins such as biggraphite which relied on that.

This re-introduces FetchInProgress and uses it in `fetch_multi()`
only.