### PR TITLE
Make it possible to fully disable tags

### DIFF
--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -43,12 +43,12 @@ class TimeSeries(list):
     else:
       self.tags = {'name': name}
       # parse for tags if a tagdb is configured and name doesn't look like a function-wrapped name
-      if STORE.tagdb and not re.match('^[a-z]+[(].+[)]$', name, re.IGNORECASE):
-        try:
+      try:
+        if STORE.tagdb and not re.match('^[a-z]+[(].+[)]$', name, re.IGNORECASE):
           self.tags = STORE.tagdb.parse(name).tags
-        except Exception as err:
-          # tags couldn't be parsed, just use "name" tag
-          log.debug("Couldn't parse tags for %s: %s" % (name, err))
+      except Exception as err:
+        # tags couldn't be parsed, just use "name" tag
+        log.debug("Couldn't parse tags for %s: %s" % (name, err))
 
   def __eq__(self, other):
     if not isinstance(other, TimeSeries):

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -66,7 +66,7 @@ class Store(object):
         self.finders = finders
 
         if tagdb is None:
-            tagdb = get_tagdb(settings.TAGDB or 'graphite.tags.localdatabase.LocalDatabaseTagDB')
+            tagdb = get_tagdb(settings.TAGDB or 'graphite.tags.base.DummyTagDB')
         self.tagdb = tagdb
 
     def get_finders(self, local=False):

--- a/webapp/graphite/tags/base.py
+++ b/webapp/graphite/tags/base.py
@@ -269,3 +269,27 @@ class BaseTagDB(object):
     spec = m.group(3)
 
     return (tag, operator, spec)
+
+
+class DummyTagDB(BaseTagDB):
+
+  def _find_series(self, tags, requestContext=None):
+    return []
+
+  def get_series(self, path, requestContext=None):
+    return None
+
+  def list_tags(self, tagFilter=None, limit=None, requestContext=None):
+    return []
+
+  def get_tag(self, tag, valueFilter=None, limit=None, requestContext=None):
+    return None
+
+  def list_values(self, tag, valueFilter=None, limit=None, requestContext=None):
+    return []
+
+  def tag_series(self, series, requestContext=None):
+    raise NotImplementedError('Tagging not implemented with DummyTagDB')
+
+  def del_series(self, series, requestContext=None):
+    return True


### PR DESCRIPTION
This allows one to set TAGDB to None to disable the
tagging code entirely.

Also catch more errors when trying to parse tags. For example
people using the old syntax for time (time(foo) instead of time("foo"))
would have `[]` as a name which would break the match