### PR TITLE
Rename timeout settings

### DIFF
--- a/docs/config-local-settings.rst
+++ b/docs/config-local-settings.rst
@@ -180,6 +180,16 @@ STORAGE_FINDERS
   It is possible to use an alternate storage layer than the default, Whisper, in order to accommodate specific needs.
   See: http://graphite.readthedocs.io/en/latest/storage-backends.html
 
+FETCH_TIMEOUT
+  `Default: 6`
+
+  Timeout for data fetches in seconds.
+
+FIND_TIMEOUT
+  `Default: 3`
+
+  Timeout for find requests (metric browsing) in seconds.
+
 TAGDB
   `Default: 'graphite.tags.localdatabase.LocalDatabaseTagDB'`
   Tag database driver to use, other options include `graphite.tags.redis.RedisTagDB`
@@ -408,16 +418,6 @@ POOL_MAX_WORKERS
   `Default: 10`
 
    The maximum number of worker threads that should be created.
-
-REMOTE_FETCH_TIMEOUT
-  `Default: 6`
-
-  Timeout for remote data fetches in seconds.
-
-REMOTE_FIND_TIMEOUT
-  `Default: 2.5`
-
-  Timeout for remote find requests (metric browsing) in seconds.
 
 REMOTE_RETRY_DELAY
   `Default: 60`

--- a/webapp/graphite/finders/remote.py
+++ b/webapp/graphite/finders/remote.py
@@ -104,7 +104,7 @@ class RemoteFinder(BaseFinder):
                 url,
                 fields=query_params,
                 headers=query.headers,
-                timeout=settings.REMOTE_FIND_TIMEOUT)
+                timeout=settings.FIND_TIMEOUT)
 
             try:
                 if result.getheader('content-type') == 'application/x-msgpack':
@@ -163,7 +163,7 @@ class RemoteFinder(BaseFinder):
               ('local', self.params.get('local', '1')),
             ],
             headers=headers,
-            timeout=settings.REMOTE_FIND_TIMEOUT)
+            timeout=settings.FIND_TIMEOUT)
 
         try:
             reader = codecs.getreader('utf-8')
@@ -197,7 +197,7 @@ class RemoteFinder(BaseFinder):
             '/tags/autoComplete/tags',
             fields,
             headers=requestContext.get('forwardHeaders') if requestContext else None,
-            timeout=settings.REMOTE_FIND_TIMEOUT)
+            timeout=settings.FIND_TIMEOUT)
         try:
             reader = codecs.getreader('utf-8')
             results = json.load(reader(result))
@@ -231,7 +231,7 @@ class RemoteFinder(BaseFinder):
             '/tags/autoComplete/values',
             fields,
             headers=requestContext.get('forwardHeaders') if requestContext else None,
-            timeout=settings.REMOTE_FIND_TIMEOUT)
+            timeout=settings.FIND_TIMEOUT)
         try:
             reader = codecs.getreader('utf-8')
             results = json.load(reader(result))

--- a/webapp/graphite/local_settings.py.example
+++ b/webapp/graphite/local_settings.py.example
@@ -90,6 +90,10 @@ DEFAULT_XFILES_FACTOR = 0
 # Interval for the Auto-Refresh feature in the Composer, measured in seconds.
 #AUTO_REFRESH_INTERVAL = 60
 
+# Timeouts for find and render requests
+#FIND_TIMEOUT = 3.0  # Timeout for metric find requests
+#FETCH_TIMEOUT = 3.0  # Timeout to fetch series data
+
 #####################################
 # Filesystem Paths #
 #####################################
@@ -274,10 +278,8 @@ DEFAULT_XFILES_FACTOR = 0
 # This setting controls whether https is used to communicate between cluster members
 #INTRACLUSTER_HTTPS = False
 
-# These are timeout values (in seconds) for requests to remote webapps
-#REMOTE_FIND_TIMEOUT = 3.0           # Timeout for metric find requests
-#REMOTE_FETCH_TIMEOUT = 3.0          # Timeout to fetch series data
-#REMOTE_RETRY_DELAY = 60.0           # Time before retrying a failed remote webapp
+# Time before retrying a failed remote webapp
+#REMOTE_RETRY_DELAY = 60.0
 
 # Try to detect when a cluster server is localhost and don't forward queries
 #REMOTE_EXCLUDE_LOCAL = False

--- a/webapp/graphite/readers/remote.py
+++ b/webapp/graphite/readers/remote.py
@@ -61,7 +61,7 @@ class RemoteReader(BaseReader):
                 '/render/',
                 fields=query_params,
                 headers=headers,
