### PR TITLE
Support for storing tagged series in hashed filenames

### DIFF
--- a/webapp/graphite/finders/ceres.py
+++ b/webapp/graphite/finders/ceres.py
@@ -25,15 +25,17 @@ class CeresFinder(BaseFinder):
         self.tree = CeresTree(directory)
 
     def find_nodes(self, query):
-
         # translate query pattern if it is tagged
         tagged = not query.pattern.startswith('_tagged.') and ';' in query.pattern
         if tagged:
-          # tagged series are stored in ceres using encoded names, so to retrieve them we need to encode the
-          # query pattern using the same scheme used in carbon when they are written.
-          variants = [TaggedSeries.encode(query.pattern)]
+            # tagged series are stored in ceres using encoded names, so to retrieve them we need to
+            # encode the query pattern using the same scheme used in carbon when they are written.
+            variants = [
+                TaggedSeries.encode(query.pattern, hash_only=True),
+                TaggedSeries.encode(query.pattern, hash_only=False),
+            ]
         else:
-          variants = extract_variants(query.pattern)
+            variants = extract_variants(query.pattern)
 
         for variant in variants:
             for fs_path in glob(self.tree.getFilesystemPath(variant)):
@@ -42,14 +44,12 @@ class CeresFinder(BaseFinder):
                 if CeresNode.isNodeDir(fs_path):
                     ceres_node = self.tree.getNode(metric_path)
 
-                    if ceres_node.hasDataForInterval(
-                            query.startTime, query.endTime):
-                        real_metric_path = get_real_metric_path(
-                            fs_path, metric_path)
+                    if ceres_node.hasDataForInterval(query.startTime, query.endTime):
+                        real_metric_path = get_real_metric_path(fs_path, metric_path)
                         reader = CeresReader(ceres_node, real_metric_path)
                         # if we're finding by tag, return the proper metric path
                         if tagged:
-                          metric_path = query.pattern
+                            metric_path = query.pattern
                         yield LeafNode(metric_path, reader)
 
                 elif os.path.isdir(fs_path):
@@ -59,12 +59,12 @@ class CeresFinder(BaseFinder):
         matches = []
 
         for root, _, files in walk(settings.CERES_DIR):
-          root = root.replace(settings.CERES_DIR, '')
-          for filename in files:
-            if filename == '.ceres-node':
-              matches.append(root)
+            root = root.replace(settings.CERES_DIR, '')
+            for filename in files:
+                if filename == '.ceres-node':
+                    matches.append(root)
 
         return sorted([
-          m.replace('/', '.').lstrip('.')
-          for m in matches
+            m.replace('/', '.').lstrip('.')
+            for m in matches
         ])

--- a/webapp/graphite/finders/standard.py
+++ b/webapp/graphite/finders/standard.py
@@ -1,6 +1,5 @@
 import bisect
 import fnmatch
-import operator
 import os
 from os.path import isdir, isfile, join, basename, splitext
 from django.conf import settings

--- a/webapp/graphite/tags/utils.py
+++ b/webapp/graphite/tags/utils.py
@@ -67,7 +67,7 @@ class TaggedSeries(object):
     ]))
 
   @staticmethod
-  def encode(metric, sep='.'):
+  def encode(metric, sep='.', hash_only=False):
     """
     Helper function to encode tagged series for storage in whisper etc
 
@@ -80,6 +80,10 @@ class TaggedSeries(object):
     up creating further subfolders. This helper is used by both whisper and ceres, but by design
     each carbon database and graphite-web finder is responsible for handling its own encoding so
     that different backends can create their own schemes if desired.
+
+    The hash_only parameter can be set to True to use the hash as the filename instead of a
+    human-readable name.  This avoids issues with filename length restrictions, at the expense of
+    being unable to decode the filename and determine the original metric name.
 
     A concrete example:
 
@@ -95,7 +99,12 @@ class TaggedSeries(object):
     """
     if ';' in metric:
       metric_hash = sha256(metric.encode('utf8')).hexdigest()
-      return sep.join(['_tagged', metric_hash[0:3], metric_hash[3:6], metric.replace('.', '_DOT_')])
+      return sep.join([
+        '_tagged',
+        metric_hash[0:3],
+        metric_hash[3:6],
+        metric_hash if hash_only else metric.replace('.', '_DOT_')
+      ])
 
     # metric isn't tagged, just replace dots with the separator and trim any leading separator
     return metric.replace('.', sep).lstrip(sep)


### PR DESCRIPTION
This is the graphite side of graphite-project/carbon#743, adding support for graphite-web to read tagged metrics stored in hashed files.  The way it's implemented here graphite-web will look for both variants so there isn't a need for a configuration option in graphite-web.

This branch also includes an optimization to avoid scanning whisper folder to resolve brace expressions like `{foo,bar}`, which should provide a modest performance increase.

I still need to do some real-world testing on this.