### PR TITLE
[1.1.x] always use bytes when computing fnv32a hashes | sync hashing.py with carbon | tidy up compactHash | fix typo in aggregate arg definition | tweak function docs | fix build-index | clarify function plug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,12 @@ matrix:
         - TOXENV=py36-django111-pyparsing2
     - python: 3.6
       env:
+        - TOXENV=py36-django111-pyparsing2-msgpack
+    - python: 3.6
+      env:
+        - TOXENV=py36-django111-pyparsing2-pyhash
+    - python: 3.6
+      env:
         - TOXENV=lint
 
 env:
@@ -27,6 +33,7 @@ env:
   - TOXENV=py27-django110-pyparsing2
   - TOXENV=py27-django111-pyparsing2-rrdtool
   - TOXENV=py27-django111-pyparsing2-msgpack
+  - TOXENV=py27-django111-pyparsing2-pyhash
   - TOXENV=py27-django111-pyparsing2-mysql TEST_MYSQL_PASSWORD=graphite
   - TOXENV=py27-django111-pyparsing2-postgresql TEST_POSTGRESQL_PASSWORD=graphite
   - TOXENV=docs
@@ -47,6 +54,7 @@ services:
 before_install:
   - bash -c "if [[ '$TOXENV' == *mysql* ]]; then mysql -e "'"'"GRANT ALL ON test_graphite.* TO 'graphite'@'localhost' IDENTIFIED BY 'graphite';"'"'"; fi"
   - bash -c "if [[ '$TOXENV' == *postgresql* ]]; then psql -c "'"'"CREATE USER graphite WITH CREATEDB PASSWORD 'graphite';"'"'" -U postgres; fi"
+  - bash -c "if [[ '$TOXENV' == *pyhash* ]]; then sudo apt-get -qq update; sudo apt-get install -y libboost-python-dev; fi"
 
 install:
   - pip install tox

--- a/bin/build-index
+++ b/bin/build-index
@@ -7,7 +7,7 @@ import django
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "graphite.settings")
 django.setup()
 
-from graphite.util import write_index
+from graphite.storage import write_index
 
 
 if __name__ == "__main__":
@@ -20,11 +20,7 @@ if __name__ == "__main__":
         " defaults."
     parser = OptionParser(description=description, prog=prog, version=version,
         epilog=epilog)
-    parser.add_option("-c", "--ceres_dir", default=settings.CERES_DIR,
-        help="default: %default")
-    parser.add_option("-w", "--whisper_dir", default=settings.WHISPER_DIR,
-        help="default: %default")
     parser.add_option("-i", "--index", default=settings.INDEX_FILE,
         help="default: %default")
     (options, args) = parser.parse_args()
-    write_index(options.whisper_dir, options.ceres_dir, options.index)
+    write_index(options.index)

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -24,7 +24,8 @@ Function Plugins
 
 Function plugins can define additional functions for use in render calls.
 
-A function plugin is simply a file defining one or more functions and exporting ``SeriesFunctions`` and/or ``PieFunctions``
+A function plugin is simply a file defining one or more functions and exporting dictionaries of ``SeriesFunctions`` and/or ``PieFunctions``.
+When Graphite loads the plugin it will add functions in ``SeriesFunctions`` and/or ``PieFunctions`` to the list of available functions.
 
 Each exposed function must accept at least a ``requestContext`` and ``seriesList`` parameter, and may accept additional parameters as needed.
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ setenv =
 passenv = TEST_MYSQL_* TEST_POSTGRESQL_*
 changedir = webapp
 commands =
-	coverage run --branch --source=graphite manage.py test
+	coverage run --branch --source=graphite manage.py test {posargs}
 	coverage xml
 	coverage report
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-	py{27,34,35,36,py}-django1{8,9,10,11}-pyparsing2{,-mysql,-postgresql,-rrdtool,-msgpack},
+	py{27,34,35,36,py}-django1{8,9,10,11}-pyparsing2{,-mysql,-postgresql,-rrdtool,-msgpack,-pyhash},
 	lint, docs
 
 [testenv]
@@ -38,6 +38,7 @@ deps =
 	postgresql: psycopg2
 	rrdtool: rrdtool
 	msgpack: msgpack-python