-                timeout=settings.REMOTE_FETCH_TIMEOUT,
+                timeout=settings.FETCH_TIMEOUT,
             )
             break
           except Exception:

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -54,6 +54,10 @@ WHISPER_DIR = ''
 RRD_DIR = ''
 STANDARD_DIRS = []
 
+# Timeout settings
+FIND_TIMEOUT = None  # default 3.0 see below
+FETCH_TIMEOUT = None  # default 6.0 see below
+
 # Cluster settings
 CLUSTER_SERVERS = []
 
@@ -63,8 +67,8 @@ POOL_MAX_WORKERS = 10
 
 # This settings control whether https is used to communicate between cluster members
 INTRACLUSTER_HTTPS = False
-REMOTE_FIND_TIMEOUT = 3.0
-REMOTE_FETCH_TIMEOUT = 3.0
+REMOTE_FIND_TIMEOUT = None  # Replaced by FIND_TIMEOUT
+REMOTE_FETCH_TIMEOUT = None  # Replaced by FETCH_TIMEOUT
 REMOTE_RETRY_DELAY = 60.0
 REMOTE_EXCLUDE_LOCAL = False
 REMOTE_STORE_MERGE_RESULTS = True
@@ -209,6 +213,10 @@ if not GRAPHITE_WEB_APP_SETTINGS_LOADED:
 STATICFILES_DIRS = (
     join(WEBAPP_DIR, 'content'),
 )
+
+# Handle renamed timeout settings
+FIND_TIMEOUT = FIND_TIMEOUT or REMOTE_FIND_TIMEOUT or 3.0
+FETCH_TIMEOUT = FETCH_TIMEOUT or REMOTE_FETCH_TIMEOUT or 6.0
 
 ## Set config dependent on flags set in local_settings
 # Path configuration

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -122,7 +122,7 @@ class Store(object):
         # Start fetches
         start = time.time()
         try:
-          for job in self.pool_exec(jobs, settings.REMOTE_FETCH_TIMEOUT):
+          for job in self.pool_exec(jobs, settings.FETCH_TIMEOUT):
             done += 1
 
             if job.exception:
@@ -199,7 +199,7 @@ class Store(object):
         # Start index lookups
         start = time.time()
         try:
-          for job in self.pool_exec(jobs, settings.REMOTE_FETCH_TIMEOUT):
+          for job in self.pool_exec(jobs, settings.FETCH_TIMEOUT):
             done += 1
 
             if job.exception:
@@ -264,7 +264,7 @@ class Store(object):
         # Start finds
         start = time.time()
         try:
-          for job in self.pool_exec(jobs, settings.REMOTE_FIND_TIMEOUT):
+          for job in self.pool_exec(jobs, settings.FIND_TIMEOUT):
             done += 1
 
             if job.exception:
@@ -420,7 +420,7 @@ class Store(object):
           return self.tagdb.auto_complete_tags(exprs, tagPrefix=tagPrefix, limit=limit, requestContext=requestContext)
 
         # start finder jobs
-        jobs = self.pool_exec(jobs, settings.REMOTE_FIND_TIMEOUT)
+        jobs = self.pool_exec(jobs, settings.FIND_TIMEOUT)
 
         results = set()
 
@@ -482,7 +482,7 @@ class Store(object):
           return self.tagdb.auto_complete_values(exprs, tag, valuePrefix=valuePrefix, limit=limit, requestContext=requestContext)
 
         # start finder jobs
-        jobs = self.pool_exec(jobs, settings.REMOTE_FIND_TIMEOUT)
+        jobs = self.pool_exec(jobs, settings.FIND_TIMEOUT)
 
         results = set()
 

--- a/webapp/graphite/tags/http.py
+++ b/webapp/graphite/tags/http.py
@@ -45,7 +45,7 @@ class HttpTagDB(BaseTagDB):
       self.base_url + url,
       fields=req_fields,
       headers=headers,
-      timeout=self.settings.REMOTE_FIND_TIMEOUT,
+      timeout=self.settings.FIND_TIMEOUT,
     )
 
     if result.status == 400:

--- a/webapp/tests/test_finders_remote.py
+++ b/webapp/tests/test_finders_remote.py
@@ -61,7 +61,7 @@ class RemoteFinderTest(TestCase):
     @patch('urllib3.PoolManager.request')
     @override_settings(INTRACLUSTER_HTTPS=False)
     @override_settings(REMOTE_STORE_USE_POST=True)
-    @override_settings(REMOTE_FIND_TIMEOUT=10)
+    @override_settings(FIND_TIMEOUT=10)
     def test_find_nodes(self, http_request):
       finder = RemoteFinder('127.0.0.1')
 
