### PR TITLE
[1.1.x] Make it possible to fully disable tags | Add support for leavesOnly in /metrics/find | storage: cleanup job pool usage

### DIFF
--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -56,6 +56,7 @@ def find_view(request):
   queryParams.update(request.POST)
 
   format = queryParams.get('format', 'treejson')
+  leaves_only = int( queryParams.get('leavesOnly', 0) )
   local_only = int( queryParams.get('local', 0) )
   wildcards = int( queryParams.get('wildcards', 0) )
 
@@ -116,7 +117,12 @@ def find_view(request):
       query = '.'.join(query_parts)
 
   try:
-    matches = list( STORE.find(query, fromTime, untilTime, local=local_only, headers=forward_headers) )
+    matches = list(STORE.find(
+      query, fromTime, untilTime,
+      local=local_only,
+      headers=forward_headers,
+      leaves_only=leaves_only,
+    ))
   except:
     log.exception()
     raise

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -43,12 +43,12 @@ class TimeSeries(list):
     else:
       self.tags = {'name': name}
       # parse for tags if a tagdb is configured and name doesn't look like a function-wrapped name
-      if STORE.tagdb and not re.match('^[a-z]+[(].+[)]$', name, re.IGNORECASE):
-        try:
+      try:
+        if STORE.tagdb and not re.match('^[a-z]+[(].+[)]$', name, re.IGNORECASE):
           self.tags = STORE.tagdb.parse(name).tags
-        except Exception as err:
-          # tags couldn't be parsed, just use "name" tag
-          log.debug("Couldn't parse tags for %s: %s" % (name, err))
+      except Exception as err:
+        # tags couldn't be parsed, just use "name" tag
+        log.debug("Couldn't parse tags for %s: %s" % (name, err))
 
   def __eq__(self, other):
     if not isinstance(other, TimeSeries):

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -75,6 +75,8 @@ REMOTE_STORE_MERGE_RESULTS = True
 REMOTE_STORE_FORWARD_HEADERS = []
 REMOTE_STORE_USE_POST = False
 REMOTE_BUFFER_SIZE = 1024 * 1024
+
+# Carbonlink settings
 CARBON_METRIC_PREFIX='carbon'
 CARBONLINK_HOSTS = ["127.0.0.1:7002"]
 CARBONLINK_TIMEOUT = 1.0
@@ -82,6 +84,8 @@ CARBONLINK_HASHING_KEYFUNC = None
 CARBONLINK_HASHING_TYPE = 'carbon_ch'
 CARBONLINK_RETRY_DELAY = 15
 REPLICATION_FACTOR = 1
+
+# Cache settings.
 MEMCACHE_HOSTS = []
 MEMCACHE_KEY_PREFIX = ''
 MEMCACHE_OPTIONS = {}
@@ -209,6 +213,7 @@ except ImportError:
 ## Load Django settings if they werent picked up in local_settings
 if not GRAPHITE_WEB_APP_SETTINGS_LOADED:
   from graphite.app_settings import *  # noqa
