### PR TITLE
add optional keepStep parameter to aggregateLine

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -4114,14 +4114,13 @@ def aggregateLine(requestContext, seriesList, func='average', keepStep=False):
         name = 'aggregateLine(%s, None)' % (series.name)
 
     if keepStep:
-      for i, _ in enumerate(series):
-        series[i] = value
+      aggSeries = series.copy(name=name, values=[value] * len(series))
     else:
-      [series] = constantLine(requestContext, value)
+      [aggSeries] = constantLine(requestContext, value)
+      aggSeries.name = name
+      aggSeries.pathExpression = name
 
-    series.name = name
-    series.pathExpression = name
-    results.append(series)
+    results.append(aggSeries)
   return results
 
 aggregateLine.group = 'Calculate'

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -4078,10 +4078,13 @@ constantLine.params = [
   Param('value', ParamTypes.float, required=True),
 ]
 
-def aggregateLine(requestContext, seriesList, func='average'):
+def aggregateLine(requestContext, seriesList, func='average', keepStep=False):
   """
   Takes a metric or wildcard seriesList and draws a horizontal line
   based on the function applied to each series.
+
+  If the optional keepStep parameter is set to True, the result will
+  have the same time period and step as the source series.
 
   Note: By default, the graphite renderer consolidates data points by
   averaging data points over time. If you are using the 'min' or 'max'
@@ -4110,7 +4113,12 @@ def aggregateLine(requestContext, seriesList, func='average'):
     else:
         name = 'aggregateLine(%s, None)' % (series.name)
 
-    [series] = constantLine(requestContext, value)
+    if keepStep:
+      for i, _ in enumerate(series):
+        series[i] = value
+    else:
+      [series] = constantLine(requestContext, value)
+
     series.name = name
     series.pathExpression = name
     results.append(series)
@@ -4120,6 +4128,7 @@ aggregateLine.group = 'Calculate'
 aggregateLine.params = [
   Param('seriesList', ParamTypes.seriesList, required=True),
   Param('func', ParamTypes.aggFunc, default='average', options=aggFuncNames),
+  Param('keepStep', ParamTypes.boolean, default=False),
 ]
 
 def verticalLine(requestContext, ts, label=None, color=None):

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -3577,10 +3577,10 @@ class FunctionsTest(TestCase):
         )
 
         expectedResult = [
-            TimeSeries('aggregateLine(collectd.test-db1.load.value, 4)', 3600, 3600, 0, [4.0, 4.0, 4.0]),
-            TimeSeries('aggregateLine(collectd.test-db2.load.value, None)', 3600, 3600, 0, [None, None, None]),
-            TimeSeries('aggregateLine(collectd.test-db3.load.value, 1.85714)', 3600, 3600, 0, [1.8571428571428572, 1.8571428571428572, 1.8571428571428572]),
-            TimeSeries('aggregateLine(collectd.test-db4.load.value, 8.22222)', 3600, 3600, 0, [8.222222222222221, 8.222222222222221, 8.222222222222221]),
+            TimeSeries('aggregateLine(collectd.test-db1.load.value, 4)', 0, 600, 60, [4.0] * 10),
+            TimeSeries('aggregateLine(collectd.test-db2.load.value, None)', 0, 600, 60, [None] * 10),
+            TimeSeries('aggregateLine(collectd.test-db3.load.value, 1.85714)', 0, 600, 60, [1.8571428571428572] * 10),
+            TimeSeries('aggregateLine(collectd.test-db4.load.value, 8.22222)', 0, 600, 60, [8.222222222222221] * 10),
         ]
         result = functions.aggregateLine(
             self._build_requestContext(
@@ -3588,7 +3588,8 @@ class FunctionsTest(TestCase):
                 endTime=datetime(1970,1,1,1,0,0,0,pytz.timezone(settings.TIME_ZONE))
             ),
             seriesList,
-            'avg'
+            'avg',
+            keepStep=True
         )
         self.assertEqual(result, expectedResult)
 
@@ -3635,10 +3636,10 @@ class FunctionsTest(TestCase):
         )
 
         expectedResult = [
-            TimeSeries('aggregateLine(collectd.test-db1.load.value, 7)', 3600, 3600, 0, [7.0, 7.0, 7.0]),
-            TimeSeries('aggregateLine(collectd.test-db2.load.value, None)', 3600, 3600, 0, [None, None, None]),
-            TimeSeries('aggregateLine(collectd.test-db3.load.value, 4)', 3600, 3600, 0, [4.0, 4.0, 4.0]),
-            TimeSeries('aggregateLine(collectd.test-db4.load.value, 10)', 3600, 3600, 0, [10.0, 10.0, 10.0]),
+            TimeSeries('aggregateLine(collectd.test-db1.load.value, 7)', 0, 600, 60, [7.0] * 10),
+            TimeSeries('aggregateLine(collectd.test-db2.load.value, None)', 0, 600, 60, [None] * 10),
+            TimeSeries('aggregateLine(collectd.test-db3.load.value, 4)', 0, 600, 60, [4.0] * 10),
+            TimeSeries('aggregateLine(collectd.test-db4.load.value, 10)', 0, 600, 60, [10.0] * 10),
         ]
         result = functions.aggregateLine(
             self._build_requestContext(
@@ -3646,7 +3647,8 @@ class FunctionsTest(TestCase):
                 endTime=datetime(1970,1,1,1,0,0,0,pytz.timezone(settings.TIME_ZONE))
             ),
             seriesList,
-            'max'
+            'max',
+            keepStep=True
         )
         self.assertEqual(result, expectedResult)
 


### PR DESCRIPTION
This PR adds an optional `keepStep` parameter to `aggregateLine` to support the use-case described in #2232