+	pyhash: pyhash
 
 [testenv:docs]
 basepython = python2.7

--- a/webapp/graphite/app_settings.py
+++ b/webapp/graphite/app_settings.py
@@ -16,7 +16,10 @@ limitations under the License."""
 # DO NOT MODIFY THIS FILE DIRECTLY - use local_settings.py instead
 from os.path import dirname, join, abspath
 from django import VERSION as DJANGO_VERSION
-
+try:
+    import raven
+except ImportError:
+    raven = None
 
 #Django settings below, do not touch!
 APPEND_SLASH = False
@@ -89,6 +92,9 @@ INSTALLED_APPS = (
   'django.contrib.staticfiles',
   'tagging',
 )
+if raven is not None:
+    INSTALLED_APPS.append('raven.contrib.django.raven_compat')
+
 
 AUTHENTICATION_BACKENDS = ['django.contrib.auth.backends.ModelBackend']
 

--- a/webapp/graphite/finders/standard.py
+++ b/webapp/graphite/finders/standard.py
@@ -53,8 +53,7 @@ class StandardFinder(BaseFinder):
 
                 relative_path = absolute_path[len(root_dir):].lstrip('/')
                 metric_path = fs_to_metric(relative_path)
-                real_metric_path = get_real_metric_path(
-                    absolute_path, metric_path)
+                real_metric_path = get_real_metric_path(absolute_path, metric_path)
 
                 metric_path_parts = metric_path.split('.')
                 for field_index in find_escaped_pattern_fields(query.pattern):
@@ -70,29 +69,24 @@ class StandardFinder(BaseFinder):
                 if isdir(absolute_path):
                     yield BranchNode(metric_path)
 
-                elif isfile(absolute_path):
-                    if absolute_path.endswith(
-                            '.wsp') and WhisperReader.supported:
-                        reader = WhisperReader(absolute_path, real_metric_path)
-                        yield LeafNode(metric_path, reader)
+                elif absolute_path.endswith('.wsp') and WhisperReader.supported:
+                    reader = WhisperReader(absolute_path, real_metric_path)
+                    yield LeafNode(metric_path, reader)
 
-                    elif absolute_path.endswith('.wsp.gz') and GzippedWhisperReader.supported:
-                        reader = GzippedWhisperReader(
-                            absolute_path, real_metric_path)
-                        yield LeafNode(metric_path, reader)
+                elif absolute_path.endswith('.wsp.gz') and GzippedWhisperReader.supported:
+                    reader = GzippedWhisperReader(
+                        absolute_path, real_metric_path)
+                    yield LeafNode(metric_path, reader)
 
-                    elif absolute_path.endswith('.rrd') and RRDReader.supported:
-                        if datasource_pattern is None:
-                            yield BranchNode(metric_path)
+                elif absolute_path.endswith('.rrd') and RRDReader.supported:
+                    if datasource_pattern is None:
+                        yield BranchNode(metric_path)
 
-                        else:
-                            for datasource_name in RRDReader.get_datasources(
-                                    absolute_path):
-                                if match_entries(
-                                        [datasource_name], datasource_pattern):
-                                    reader = RRDReader(
-                                        absolute_path, datasource_name)
-                                    yield LeafNode(metric_path + "." + datasource_name, reader)
+                    else:
+                        for datasource_name in RRDReader.get_datasources(absolute_path):
+                            if match_entries([datasource_name], datasource_pattern):
+                                reader = RRDReader(absolute_path, datasource_name)
+                                yield LeafNode(metric_path + "." + datasource_name, reader)
 
     def _find_paths(self, current_dir, patterns):
         """Recursively generates absolute paths whose components underneath current_dir
@@ -102,42 +96,40 @@ class StandardFinder(BaseFinder):
 
         has_wildcard = pattern.find(
             '{') > -1 or pattern.find('[') > -1 or pattern.find('*') > -1 or pattern.find('?') > -1
-        using_globstar = pattern == "**"
 
+        matching_subdirs = []
+        files = []
         if has_wildcard:  # this avoids os.listdir() for performance
+            subdirs = []
             try:
-                entries = [x.name for x in scandir(current_dir)]
+                for x in scandir(current_dir):
+                    if x.is_file():
+                        files.append(x.name)
+                    if x.is_dir():
+                        subdirs.append(x.name)
             except OSError as e:
                 log.exception(e)
-                entries = []
-        else:
-            entries = [pattern]
 
-        if using_globstar:
-            matching_subdirs = map(operator.itemgetter(0), walk(current_dir))
-        else:
-            subdirs = [
-                entry for entry in entries if isdir(
-                    join(
-                        current_dir,
-                        entry))]
-            matching_subdirs = match_entries(subdirs, pattern)
+            if pattern == "**":
+                matching_subdirs = map(operator.itemgetter(0), walk(current_dir))
 
-        # if this is a terminal globstar, add a pattern for all files in
-        # subdirs
-        if using_globstar and not patterns:
-            patterns = ["*"]
+                # if this is a terminal globstar, add a pattern for all files in subdirs
+                if not patterns:
+                    patterns = ["*"]
+            else:
+                matching_subdirs = match_entries(subdirs, pattern)
+        elif isdir(join(current_dir, pattern)):
+            matching_subdirs.append(pattern)
 
         # the last pattern may apply to RRD data sources
         if len(patterns) == 1 and RRDReader.supported:
             if not has_wildcard:
-                entries = [pattern + ".rrd"]
-            files = [
-                entry for entry in entries if isfile(
-                    join(
-                        current_dir,
-                        entry))]
-            rrd_files = match_entries(files, pattern + ".rrd")
+                entries = [
+                  pattern + ".rrd",
+                ]
+                rrd_files = [entry for entry in entries if isfile(join(current_dir, entry))]
+            else:
+                rrd_files = match_entries(files, pattern + ".rrd")
 
             if rrd_files:  # let's assume it does
                 datasource_pattern = patterns[0]
@@ -148,7 +140,6 @@ class StandardFinder(BaseFinder):
 
         if patterns:  # we've still got more directories to traverse
             for subdir in matching_subdirs:
-
                 absolute_path = join(current_dir, subdir)
                 for match in self._find_paths(absolute_path, patterns):
                     yield match
@@ -158,13 +149,11 @@ class StandardFinder(BaseFinder):
                 entries = [
                     pattern + '.wsp',
                     pattern + '.wsp.gz',
-                    pattern + '.rrd']
-            files = [
-                entry for entry in entries if isfile(
-                    join(
-                        current_dir,
-                        entry))]
-            matching_files = match_entries(files, pattern + '.*')
+                    pattern + '.rrd',
+                ]
+                matching_files = [entry for entry in entries if isfile(join(current_dir, entry))]
+            else:
+                matching_files = match_entries(files, pattern + '.*')
 
             for base_name in matching_files + matching_subdirs:
                 yield join(current_dir, base_name)

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+import os
 import time
 import random
 import sys
@@ -6,6 +7,8 @@ import types
 
 from collections import defaultdict
 from copy import deepcopy
+from shutil import move
+from tempfile import mkstemp
 
 from django.conf import settings
 from django.core.cache import cache
@@ -527,6 +530,26 @@ def extractForwardHeaders(request):
         if value is not None:
             headers[name] = value
     return headers
+
+
+def write_index(index=None):
+  if not index:
+    index = settings.INDEX_FILE
+  try:
+    fd, tmp = mkstemp()
+    try:
+      tmp_index = os.fdopen(fd, 'wt')
+      for metric in STORE.get_index():
+        tmp_index.write("{0}\n".format(metric))
+    finally:
+      tmp_index.close()
+    move(tmp, index)
+  finally:
+    try:
+      os.unlink(tmp)
+    except:
+      pass
+  return None
 
 
 STORE = Store()

