### PR TITLE
Some changes to the "tools" page

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -69,6 +69,8 @@ Collection
 `SSC Serv`_
   A Windows service (agent) which periodically publishes system metrics, for example CPU, memory and disk usage. It can store data in Graphite using a naming schema that's identical to that used by collectd.
 
+`telegraf`_
+  Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics. It also supports metric output to Graphite.
 
 Forwarding
 ----------
@@ -242,7 +244,10 @@ Storage Backend Alternates
 If you wish to use a backend to graphite other than Whisper, there are some options available to you.
 
 `BigGraphite`_
-  A time-series database written in Python on top of Cassandra.
+  A time-series database written in Python on top of Cassandra. It integrates with Graphite as a plugin.
+
+`carbon-clickhouse`_
+  Graphite metrics receiver with `ClickHouse`_ as storage. You will also need `graphite-clickhouse`_ as backend for Graphite-web.
 
 `Ceres`_
   An alternate storage backend provided by the Graphite Project.  It it intended to be a distributable time-series database.  It is currently in a pre-release status.
@@ -250,19 +255,28 @@ If you wish to use a backend to graphite other than Whisper, there are some opti
 `Cyanite`_
   A highly available, elastic, and low-latency time-series storage wirtten on top of Cassandra
 
-`InfluxDB`_
-  A distributed time series database.
+`graphite-clickhouse`_
+  Graphite-web backend with `ClickHouse`_ support. Please also see `carbon-clickhouse`_.
 
-`KairosDB`_
-  A distributed time-series database written on top of Cassandra.
+`go-carbon`_
+  Golang implementation of Graphite/Carbon server with classic architecture: Agent -> Cache -> Persister.
 
-`OpenTSDB`_
-  A distributed time-series database written on top of HBase.
+`influxgraph`_
+  Graphite `InfluxDB`_ backend. `InfluxDB`_ storage finder / plugin for Graphite API.
+
+`Kenshin`_
+  A time-series database alternative to Graphite Whisper with 40x improvement in IOPS. It integrates with Graphite as a plugin.
+
+`metrictank`_
+  Cassandra-backed, metrics2.0 based, multi-tenant timeseries database for Graphite and friends.
 
 Other
 -----
 `bosun`_
   Time Series Alerting Framework. Can use Graphite as time series source.
+
+`carbonapi`_
+  3rd party reimplementation of graphite-web in Go, which supports a significant subset of graphite functions. In some testing it has shown to be 5x-10x faster than requesting data from graphite-web.
 
 `Bryans-Graphite-Tools`_
   A collection of miscellaneous scripts for pulling data from various devices, F5, Infoblox, Nutanix, etc.
@@ -273,8 +287,8 @@ Other
 `carbonate`_
   Utilities for managing graphite clusters.
 
-`go-carbon`_
-  Golang implementation of Graphite/Carbon server with classic architecture: Agent -> Cache -> Persister.
+`graphite-remote-adapter`_
+  Fully featured graphite remote adapter for `Prometheus`_.
 
 `riemann`_
   A network event stream processing system, in Clojure. Can use Graphite as source of event stream.
@@ -293,9 +307,12 @@ Other
 .. _buckytools: https://github.com/jjneely/buckytools
 .. _Cabot: https://github.com/arachnys/cabot
 .. _carbon-c-relay: https://github.com/grobian/carbon-c-relay
+.. _carbon-clickhouse: https://github.com/lomik/carbon-clickhouse
 .. _carbon-relay-ng: https://github.com/graphite-ng/carbon-relay-ng
+.. _carbonapi: https://github.com/go-graphite/carbonapi
 .. _carbonate: https://github.com/graphite-project/carbonate
 .. _Ceres: https://github.com/graphite-project/ceres
+.. _ClickHouse: https://clickhouse.yandex
 .. _Charcoal: https://github.com/cebailey59/charcoal
 .. _collectd: http://collectd.org
 .. _collectd-carbon: https://github.com/indygreg/collectd-carbon
@@ -319,9 +336,11 @@ Other
 .. _Graphene: http://jondot.github.com/graphene
 .. _Graphios: https://github.com/shawn-sterling/graphios
 .. _graphite-beacon: https://github.com/klen/graphite-beacon
