### PR TITLE
[1.1.x] support for storing tagged series in hashed filenames | lint fix | add optional keepStep parameter to aggregateLine | don't modify series | w/g/f/remote.py: add missing local field to auto_complete_{t

### DIFF
--- a/webapp/graphite/finders/ceres.py
+++ b/webapp/graphite/finders/ceres.py
@@ -25,15 +25,17 @@ class CeresFinder(BaseFinder):
         self.tree = CeresTree(directory)
 
     def find_nodes(self, query):
-
         # translate query pattern if it is tagged
         tagged = not query.pattern.startswith('_tagged.') and ';' in query.pattern
         if tagged:
-          # tagged series are stored in ceres using encoded names, so to retrieve them we need to encode the
-          # query pattern using the same scheme used in carbon when they are written.
-          variants = [TaggedSeries.encode(query.pattern)]
+            # tagged series are stored in ceres using encoded names, so to retrieve them we need to
+            # encode the query pattern using the same scheme used in carbon when they are written.
+            variants = [
+                TaggedSeries.encode(query.pattern, hash_only=True),
+                TaggedSeries.encode(query.pattern, hash_only=False),
+            ]
         else:
-          variants = extract_variants(query.pattern)
+            variants = extract_variants(query.pattern)
 
         for variant in variants:
             for fs_path in glob(self.tree.getFilesystemPath(variant)):
@@ -42,14 +44,12 @@ class CeresFinder(BaseFinder):
                 if CeresNode.isNodeDir(fs_path):
                     ceres_node = self.tree.getNode(metric_path)
 
-                    if ceres_node.hasDataForInterval(
-                            query.startTime, query.endTime):
-                        real_metric_path = get_real_metric_path(
-                            fs_path, metric_path)
+                    if ceres_node.hasDataForInterval(query.startTime, query.endTime):
+                        real_metric_path = get_real_metric_path(fs_path, metric_path)
                         reader = CeresReader(ceres_node, real_metric_path)
                         # if we're finding by tag, return the proper metric path
                         if tagged:
-                          metric_path = query.pattern
+                            metric_path = query.pattern
                         yield LeafNode(metric_path, reader)
 
                 elif os.path.isdir(fs_path):
@@ -59,12 +59,12 @@ class CeresFinder(BaseFinder):
         matches = []
 
         for root, _, files in walk(settings.CERES_DIR):
-          root = root.replace(settings.CERES_DIR, '')
-          for filename in files:
-            if filename == '.ceres-node':
-              matches.append(root)
+            root = root.replace(settings.CERES_DIR, '')
+            for filename in files:
+                if filename == '.ceres-node':
+                    matches.append(root)
 
         return sorted([
-          m.replace('/', '.').lstrip('.')
-          for m in matches
+            m.replace('/', '.').lstrip('.')
+            for m in matches
         ])

--- a/webapp/graphite/finders/remote.py
+++ b/webapp/graphite/finders/remote.py
@@ -189,6 +189,7 @@ class RemoteFinder(BaseFinder):
         fields = [
             ('tagPrefix', tagPrefix or ''),
             ('limit', str(limit)),
+            ('local', self.params.get('local', '1')),
         ]
         for expr in exprs:
             fields.append(('expr', expr))
@@ -223,6 +224,7 @@ class RemoteFinder(BaseFinder):
             ('tag', tag or ''),
             ('valuePrefix', valuePrefix or ''),
             ('limit', str(limit)),
+            ('local', self.params.get('local', '1')),
         ]
         for expr in exprs:
             fields.append(('expr', expr))

--- a/webapp/graphite/finders/standard.py
+++ b/webapp/graphite/finders/standard.py
@@ -1,6 +1,5 @@
 import bisect
 import fnmatch
-import operator
 import os
 from os.path import isdir, isfile, join, basename, splitext
 from django.conf import settings

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -148,6 +148,11 @@ class TimeSeries(list):
     )
 
 