@@ -220,7 +220,7 @@ class RemoteFinderTest(TestCase):
     @patch('urllib3.PoolManager.request')
     @override_settings(INTRACLUSTER_HTTPS=True)
     @override_settings(REMOTE_STORE_USE_POST=True)
-    @override_settings(REMOTE_FETCH_TIMEOUT=10)
+    @override_settings(FETCH_TIMEOUT=10)
     def test_RemoteFinder_fetch(self, http_request):
       test_finders = RemoteFinder.factory()
       finder = test_finders[0]
@@ -270,7 +270,7 @@ class RemoteFinderTest(TestCase):
     @patch('urllib3.PoolManager.request')
     @override_settings(INTRACLUSTER_HTTPS=False)
     @override_settings(REMOTE_STORE_USE_POST=True)
-    @override_settings(REMOTE_FIND_TIMEOUT=10)
+    @override_settings(FIND_TIMEOUT=10)
     def test_get_index(self, http_request):
       finder = RemoteFinder('127.0.0.1')
 
@@ -314,7 +314,7 @@ class RemoteFinderTest(TestCase):
     @override_settings(
       INTRACLUSTER_HTTPS=False,
       REMOTE_STORE_USE_POST=True,
-      REMOTE_FIND_TIMEOUT=10,
+      FIND_TIMEOUT=10,
       TAGDB_AUTOCOMPLETE_LIMIT=100)
     def test_auto_complete_tags(self, http_request):
       finder = RemoteFinder('127.0.0.1')
@@ -391,7 +391,7 @@ class RemoteFinderTest(TestCase):
     @override_settings(
       INTRACLUSTER_HTTPS=False,
       REMOTE_STORE_USE_POST=True,
-      REMOTE_FIND_TIMEOUT=10,
+      FIND_TIMEOUT=10,
       TAGDB_AUTOCOMPLETE_LIMIT=100)
     def test_auto_complete_values(self, http_request):
       finder = RemoteFinder('127.0.0.1')

--- a/webapp/tests/test_readers_remote.py
+++ b/webapp/tests/test_readers_remote.py
@@ -38,7 +38,7 @@ class RemoteReaderTests(TestCase):
     @mock.patch('django.conf.settings.CLUSTER_SERVERS', ['127.0.0.1', 'http://8.8.8.8/graphite?format=msgpack&local=0'])
     @mock.patch('django.conf.settings.INTRACLUSTER_HTTPS', False)
     @mock.patch('django.conf.settings.REMOTE_STORE_USE_POST', False)
-    @mock.patch('django.conf.settings.REMOTE_FETCH_TIMEOUT', 10)
+    @mock.patch('django.conf.settings.FETCH_TIMEOUT', 10)
     def test_RemoteReader_fetch_multi(self, http_request):
         test_finders = RemoteFinder.factory()
         finder = test_finders[0]
@@ -186,7 +186,7 @@ class RemoteReaderTests(TestCase):
     @mock.patch('django.conf.settings.CLUSTER_SERVERS', ['127.0.0.1', '8.8.8.8'])
     @mock.patch('django.conf.settings.INTRACLUSTER_HTTPS', False)
     @mock.patch('django.conf.settings.REMOTE_STORE_USE_POST', False)
-    @mock.patch('django.conf.settings.REMOTE_FETCH_TIMEOUT', 10)
+    @mock.patch('django.conf.settings.FETCH_TIMEOUT', 10)
     def test_RemoteReader_fetch(self, http_request):
         test_finders = RemoteFinder.factory()
         finder = test_finders[0]

--- a/webapp/tests/test_storage.py
+++ b/webapp/tests/test_storage.py
@@ -515,7 +515,7 @@ class StorageTest(TestCase):
     # test pool timeout handling
     store = mockStore([TestFinderTagsTimeout()])
 
-    with self.settings(USE_WORKER_POOL=True, REMOTE_FIND_TIMEOUT=0):
+    with self.settings(USE_WORKER_POOL=True, FIND_TIMEOUT=0):
       with self.assertRaisesRegexp(Exception, 'Timed out in autocomplete tags for \[\'tag1=value1\'\] test after [-.e0-9]+s'):
         store.tagdb_auto_complete_tags(['tag1=value1'], 'test', 100, request_context)
 


### PR DESCRIPTION
This PR renames the old `REMOTE_FIND_TIMEOUT` and `REMOTE_FETCH_TIMEOUT` settings to `FIND_TIMEOUT` and `FETCH_TIMEOUT` to better reflect how they're used in 1.1.x.  Backward compatibility is retained for anyone using the old names in `local_settings.py`.

It also increases the default setting for FETCH_TIMEOUT from 3 to 6 seconds.