### PR TITLE
w/g/f/remote.py: add missing local field to auto_complete_{tags,values}

### DIFF
--- a/webapp/graphite/finders/remote.py
+++ b/webapp/graphite/finders/remote.py
@@ -189,6 +189,7 @@ class RemoteFinder(BaseFinder):
         fields = [
             ('tagPrefix', tagPrefix or ''),
             ('limit', str(limit)),
+            ('local', self.params.get('local', '1')),
         ]
         for expr in exprs:
             fields.append(('expr', expr))
@@ -223,6 +224,7 @@ class RemoteFinder(BaseFinder):
             ('tag', tag or ''),
             ('valuePrefix', valuePrefix or ''),
             ('limit', str(limit)),
+            ('local', self.params.get('local', '1')),
         ]
         for expr in exprs:
             fields.append(('expr', expr))

--- a/webapp/graphite/tags/views.py
+++ b/webapp/graphite/tags/views.py
@@ -1,9 +1,10 @@
 from graphite.util import jsonResponse, HttpResponse, HttpError
 from graphite.storage import STORE, extractForwardHeaders
 
-def _requestContext(request):
+def _requestContext(request, queryParams):
   return {
     'forwardHeaders': extractForwardHeaders(request),
+    'localOnly': queryParams.get('local') == '1',
   }
 
 @jsonResponse
@@ -15,7 +16,7 @@ def tagSeries(request, queryParams):
   if not path:
     raise HttpError('no path specified', status=400)
 
-  return STORE.tagdb.tag_series(path, requestContext=_requestContext(request))
+  return STORE.tagdb.tag_series(path, requestContext=_requestContext(request, queryParams))
 
 @jsonResponse
 def tagMultiSeries(request, queryParams):
@@ -32,7 +33,7 @@ def tagMultiSeries(request, queryParams):
   else:
     raise HttpError('no paths specified',status=400)
 
-  return STORE.tagdb.tag_multi_series(paths, requestContext=_requestContext(request))
+  return STORE.tagdb.tag_multi_series(paths, requestContext=_requestContext(request, queryParams))
 
 @jsonResponse
 def delSeries(request, queryParams):
@@ -49,7 +50,7 @@ def delSeries(request, queryParams):
   else:
     raise HttpError('no path specified', status=400)
 
-  return STORE.tagdb.del_multi_series(paths, requestContext=_requestContext(request))
+  return STORE.tagdb.del_multi_series(paths, requestContext=_requestContext(request, queryParams))
 
 @jsonResponse
 def findSeries(request, queryParams):
@@ -67,7 +68,7 @@ def findSeries(request, queryParams):
   if not exprs:
     raise HttpError('no tag expressions specified', status=400)
 
-  return STORE.tagdb.find_series(exprs, requestContext=_requestContext(request))
+  return STORE.tagdb.find_series(exprs, requestContext=_requestContext(request, queryParams))
 
 @jsonResponse
 def tagList(request, queryParams):
@@ -77,7 +78,7 @@ def tagList(request, queryParams):
   return STORE.tagdb.list_tags(
     tagFilter=request.GET.get('filter'),
     limit=request.GET.get('limit'),
-    requestContext=_requestContext(request),
+    requestContext=_requestContext(request, queryParams),
   )
 
 @jsonResponse
@@ -89,7 +90,7 @@ def tagDetails(request, queryParams, tag):
     tag,
     valueFilter=queryParams.get('filter'),
     limit=queryParams.get('limit'),
-    requestContext=_requestContext(request),
+    requestContext=_requestContext(request, queryParams),
   )
 
 @jsonResponse
@@ -109,7 +110,7 @@ def autoCompleteTags(request, queryParams):
     exprs,
     tagPrefix=queryParams.get('tagPrefix'),
     limit=queryParams.get('limit'),
-    requestContext=_requestContext(request)
+    requestContext=_requestContext(request, queryParams)
   )
 
 @jsonResponse
@@ -134,5 +135,5 @@ def autoCompleteValues(request, queryParams):
     tag,
     valuePrefix=queryParams.get('valuePrefix'),
     limit=queryParams.get('limit'),
-    requestContext=_requestContext(request)
+    requestContext=_requestContext(request, queryParams)
   )

--- a/webapp/tests/test_finders_remote.py
+++ b/webapp/tests/test_finders_remote.py
@@ -339,6 +339,7 @@ class RemoteFinderTest(TestCase):
         'fields': [
           ('tagPrefix', 'tag'),
           ('limit', '100'),
+          ('local', '1'),
           ('expr', 'name=test'),
         ],
         'headers': None,
@@ -367,6 +368,7 @@ class RemoteFinderTest(TestCase):
         'fields': [
           ('tagPrefix', 'tag'),
           ('limit', '5'),
+          ('local', '1'),
           ('expr', 'name=test'),
           ('expr', 'tag3=value3'),
         ],
@@ -417,6 +419,7 @@ class RemoteFinderTest(TestCase):
           ('tag', 'tag1'),
           ('valuePrefix', 'value'),
           ('limit', '100'),
+          ('local', '1'),
           ('expr', 'name=test'),
         ],
         'headers': None,
@@ -446,6 +449,7 @@ class RemoteFinderTest(TestCase):
           ('tag', 'tag1'),
           ('valuePrefix', 'value'),
           ('limit', '5'),
+          ('local', '1'),
           ('expr', 'name=test'),
           ('expr', 'tag3=value3'),
         ],


### PR DESCRIPTION
This PR makes the `tags/autoComplete/tags` and `tags/autoComplete/values` API calls work properly in a clustered configuration of graphite-web. It adds the `localOnly` query parameter as needed in order to avoid an infinite recursion of API calls across the cluster, similarly to `/metrics/find`.

Fixes https://github.com/graphite-project/graphite-web/issues/2243
Follows https://github.com/graphite-project/graphite-web/pull/2128