+
 
 STATICFILES_DIRS = (
     join(WEBAPP_DIR, 'content'),

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -66,7 +66,7 @@ class Store(object):
         self.finders = finders
 
         if tagdb is None:
-            tagdb = get_tagdb(settings.TAGDB or 'graphite.tags.localdatabase.LocalDatabaseTagDB')
+            tagdb = get_tagdb(settings.TAGDB or 'graphite.tags.base.DummyTagDB')
         self.tagdb = tagdb
 
     def get_finders(self, local=False):

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
 import os
-import time
 import random
 import sys
+import time
+import traceback
 import types
 
 from collections import defaultdict
@@ -82,11 +83,55 @@ class Store(object):
             yield finder
 
     def pool_exec(self, jobs, timeout):
+        if not jobs:
+            return []
+
         thread_count = 0
         if settings.USE_WORKER_POOL:
             thread_count = min(len(self.finders), settings.POOL_MAX_WORKERS)
 
         return pool_exec(get_pool('finders', thread_count), jobs, timeout)
+
+    def wait_jobs(self, jobs, timeout, context):
+        if not jobs:
+            return []
+
+        start = time.time()
+        results = []
+        failed = []
+        done = 0
+        try:
+            for job in self.pool_exec(jobs, timeout):
+                elapsed = time.time() - start
+                done += 1
+                if job.exception:
+                    failed.append(job)
+                    log.info("Exception during %s after %fs: %s" % (
+                        job, elapsed, str(job.exception))
+                    )
+                else:
+                    log.debug("Got a result for %s after %fs" % (job, elapsed))
+                    results.append(job.result)
+        except PoolTimeoutError:
+            message = "Timed out after %fs for %s" % (
+                time.time() - start, context
+            )
+            log.info(message)
+            if done == 0:
+                raise Exception(message)
+
+        if len(failed) == done:
+            message = "All requests failed for %s (%d)" % (
+                context, len(failed)
+            )
+            for job in failed:
+                message += "\n\n%s: %s: %s" % (
+                    job, job.exception,
+                    '\n'.join(traceback.format_exception(*job.exception_info))
+                )
+            raise Exception(message)
+
+        return results
 
     def fetch(self, patterns, startTime, endTime, now, requestContext):
         # deduplicate patterns
@@ -104,7 +149,12 @@ class Store(object):
         for finder in self.get_finders(requestContext.get('localOnly')):
           # if the finder supports tags, just pass the patterns through
           if getattr(finder, 'tags', False):
-            jobs.append(Job(finder.fetch, patterns, startTime, endTime, now=now, requestContext=requestContext))
+            job = Job(
+                finder.fetch, 'fetch for %s' % patterns,
+                patterns, startTime, endTime,
+                now=now, requestContext=requestContext
+            )
+            jobs.append(job)
             continue
 
           # if we haven't resolved the seriesByTag calls, build resolved patterns and translation table
@@ -112,33 +162,22 @@ class Store(object):
             tag_patterns, pattern_aliases = self._tag_patterns(patterns, requestContext)
 
           # dispatch resolved patterns to finder
-          jobs.append(Job(finder.fetch, tag_patterns, startTime, endTime, now=now, requestContext=requestContext))
-
-        results = []
+          job = Job(
+              finder.fetch,
+              'fetch for %s' % tag_patterns,
+              tag_patterns, startTime, endTime,
+              now=now, requestContext=requestContext
+          )
+          jobs.append(job)
 
         done = 0
         errors = 0
 
         # Start fetches
         start = time.time()
-        try:
-          for job in self.pool_exec(jobs, settings.FETCH_TIMEOUT):
-            done += 1
-
-            if job.exception:
-              errors += 1
-              log.info("Fetch for %s failed after %fs: %s" % (str(patterns), time.time() - start, str(job.exception)))
-              continue
-
-            log.debug("Got a fetch result for %s after %fs" % (str(patterns), time.time() - start))
-            results.extend(job.result)
-        except PoolTimeoutError:
-          log.info("Timed out in fetch after %fs" % (time.time() - start))
-
-        if errors == done:
-          if errors == 1:
-            raise Exception("Fetch for %s failed: %s" % (str(patterns), str(job.exception)))
-          raise Exception('All fetches failed for %s' % (str(patterns)))
+        results = self.wait_jobs(jobs, settings.FETCH_TIMEOUT,
+                                 'fetch for %s' % str(patterns))
+        results = [i for l in results for i in l]  # flatten
 
         # translate path expressions for responses from resolved seriesByTag patterns
         for result in results:
@@ -186,36 +225,15 @@ class Store(object):
         if not requestContext:
           requestContext = {}
 
+        context = 'get_index'
         jobs = [
-            Job(finder.get_index, requestContext=requestContext)
+            Job(finder.get_index, context, requestContext=requestContext)
             for finder in self.get_finders(local=requestContext.get('localOnly'))
         ]
 
-        results = []
-
-        done = 0
-        errors = 0
-
-        # Start index lookups
         start = time.time()
-        try:
-          for job in self.pool_exec(jobs, settings.FETCH_TIMEOUT):
-            done += 1
-
-            if job.exception:
-              errors += 1
-              log.info("get_index failed after %fs: %s" % (time.time() - start, str(job.exception)))
-              continue
-
-            log.debug("Got an index result after %fs" % (time.time() - start))
-            results.extend(job.result)
-        except PoolTimeoutError:
-          log.info("Timed out in get_index after %fs" % (time.time() - start))
-
-        if errors == done:
-          if errors == 1:
-            raise Exception("get_index failed: %s" % (str(job.exception)))
-          raise Exception('All index lookups failed')
+        results = self.wait_jobs(jobs, settings.FETCH_TIMEOUT, context)
+        results = [i for l in results if l is not None for i in l]  # flatten
 
         log.debug("Got all index results in %fs" % (time.time() - start))
         return sorted(list(set(results)))
@@ -250,40 +268,25 @@ class Store(object):
                      pattern, matched_leafs, warn_threshold))
 
     def _find(self, query):