+.. _graphite-clickhouse: https://github.com/lomik/graphite-clickhouse
 .. _graphite-dashboardcli: https://github.com/blacked/graphite-dashboardcli
 .. _Graphite-Newrelic: https://github.com/gingerlime/graphite-newrelic
 .. _Graphite-relay: https://github.com/markchadwick/graphite-relay
+.. _graphite-remote-adapter: https://github.com/criteo/graphite-remote-adapter
 .. _Graphite-Tattle: https://github.com/wayfair/Graphite-Tattle
 .. _graphite-to-zabbix: https://github.com/blacked/graphite-to-zabbix
 .. _Graphiti: https://github.com/paperlesspost/graphiti
@@ -338,21 +357,24 @@ Other
 .. _Hubot: https://github.com/github/hubot
 .. _hubot-scripts: https://github.com/github/hubot-scripts
 .. _InfluxDB: https://influxdb.com/
+.. _influxgraph: https://github.com/InfluxGraph/influxgraph
 .. _Icinga: http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/icinga2-features#graphite-carbon-cache-writer
 .. _jmx2graphite: https://github.com/logzio/jmx2graphite
 .. _jmxtrans: https://github.com/jmxtrans/jmxtrans
-.. _KairosDB: http://kairosdb.github.io/
+.. _Kenshin: https://github.com/douban/Kenshin
 .. _Ledbetter: https://github.com/github/ledbetter
 .. _Leonardo: https://github.com/PrFalken/leonardo
 .. _Logster: https://github.com/etsy/logster
 .. _OpenTSDB: http://opentsdb.net/
 .. _Orion: https://github.com/gree/Orion
 .. _metrics-sampler: https://github.com/dimovelev/metrics-sampler
+.. _metrictank: https://github.com/grafana/metrictank
 .. _Moira: http://moira.readthedocs.io
 .. _New Relic: https://newrelic.com/platform
 .. _Pencil: https://github.com/fetep/pencil
 .. _pipe-to-graphite: https://github.com/iFixit/pipe-to-graphite
 .. _Polymur: https://github.com/jamiealquiza/polymur
+.. _Prometheus: https://github.com/prometheus/prometheus
 .. _RabbitMQ: http://www.rabbitmq.com
 .. _rearview: http://github.com/livingsocial/rearview
 .. _Rickshaw: http://code.shutterstock.com/rickshaw
@@ -367,6 +389,7 @@ Other
 .. _statsd: https://github.com/etsy/statsd
 .. _Tasseo: https://github.com/obfuscurity/tasseo
 .. _Targets-io: https://github.com/dmoll1974/targets-io
+.. _telegraf: https://github.com/influxdata/telegraf
 .. _Terphite: https://github.com/benwtr/terphite
 .. _Tessera: https://github.com/urbanairship/tessera
 .. _Therry: https://github.com/obfuscurity/therry

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -261,6 +261,9 @@ If you wish to use a backend to graphite other than Whisper, there are some opti
 `go-carbon`_
   Golang implementation of Graphite/Carbon server with classic architecture: Agent -> Cache -> Persister.
 
+`Graphouse`_
+  Graphouse allows you to use `ClickHouse`_ as a Graphite storage.
+
 `influxgraph`_
   Graphite `InfluxDB`_ backend. `InfluxDB`_ storage finder / plugin for Graphite API.
 
@@ -346,6 +349,7 @@ Other
 .. _Graphiti: https://github.com/paperlesspost/graphiti
 .. _Graphitoid: https://market.android.com/details?id=com.tnc.android.graphite
 .. _graphitus: https://github.com/ezbz/graphitus
+.. _Graphouse: https://github.com/yandex/graphouse
 .. _Graphout: http://shamil.github.io/graphout
 .. _Graphsky: https://github.com/hyves-org/graphsky
 .. _Graph-Explorer: http://vimeo.github.io/graph-explorer


### PR DESCRIPTION
 Collectors:
  - `telegraf` was added
 Storage Backend Alternates:
  - removing KairosDB and OpenTSDB. They're nice products but not working with Graphite in compatible way.
  - InfluxDB replaced with `influxgraph` - Graphite storage plugin.
  - Added `carbon/graphite-clickhouse`, `go-carbon`, `Kenshin` and `metrictank`
 Other:
  - Added `graphite-remote-adapter` and `carbonapi`