--- a/webapp/tests/README.md
+++ b/webapp/tests/README.md
@@ -1,0 +1,48 @@
+# Graphite-Web Test Framework
+
+## Overview
+
+These Graphite-Web unit tests are for the Django portions of the graphite-web code base.  They utilize the Django test framework and run via `manage.py test`.
+
+For pull-requests, the tests run inside of Travis-ci using Python tox (https://pypi.python.org/pypi/tox) to invoke the tests across all the environments defined in tox.ini.
+
+The current tox.ini configuration uses Python coverage (http://coverage.readthedocs.io/en/latest/) to invoke `manage.py` and capture the code coverage levels.
+
+## Installation, Configuration and Usage
+
+### Example Tox invocations to run unit tests manually
+
+Invoke `tox` in the root of the tree and all tests across all environments will be run serially.  There are currently 122 environment combinations (`tox -l` lists them all), so running tox without specifying an environment will take a while to run.
+
+A set of minimum environments to run tests against are:
+`py27-django111-pyparsing2`
+`py35-django111-pyparsing2`
+`lint`
+
+Passing multiple environments to tox can be done by separating with commas:
+`tox -e py27-django111-pyparsing2,py35-django111-pyparsing2,lint`
+
+To run only a specific test suite run (aka. run the file tests/test_finders.py):
+`tox -e py27-django111-pyparsing2,py35-django111-pyparsing2,lint -- tests.test_finders`
+
+To run only a specific class in a test suite run (aka. run the MetricsTester class inside of test/test_metrics.py):
+
+`tox -e py27-django111-pyparsing2,py35-django111-pyparsing2,lint -- tests.test_metrics.MetricsTester`
+
+To run only a specific test within a test suite's class run:
+
+`tox -e py27-django111-pyparsing2,py35-django111-pyparsing2,lint -- tests.test_metrics.MetricsTester.test_index_json`
+
+### Minimum tests to verify
+
+### Generating html coverage report
+
+Run `coverage html` from the webapp directory.  Afterwards, the webapp/htmlcov/index.html file can be loaded in a browser and the coverage map for the tested code can be evaluated.
+
+### Setting up an environment to test
+
+There may need to be additional system packages or python dependencies installed in order for tox to successfully install the required packages for the tests.  Also, there may be system services running locally that are needed for the unit tests to complete successfully.
+
+## License
+
+Graphite-Web is licensed under version 2.0 of the Apache License. See the [LICENSE](https://github.com/graphite-project/graphite-web/blob/master/LICENSE) file for details.

--- a/webapp/tests/test_finders_remote.py
+++ b/webapp/tests/test_finders_remote.py
@@ -126,7 +126,7 @@ class RemoteFinderTest(TestCase):
         },
       ]
       responseObject = HTTPResponse(
-        body=BytesIO(msgpack.dumps(data)),
+        body=BytesIO(msgpack.dumps(data, use_bin_type=True)),
         status=200,
         preload_content=False,
         headers={'Content-Type': 'application/x-msgpack'}

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -979,7 +979,12 @@ class ConsistentHashRingTestFNV1A(TestCase):
         ("127.0.0.3", "866a18b81f2dc4649517a1df13e26f28")]
         hashring = ConsistentHashRing(hosts, hash_type='fnv1a_ch')
         self.assertEqual(hashring.compute_ring_position('hosts.worker1.cpu'), 59573)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker1.load'), 57163)
         self.assertEqual(hashring.compute_ring_position('hosts.worker2.cpu'), 35749)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker2.network'), 43584)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker3.cpu'), 12600)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker3.irq'), 10052)
+        self.assertEqual(hashring.compute_ring_position(u'a\xac\u1234\u20ac\U00008000'), 38658)
 
     def test_chr_get_node_fnv1a(self):
         hosts = [("127.0.0.1", "ba603c36342304ed77953f84ac4d357b"), ("127.0.0.2", "5dd63865534f84899c6e5594dba6749a"),


### PR DESCRIPTION
Backports the following commits to 1.1.x:
 - always use bytes when computing fnv32a hashes (#2168)
 - sync hashing.py with carbon (#2168)
 - tidy up compactHash (#2168)
 - fix typo in aggregate arg definition (#2169)
 - tweak function docs (#2172)
 - fix build-index (#2178)
 - clarify function plugin docs (#2177)
 - Add a README and examples for invoking test harness by hand  (#2176)
 - graphite: add support for raven/sentry.io (optional) (#2180)
 - improve efficiency of standard finder (#2185)
 - always pass use_bin_type=True to msgpack.dump(s) (2cd94ba)