+        context = 'find %s' % query
         jobs = [
-            Job(finder.find_nodes, query)
+            Job(finder.find_nodes, context, query)
             for finder in self.get_finders(query.local)
         ]
 
         # Group matching nodes by their path
         nodes_by_path = defaultdict(list)
 
-        done = 0
-        errors = 0
-
         # Start finds
         start = time.time()
-        try:
-          for job in self.pool_exec(jobs, settings.FIND_TIMEOUT):
-            done += 1
+        results = self.wait_jobs(jobs, settings.FIND_TIMEOUT, context)
+        for result in results:
+            for node in result or []:
+                nodes_by_path[node.path].append(node)
 
-            if job.exception:
-              errors += 1
-              log.info("Find for %s failed after %fs: %s" % (str(query), time.time() - start, str(job.exception)))
-              continue
-
-            log.debug("Got a find result for %s after %fs" % (str(query), time.time() - start))
-            for node in job.result or []:
-              nodes_by_path[node.path].append(node)
-        except PoolTimeoutError:
-          log.info("Timed out in find after %fs" % (time.time() - start))
-
-        if errors == done:
-          if errors == 1:
-            raise Exception("Find for %s failed: %s" % (str(query), str(job.exception)))
-          raise Exception('All finds failed for %s' % (str(query)))
-
-        log.debug("Got all find results for %s in %fs" % (str(query), time.time() - start))
+        log.debug("Got all find results for %s in %fs" % (
+            str(query), time.time() - start)
+        )
         return self._list_nodes(query, nodes_by_path)
 
     def _list_nodes(self, query, nodes_by_path):
@@ -405,59 +408,44 @@ class Store(object):
         if requestContext is None:
           requestContext = {}
 
+        context = 'tags for %s %s' % (str(exprs), tagPrefix or '')
         jobs = []
         use_tagdb = False
         for finder in self.get_finders(requestContext.get('localOnly')):
           if getattr(finder, 'tags', False):
-            jobs.append(Job(finder.auto_complete_tags, exprs, tagPrefix=tagPrefix, limit=limit, requestContext=requestContext))
+            job = Job(
+                finder.auto_complete_tags, context,
+                exprs, tagPrefix=tagPrefix,
+                limit=limit, requestContext=requestContext
+            )
+            jobs.append(job)
           else:
             use_tagdb = True
 
-        if not jobs:
-          if not use_tagdb:
-            return []
-
-          return self.tagdb.auto_complete_tags(exprs, tagPrefix=tagPrefix, limit=limit, requestContext=requestContext)
-
-        # start finder jobs
-        jobs = self.pool_exec(jobs, settings.FIND_TIMEOUT)
 
         results = set()
 
-        # if we're using the local tagdb then execute it (in the main thread so that LocalDatabaseTagDB will work)
+        # if we're using the local tagdb then execute it (in the main thread
+        # so that LocalDatabaseTagDB will work)
         if use_tagdb:
-          results.update(self.tagdb.auto_complete_tags(exprs, tagPrefix=tagPrefix, limit=limit, requestContext=requestContext))
-
-        done = 0
-        errors = 0
+          results.update(self.tagdb.auto_complete_tags(
+              exprs, tagPrefix=tagPrefix,
+              limit=limit, requestContext=requestContext
+          ))
 
         # Start fetches
         start = time.time()
-        try:
-          for job in jobs:
-            done += 1
-
-            if job.exception:
-              errors += 1
-              log.info("Autocomplete tags for %s %s failed after %fs: %s" % (str(exprs), tagPrefix or '', time.time() - start, str(job.exception)))
-              continue
-
-            log.debug("Got an autocomplete result for %s %s after %fs" % (str(exprs), tagPrefix or '', time.time() - start))
-            results.update(job.result)
-        except PoolTimeoutError:
-          raise Exception("Timed out in autocomplete tags for %s %s after %fs" % (str(exprs), tagPrefix or '', time.time() - start))
-
-        if errors == done:
-          if errors == 1:
-            raise Exception("Autocomplete tags for %s %s failed: %s" % (str(exprs), tagPrefix or '', str(job.exception)))
-          raise Exception('All autocomplete tag requests failed for %s %s' % (str(exprs), tagPrefix or ''))
+        for result in self.wait_jobs(jobs, settings.FIND_TIMEOUT, context):
+            results.update(result)
 
         # sort & limit results
         results = sorted(results)
         if limit:
           results = results[:int(limit)]
 