+  def datapoints(self):
+    timestamps = range(int(self.start), int(self.end) + 1, int(self.step * self.valuesPerPoint))
+    return list(zip(self, timestamps))
+
+
 # Data retrieval API
 @logtime
 def fetchData(requestContext, pathExpr, timer=None):

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -4856,7 +4856,7 @@ def hitcount(requestContext, seriesList, intervalString, alignToInterval = False
 
   for series in seriesList:
     step = int(series.step)
-    bucket_count = int(math.ceil(float(series.end - series.start) // interval))
+    bucket_count = int(math.ceil(float(series.end - series.start) / interval))
     buckets = [[] for _ in range(bucket_count)]
     newStart = int(series.end - bucket_count * interval)
 

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -4114,14 +4114,13 @@ def aggregateLine(requestContext, seriesList, func='average', keepStep=False):
         name = 'aggregateLine(%s, None)' % (series.name)
 
     if keepStep:
-      for i, _ in enumerate(series):
-        series[i] = value
+      aggSeries = series.copy(name=name, values=[value] * len(series))
     else:
-      [series] = constantLine(requestContext, value)
+      [aggSeries] = constantLine(requestContext, value)
+      aggSeries.name = name
+      aggSeries.pathExpression = name
 
-    series.name = name
-    series.pathExpression = name
-    results.append(series)
+    results.append(aggSeries)
   return results
 
 aggregateLine.group = 'Calculate'

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -4078,10 +4078,13 @@ constantLine.params = [
   Param('value', ParamTypes.float, required=True),
 ]
 
-def aggregateLine(requestContext, seriesList, func='average'):
+def aggregateLine(requestContext, seriesList, func='average', keepStep=False):
   """
   Takes a metric or wildcard seriesList and draws a horizontal line
   based on the function applied to each series.
+
+  If the optional keepStep parameter is set to True, the result will
+  have the same time period and step as the source series.
 
   Note: By default, the graphite renderer consolidates data points by
   averaging data points over time. If you are using the 'min' or 'max'
@@ -4110,7 +4113,12 @@ def aggregateLine(requestContext, seriesList, func='average'):
     else:
         name = 'aggregateLine(%s, None)' % (series.name)
 
-    [series] = constantLine(requestContext, value)
+    if keepStep:
+      for i, _ in enumerate(series):
+        series[i] = value
+    else:
+      [series] = constantLine(requestContext, value)
+
     series.name = name
     series.pathExpression = name
     results.append(series)
@@ -4120,6 +4128,7 @@ aggregateLine.group = 'Calculate'
 aggregateLine.params = [
   Param('seriesList', ParamTypes.seriesList, required=True),
   Param('func', ParamTypes.aggFunc, default='average', options=aggFuncNames),
+  Param('keepStep', ParamTypes.boolean, default=False),
 ]
 
 def verticalLine(requestContext, ts, label=None, color=None):

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -19,6 +19,7 @@ from six.moves.urllib.parse import unquote_plus
 from six.moves.configparser import SafeConfigParser
 from django.conf import settings
 import pytz
+import six
 
 from graphite.render.datalib import TimeSeries
 from graphite.util import json, BytesIO
@@ -594,7 +595,7 @@ class Graph:
       r,g,b = value
     elif value in colorAliases:
       r,g,b = colorAliases[value]
-    elif type(value) in (str,unicode) and len(value) >= 6:
+    elif type(value) in six.string_types and len(value) >= 6:
       s = value
       if s[0] == '#': s = s[1:]
       if s[0:3] == '%23': s = s[3:]
@@ -985,7 +986,7 @@ class LineGraph(Graph):
     if 'yUnitSystem' not in params:
       params['yUnitSystem'] = 'si'
     else:
-      params['yUnitSystem'] = unicode(params['yUnitSystem']).lower()
+      params['yUnitSystem'] = six.text_type(params['yUnitSystem']).lower()
       if params['yUnitSystem'] not in UnitSystems:
         params['yUnitSystem'] = 'si'
 
@@ -1044,11 +1045,11 @@ class LineGraph(Graph):
     self.setColor( self.foregroundColor )
 
     if params.get('title'):
-      self.drawTitle( unicode( unquote_plus(params['title']) ) )
+      self.drawTitle( six.text_type( unquote_plus(params['title']) ) )
     if params.get('vtitle'):
-      self.drawVTitle( unicode( unquote_plus(params['vtitle']) ) )
+      self.drawVTitle( six.text_type( unquote_plus(params['vtitle']) ) )
     if self.secondYAxis and params.get('vtitleRight'):
-      self.drawVTitle( unicode( unquote_plus(params['vtitleRight']) ), rightAlign=True )
+      self.drawVTitle( six.text_type( unquote_plus(params['vtitleRight']) ), rightAlign=True )
     self.setFont()
 
     if not params.get('hideLegend', len(self.data) > settings.LEGEND_MAX_ITEMS):
@@ -1850,7 +1851,7 @@ class PieGraph(Graph):
         if slice['value'] < 10 and slice['value'] != int(slice['value']):
           label = "%.2f" % slice['value']
         else:
-          label = unicode(int(slice['value']))
+          label = six.text_type(int(slice['value']))
       theta = slice['midAngle']
       x = self.x0 + (self.radius / 2.0 * math.cos(theta))
       y = self.y0 + (self.radius / 2.0 * math.sin(theta))

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -595,7 +595,7 @@ class Graph:
       r,g,b = value
     elif value in colorAliases:
       r,g,b = colorAliases[value]
-    elif type(value) in six.string_types and len(value) >= 6:
+    elif isinstance(value, six.string_types) and len(value) >= 6:
       s = value
       if s[0] == '#': s = s[1:]
       if s[0:3] == '%23': s = s[3:]

--- a/webapp/graphite/tags/utils.py
+++ b/webapp/graphite/tags/utils.py
@@ -67,7 +67,7 @@ class TaggedSeries(object):
     ]))
 
   @staticmethod
-  def encode(metric, sep='.'):
+  def encode(metric, sep='.', hash_only=False):
     """
     Helper function to encode tagged series for storage in whisper etc
 
@@ -80,6 +80,10 @@ class TaggedSeries(object):
     up creating further subfolders. This helper is used by both whisper and ceres, but by design
     each carbon database and graphite-web finder is responsible for handling its own encoding so
     that different backends can create their own schemes if desired.
+
+    The hash_only parameter can be set to True to use the hash as the filename instead of a
+    human-readable name.  This avoids issues with filename length restrictions, at the expense of
+    being unable to decode the filename and determine the original metric name.
 
     A concrete example:
 
@@ -95,7 +99,12 @@ class TaggedSeries(object):
     """
     if ';' in metric:
       metric_hash = sha256(metric.encode('utf8')).hexdigest()
-      return sep.join(['_tagged', metric_hash[0:3], metric_hash[3:6], metric.replace('.', '_DOT_')])
+      return sep.join([
+        '_tagged',
+        metric_hash[0:3],
+        metric_hash[3:6],
+        metric_hash if hash_only else metric.replace('.', '_DOT_')
+      ])
 
     # metric isn't tagged, just replace dots with the separator and trim any leading separator
     return metric.replace('.', sep).lstrip(sep)

--- a/webapp/graphite/tags/views.py
+++ b/webapp/graphite/tags/views.py
@@ -1,9 +1,10 @@
 from graphite.util import jsonResponse, HttpResponse, HttpError
 from graphite.storage import STORE, extractForwardHeaders
 
-def _requestContext(request):
+def _requestContext(request, queryParams):
   return {
     'forwardHeaders': extractForwardHeaders(request),
+    'localOnly': queryParams.get('local') == '1',
   }
 
 @jsonResponse
@@ -15,7 +16,7 @@ def tagSeries(request, queryParams):
   if not path:
     raise HttpError('no path specified', status=400)
 
-  return STORE.tagdb.tag_series(path, requestContext=_requestContext(request))
+  return STORE.tagdb.tag_series(path, requestContext=_requestContext(request, queryParams))
 
 @jsonResponse
 def tagMultiSeries(request, queryParams):
@@ -32,7 +33,7 @@ def tagMultiSeries(request, queryParams):
   else:
     raise HttpError('no paths specified',status=400)
 
-  return STORE.tagdb.tag_multi_series(paths, requestContext=_requestContext(request))
+  return STORE.tagdb.tag_multi_series(paths, requestContext=_requestContext(request, queryParams))
 
 @jsonResponse
 def delSeries(request, queryParams):
@@ -49,7 +50,7 @@ def delSeries(request, queryParams):
   else:
     raise HttpError('no path specified', status=400)
 
-  return STORE.tagdb.del_multi_series(paths, requestContext=_requestContext(request))
+  return STORE.tagdb.del_multi_series(paths, requestContext=_requestContext(request, queryParams))
 
 @jsonResponse
 def findSeries(request, queryParams):
@@ -67,7 +68,7 @@ def findSeries(request, queryParams):
   if not exprs:
     raise HttpError('no tag expressions specified', status=400)
 
-  return STORE.tagdb.find_series(exprs, requestContext=_requestContext(request))
+  return STORE.tagdb.find_series(exprs, requestContext=_requestContext(request, queryParams))
 
 @jsonResponse
 def tagList(request, queryParams):
@@ -77,7 +78,7 @@ def tagList(request, queryParams):
   return STORE.tagdb.list_tags(
     tagFilter=request.GET.get('filter'),
     limit=request.GET.get('limit'),
-    requestContext=_requestContext(request),
+    requestContext=_requestContext(request, queryParams),
   )
 
 @jsonResponse
@@ -89,7 +90,7 @@ def tagDetails(request, queryParams, tag):
     tag,
     valueFilter=queryParams.get('filter'),
     limit=queryParams.get('limit'),
-    requestContext=_requestContext(request),
+    requestContext=_requestContext(request, queryParams),
   )
 
 @jsonResponse
@@ -109,7 +110,7 @@ def autoCompleteTags(request, queryParams):
     exprs,
     tagPrefix=queryParams.get('tagPrefix'),
     limit=queryParams.get('limit'),
-    requestContext=_requestContext(request)
+    requestContext=_requestContext(request, queryParams)
   )
 
 @jsonResponse
@@ -134,5 +135,5 @@ def autoCompleteValues(request, queryParams):
     tag,
     valuePrefix=queryParams.get('valuePrefix'),
     limit=queryParams.get('limit'),
-    requestContext=_requestContext(request)
+    requestContext=_requestContext(request, queryParams)
   )

--- a/webapp/tests/test_finders_remote.py
+++ b/webapp/tests/test_finders_remote.py
@@ -339,6 +339,7 @@ class RemoteFinderTest(TestCase):
         'fields': [
           ('tagPrefix', 'tag'),
           ('limit', '100'),
+          ('local', '1'),
           ('expr', 'name=test'),
         ],
         'headers': None,
@@ -367,6 +368,7 @@ class RemoteFinderTest(TestCase):
         'fields': [
           ('tagPrefix', 'tag'),
           ('limit', '5'),
+          ('local', '1'),
           ('expr', 'name=test'),
           ('expr', 'tag3=value3'),
         ],
@@ -417,6 +419,7 @@ class RemoteFinderTest(TestCase):
           ('tag', 'tag1'),
           ('valuePrefix', 'value'),
           ('limit', '100'),
+          ('local', '1'),
           ('expr', 'name=test'),
         ],
         'headers': None,
@@ -446,6 +449,7 @@ class RemoteFinderTest(TestCase):
           ('tag', 'tag1'),
           ('valuePrefix', 'value'),
           ('limit', '5'),
+          ('local', '1'),
           ('expr', 'name=test'),
           ('expr', 'tag3=value3'),
         ],

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -3577,10 +3577,10 @@ class FunctionsTest(TestCase):
         )
 
         expectedResult = [
-            TimeSeries('aggregateLine(collectd.test-db1.load.value, 4)', 3600, 3600, 0, [4.0, 4.0, 4.0]),
-            TimeSeries('aggregateLine(collectd.test-db2.load.value, None)', 3600, 3600, 0, [None, None, None]),
-            TimeSeries('aggregateLine(collectd.test-db3.load.value, 1.85714)', 3600, 3600, 0, [1.8571428571428572, 1.8571428571428572, 1.8571428571428572]),
-            TimeSeries('aggregateLine(collectd.test-db4.load.value, 8.22222)', 3600, 3600, 0, [8.222222222222221, 8.222222222222221, 8.222222222222221]),
+            TimeSeries('aggregateLine(collectd.test-db1.load.value, 4)', 0, 600, 60, [4.0] * 10),
+            TimeSeries('aggregateLine(collectd.test-db2.load.value, None)', 0, 600, 60, [None] * 10),
+            TimeSeries('aggregateLine(collectd.test-db3.load.value, 1.85714)', 0, 600, 60, [1.8571428571428572] * 10),
+            TimeSeries('aggregateLine(collectd.test-db4.load.value, 8.22222)', 0, 600, 60, [8.222222222222221] * 10),
         ]
         result = functions.aggregateLine(
             self._build_requestContext(
@@ -3588,7 +3588,8 @@ class FunctionsTest(TestCase):
                 endTime=datetime(1970,1,1,1,0,0,0,pytz.timezone(settings.TIME_ZONE))
             ),
             seriesList,
-            'avg'
+            'avg',
+            keepStep=True
         )
         self.assertEqual(result, expectedResult)
 
@@ -3635,10 +3636,10 @@ class FunctionsTest(TestCase):
         )
 
         expectedResult = [
-            TimeSeries('aggregateLine(collectd.test-db1.load.value, 7)', 3600, 3600, 0, [7.0, 7.0, 7.0]),
-            TimeSeries('aggregateLine(collectd.test-db2.load.value, None)', 3600, 3600, 0, [None, None, None]),
-            TimeSeries('aggregateLine(collectd.test-db3.load.value, 4)', 3600, 3600, 0, [4.0, 4.0, 4.0]),
-            TimeSeries('aggregateLine(collectd.test-db4.load.value, 10)', 3600, 3600, 0, [10.0, 10.0, 10.0]),
+            TimeSeries('aggregateLine(collectd.test-db1.load.value, 7)', 0, 600, 60, [7.0] * 10),
+            TimeSeries('aggregateLine(collectd.test-db2.load.value, None)', 0, 600, 60, [None] * 10),
+            TimeSeries('aggregateLine(collectd.test-db3.load.value, 4)', 0, 600, 60, [4.0] * 10),
+            TimeSeries('aggregateLine(collectd.test-db4.load.value, 10)', 0, 600, 60, [10.0] * 10),
         ]
         result = functions.aggregateLine(
             self._build_requestContext(
@@ -3646,7 +3647,8 @@ class FunctionsTest(TestCase):
                 endTime=datetime(1970,1,1,1,0,0,0,pytz.timezone(settings.TIME_ZONE))
             ),
             seriesList,
-            'max'
+            'max',
+            keepStep=True
         )
         self.assertEqual(result, expectedResult)
 


### PR DESCRIPTION
Backports the following commits to 1.1.x:
 - support for storing tagged series in hashed filenames (#2221)
 - lint fix (#2221)
 - add optional keepStep parameter to aggregateLine (#2234)
 - don't modify series (#2234)
 - w/g/f/remote.py: add missing local field to auto_complete_{tags,values} (#2244)
 - fix hitcount bucket calculation (#2252)
 - fix usage of "unicode" in glyph.py for Python 3 (#2254)
 - use isinstance (#2254)
 - support specifying noNullPoints and maxDataPoints together (#2257)