### PR TITLE
[1.1.x] functions: fix groupByNode() ouput (and others) | Update config-carbon.rst | Update config-carbon.rst | Update config-carbon.rst

### DIFF
--- a/docs/config-carbon.rst
+++ b/docs/config-carbon.rst
@@ -100,6 +100,7 @@ Important notes before continuing:
 
 * This file is optional.  If it is not present, defaults will be used.
 * The sections are applied in order from the top (first) and bottom (last).
+* The first pattern that matches the metric name is used.
 * There is no ``retentions`` line.  Instead, there are ``xFilesFactor`` and/or ``aggregationMethod`` lines.
 * ``xFilesFactor`` should be a floating point number between 0 and 1, and specifies what fraction of the previous retention level's slots must have non-null values in order to aggregate to a non-null value.  The default is 0.5.
 * ``aggregationMethod`` specifies the function used to aggregate values for the next retention level.  Legal methods are ``average``, ``sum``, ``min``, ``max``, and ``last``. The default is ``average``.

--- a/docs/config-carbon.rst
+++ b/docs/config-carbon.rst
@@ -99,8 +99,8 @@ This file defines how to aggregate data to lower-precision retentions.  The form
 Important notes before continuing:
 
 * This file is optional.  If it is not present, defaults will be used.
-* The sections are applied in order from the top (first) and bottom (last).
-* The first pattern that matches the metric name is used.
+* The sections are applied in order from the top (first) and bottom (last), similar to ``storage-schemas.conf``.
+* The first pattern that matches the metric name is used, similar to ``storage-schemas.conf``.
 * There is no ``retentions`` line.  Instead, there are ``xFilesFactor`` and/or ``aggregationMethod`` lines.
 * ``xFilesFactor`` should be a floating point number between 0 and 1, and specifies what fraction of the previous retention level's slots must have non-null values in order to aggregate to a non-null value.  The default is 0.5.
 * ``aggregationMethod`` specifies the function used to aggregate values for the next retention level.  Legal methods are ``average``, ``sum``, ``min``, ``max``, and ``last``. The default is ``average``.

--- a/docs/config-carbon.rst
+++ b/docs/config-carbon.rst
@@ -99,6 +99,7 @@ This file defines how to aggregate data to lower-precision retentions.  The form
 Important notes before continuing:
 
 * This file is optional.  If it is not present, defaults will be used.
+* The sections are applied in order from the top (first) and bottom (last).
 * There is no ``retentions`` line.  Instead, there are ``xFilesFactor`` and/or ``aggregationMethod`` lines.
 * ``xFilesFactor`` should be a floating point number between 0 and 1, and specifies what fraction of the previous retention level's slots must have non-null values in order to aggregate to a non-null value.  The default is 0.5.
 * ``aggregationMethod`` specifies the function used to aggregate values for the next retention level.  Legal methods are ``average``, ``sum``, ``min``, ``max``, and ``last``. The default is ``average``.

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -192,6 +192,9 @@ def getNodeOrTag(series, n, pathExpression=None):
   return series.tags.get(str(n), '')
 
 def aggKey(series, nodes, pathExpression=None):
+  # if series.name looks like it includes a function, use the first path expression
+  if pathExpression is None and series.name[-1] == ')':
+    pathExpression = _getFirstPathExpression(series.name)
   return '.'.join([getNodeOrTag(series, n, pathExpression) for n in nodes])
 
 def normalize(seriesLists):
@@ -2376,8 +2379,7 @@ def aliasByNode(requestContext, seriesList, *nodes):
     # dc1.server1.load5, dc1.server2.load5, dc1.server1.load10, dc1.server2.load10
   """
   for series in seriesList:
-    pathExpression = _getFirstPathExpression(series.name)
-    series.name = aggKey(series, nodes, pathExpression)
+    series.name = aggKey(series, nodes)
   return seriesList
 
 aliasByNode.group = 'Alias'

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -37,6 +37,11 @@ def return_less(series, value):
 
 class FunctionsTest(TestCase):
 
+    def setUp(self):
+      super(FunctionsTest, self).setUp()
+      # Display more diff.
+      self.maxDiff = 1024
+
     #
     # Test safeSum()
     #
@@ -2931,7 +2936,7 @@ class FunctionsTest(TestCase):
     def test_groupByNode(self):
         seriesList, inputList = self._generate_mr_series()
 
-        def verify_groupByNode(expectedResult, nodeNum):
+        def verify_groupByNode(expectedResult, nodeNum, seriesList):
             results = functions.groupByNode({}, copy.deepcopy(seriesList), nodeNum, "keepLastValue")
 
             self.assertEqual(results, expectedResult)
@@ -2939,13 +2944,33 @@ class FunctionsTest(TestCase):
         expectedResult   = [
             TimeSeries('group',0,1,1,[None]),
         ]
-        verify_groupByNode(expectedResult, 0)
+        verify_groupByNode(expectedResult, 0, seriesList)
 
         expectedResult   = [
             TimeSeries('server1',0,1,1,[None]),
             TimeSeries('server2',0,1,1,[None]),
         ]
-        verify_groupByNode(expectedResult, 1)
+        verify_groupByNode(expectedResult, 1, seriesList)
+
+        # Additiona tests
+        seriesList = []
+        names = [
+            "collectd.test-db1.load.value",
+            "sum(collectd.test-db1.load.value)",
+            "sum(sum(collectd.test-db1.load.value))",
+            "divide(collectd.test-db1.load.value, 5)",
+            "scaleToSeconds(divide(collectd.test-db1.load.value, 5),1)",
+        ]
+        expectedResult = []
+        for name in names:
+            series = TimeSeries(name, 0, 1, 1, [1])
+            seriesList.append(series)
+        for expected in ["value"] * len(names):
+            series = TimeSeries(expected, 0, 1, 1, [1])
+            expectedResult.append(series)
+        for i, series in enumerate(seriesList):
+          verify_groupByNode([expectedResult[i]], 3, [series])
+
 
     def test_groupByNodes(self):
         seriesList, inputList = self._generate_mr_series()


### PR DESCRIPTION
Backports the following commits to 1.1.x:
 - functions: fix groupByNode() ouput (and others) (#2213)
 - Update config-carbon.rst (#2215)
 - Update config-carbon.rst (#2215)
 - Update config-carbon.rst (#2215)