-        log.debug("Got all autocomplete tag results for %s %s in %fs" % (str(exprs), tagPrefix or '', time.time() - start))
+        log.debug("Got all autocomplete %s in %fs" % (
+            context, time.time() - start)
+        )
         return results
 
     def tagdb_auto_complete_values(self, exprs, tag, valuePrefix=None, limit=None, requestContext=None):
@@ -467,59 +455,43 @@ class Store(object):
         if requestContext is None:
           requestContext = {}
 
+        context = 'values for %s %s %s' % (str(exprs), tag, valuePrefix or '')
         jobs = []
         use_tagdb = False
         for finder in self.get_finders(requestContext.get('localOnly')):
           if getattr(finder, 'tags', False):
-            jobs.append(Job(finder.auto_complete_values, exprs, tag, valuePrefix=valuePrefix, limit=limit, requestContext=requestContext))
+            job = Job(
+                finder.auto_complete_values, context,
+                exprs, tag, valuePrefix=valuePrefix,
+                limit=limit, requestContext=requestContext
+            )
+            jobs.append(job)
           else:
             use_tagdb = True
 
-        if not jobs:
-          if not use_tagdb:
-            return []
-
-          return self.tagdb.auto_complete_values(exprs, tag, valuePrefix=valuePrefix, limit=limit, requestContext=requestContext)
-
         # start finder jobs
-        jobs = self.pool_exec(jobs, settings.FIND_TIMEOUT)
-
+        start = time.time()
         results = set()
 
-        # if we're using the local tagdb then execute it (in the main thread so that LocalDatabaseTagDB will work)
+        # if we're using the local tagdb then execute it (in the main thread
+        # so that LocalDatabaseTagDB will work)
         if use_tagdb:
-          results.update(self.tagdb.auto_complete_values(exprs, tag, valuePrefix=valuePrefix, limit=limit, requestContext=requestContext))
+          results.update(self.tagdb.auto_complete_values(
+              exprs, tag, valuePrefix=valuePrefix,
+              limit=limit, requestContext=requestContext
+          ))
 
-        done = 0
-        errors = 0
-
-        # Start fetches
-        start = time.time()
-        try:
-          for job in jobs:
-            done += 1
-
-            if job.exception:
-              errors += 1
-              log.info("Autocomplete values for %s %s %s failed after %fs: %s" % (str(exprs), tag, valuePrefix or '', time.time() - start, str(job.exception)))
-              continue
-
-            log.debug("Got an autocomplete result for %s %s %s after %fs" % (str(exprs), tag, valuePrefix or '', time.time() - start))
-            results.update(job.result)
-        except PoolTimeoutError:
-          raise Exception("Timed out in autocomplete values for %s %s %s after %fs" % (str(exprs), tag, valuePrefix or '', time.time() - start))
-
-        if errors == done:
-          if errors == 1:
-            raise Exception("Autocomplete values for %s %s %s failed: %s" % (str(exprs), tag, valuePrefix or '', str(job.exception)))
-          raise Exception('All autocomplete value requests failed for %s %s %s' % (str(exprs), tag, valuePrefix or ''))
+        for result in self.wait_jobs(jobs, settings.FIND_TIMEOUT, context):
+            results.update(result)
 
         # sort & limit results
         results = sorted(results)
         if limit:
           results = results[:int(limit)]
 
-        log.debug("Got all autocomplete value results for %s %s %s in %fs" % (str(exprs), tag, valuePrefix or '', time.time() - start))
+        log.debug("Got all autocomplete %s in %fs" % (
+            context, time.time() - start)
+        )
         return results
 
 

--- a/webapp/graphite/tags/base.py
+++ b/webapp/graphite/tags/base.py
@@ -269,3 +269,27 @@ class BaseTagDB(object):
     spec = m.group(3)
 
     return (tag, operator, spec)
