### PR TITLE
[1.1.x] Propagate `now` parameter for `fetch()` in whisper reader | Revert "Graphouse was added" | removing extra parameter in GzippedWhisperReader | Graphouse was added | proper sorting

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -264,6 +264,9 @@ If you wish to use a backend to graphite other than Whisper, there are some opti
 `go-carbon`_
   Golang implementation of Graphite/Carbon server with classic architecture: Agent -> Cache -> Persister.
 
+`Graphouse`_
+  Graphouse allows you to use `ClickHouse`_ as a Graphite storage.
+
 `influxgraph`_
   Graphite `InfluxDB`_ backend. `InfluxDB`_ storage finder / plugin for Graphite API.
 
@@ -350,6 +353,7 @@ Other
 .. _Graphiti: https://github.com/paperlesspost/graphiti
 .. _Graphitoid: https://market.android.com/details?id=com.tnc.android.graphite
 .. _graphitus: https://github.com/ezbz/graphitus
+.. _Graphouse: https://github.com/yandex/graphouse
 .. _Graphout: http://shamil.github.io/graphout
 .. _Graphsky: https://github.com/hyves-org/graphsky
 .. _Graph-Explorer: http://vimeo.github.io/graph-explorer

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -261,11 +261,11 @@ If you wish to use a backend to graphite other than Whisper, there are some opti
 `graphite-clickhouse`_
   Graphite-web backend with `ClickHouse`_ support. Please also see `carbon-clickhouse`_.
 
-`go-carbon`_
-  Golang implementation of Graphite/Carbon server with classic architecture: Agent -> Cache -> Persister.
-
 `Graphouse`_
   Graphouse allows you to use `ClickHouse`_ as a Graphite storage.
+
+`go-carbon`_
+  Golang implementation of Graphite/Carbon server with classic architecture: Agent -> Cache -> Persister.
 
 `influxgraph`_
   Graphite `InfluxDB`_ backend. `InfluxDB`_ storage finder / plugin for Graphite API.

--- a/webapp/graphite/readers/whisper.py
+++ b/webapp/graphite/readers/whisper.py
@@ -88,7 +88,7 @@ class GzippedWhisperReader(WhisperReader):
                 fh.close()
         return self.meta_info
 
-    def fetch_data(self, startTime, endTime, now=None, requestContext=None):
+    def fetch_data(self, startTime, endTime, now=None):
         fh = gzip.GzipFile(self.fs_path, 'rb')
         try:
             return whisper.file_fetch(fh, startTime, endTime, now=now)

--- a/webapp/graphite/readers/whisper.py
+++ b/webapp/graphite/readers/whisper.py
@@ -51,12 +51,12 @@ class WhisperReader(BaseReader):
         end = max(stat(self.fs_path).st_mtime, start)
         return IntervalSet([Interval(start, end)])
 
-    def fetch_data(self, startTime, endTime):
-        return whisper.fetch(self.fs_path, startTime, endTime)
+    def fetch_data(self, startTime, endTime, now=None):
+        return whisper.fetch(self.fs_path, startTime, endTime, now=now)
 
-    def fetch(self, startTime, endTime):
+    def fetch(self, startTime, endTime, now=None, requestContext=None):
         try:
-            data = self.fetch_data(startTime, endTime)
+            data = self.fetch_data(startTime, endTime, now=now)
         except IOError:
             log.exception("Failed fetch of whisper file '%s'" % self.fs_path)
             return None
@@ -88,9 +88,9 @@ class GzippedWhisperReader(WhisperReader):
                 fh.close()
         return self.meta_info
 
-    def fetch_data(self, startTime, endTime):
+    def fetch_data(self, startTime, endTime, now=None, requestContext=None):
         fh = gzip.GzipFile(self.fs_path, 'rb')
         try:
-            return whisper.file_fetch(fh, startTime, endTime)
+            return whisper.file_fetch(fh, startTime, endTime, now=now)
         finally:
             fh.close()


### PR DESCRIPTION
Backports the following commits to 1.1.x:
 - Propagate `now` parameter for `fetch()` in whisper reader (#2207)
 - Revert "Graphouse was added" (#2207)
 - removing extra parameter in GzippedWhisperReader (#2207)
 - Graphouse was added (#2208)
 - proper sorting (#2208)