+
+
+class DummyTagDB(BaseTagDB):
+
+  def _find_series(self, tags, requestContext=None):
+    return []
+
+  def get_series(self, path, requestContext=None):
+    return None
+
+  def list_tags(self, tagFilter=None, limit=None, requestContext=None):
+    return []
+
+  def get_tag(self, tag, valueFilter=None, limit=None, requestContext=None):
+    return None
+
+  def list_values(self, tag, valueFilter=None, limit=None, requestContext=None):
+    return []
+
+  def tag_series(self, series, requestContext=None):
+    raise NotImplementedError('Tagging not implemented with DummyTagDB')
+
+  def del_series(self, series, requestContext=None):
+    return True

--- a/webapp/graphite/worker_pool/pool.py
+++ b/webapp/graphite/worker_pool/pool.py
@@ -1,5 +1,7 @@
-import six.moves.queue
 import time
+import sys
+
+import six.moves.queue
 
 from threading import Lock
 from multiprocessing.pool import ThreadPool
@@ -19,20 +21,29 @@ class Job(object):
 
   If the function raises an exception, it will be stored in the exception property of the job.
   """
-  __slots__ = ('func', 'args', 'kwargs', 'result', 'exception')
+  __slots__ = (
+    'func', 'description',
+    'args', 'kwargs', 'result',
+    'exception', 'exception_info',
+  )
 
-  def __init__(self, func, *args, **kwargs):
+  def __init__(self, func, description, *args, **kwargs):
     self.func = func
     self.args = args
+    self.description = description
     self.kwargs = kwargs
     self.result = None
     self.exception = None
 
+  def __str__(self):
+    return self.description
+
   def run(self):
     try:
       self.result = self.func(*self.args, **self.kwargs)
-    except Exception as err:
-      self.exception = err
+    except Exception as e:
+      self.exception_info = sys.exc_info()
+      self.exception = e
 
 
 def get_pool(name="default", thread_count=1):

--- a/webapp/tests/test_worker_pool.py
+++ b/webapp/tests/test_worker_pool.py
@@ -22,7 +22,7 @@ class TestPool(unittest.TestCase):
         def testfunc():
           raise err
 
-        results = pool.pool_exec(p, [pool.Job(testfunc)], 1)
+        results = pool.pool_exec(p, [pool.Job(testfunc, 'job')], 1)
 
         self.assertEqual(list(results)[0].exception, err)
 
@@ -34,7 +34,7 @@ class TestPool(unittest.TestCase):
 
         self.assertNotEqual(default, p)
 
-        results = pool.pool_exec(p, [pool.Job(lambda v: v, 'a')], 1)
+        results = pool.pool_exec(p, [pool.Job(lambda v: v, 'job', 'a')], 1)
 
         self.assertEqual(list(results)[0].result, 'a')
 
@@ -49,14 +49,14 @@ class TestPool(unittest.TestCase):
         self.assertIsNone(p)
         self.assertIsNone(default)
 
-        results = pool.pool_exec(p, [pool.Job(lambda v: v, 'a')], 1)
+        results = pool.pool_exec(p, [pool.Job(lambda v: v, 'job', 'a')], 1)
 
         self.assertEqual(list(results)[0].result, 'a')
 
     def test_timeout(self):
         p = pool.get_pool(thread_count=2)
 
-        jobs = [pool.Job(lambda v: time.sleep(1) and v, i) for i in range(1, 5)]
+        jobs = [pool.Job(lambda v: time.sleep(1) and v, 'job', i) for i in range(1, 5)]
 
         with self.assertRaises(pool.PoolTimeoutError):
           results = pool.pool_exec(p, jobs, 1)
@@ -66,7 +66,7 @@ class TestPool(unittest.TestCase):
     def test_timeout_sync(self):
         p = pool.get_pool(thread_count=0)
 
-        jobs = [pool.Job(lambda v: time.sleep(1) and v, i) for i in range(1, 5)]
+        jobs = [pool.Job(lambda v: time.sleep(1) and v, 'job', i) for i in range(1, 5)]
 
         with self.assertRaises(pool.PoolTimeoutError):
           results = pool.pool_exec(p, jobs, 1)


### PR DESCRIPTION
Backports the following commits to 1.1.x:
 - Make it possible to fully disable tags (#2206)
 - Add support for leavesOnly in /metrics/find (#2181)
 - storage: cleanup job pool usage (#2181)