### PR TITLE
Adding dummy.txt to storage dirs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ else:
 
 storage_dirs = []
 
-for subdir in ('whisper', 'ceres', 'rrd', 'log', 'log/webapp'):
+for subdir in ('whisper/dummy.txt', 'ceres/dummy.txt', 'rrd/dummy.txt', 'log/dummy.txt', 'log/webapp/dummy.txt'):
   storage_dirs.append( ('storage/%s' % subdir, []) )
 
 webapp_content = defaultdict(list)


### PR DESCRIPTION
Fixing https://github.com/graphite-project/graphite-web/issues/2193
Also, upgrade manual for next release should include instructions to remove all `/opt/graphite/storage` entries from `/opt/graphite/lib/graphite-web-x.x.x-pyx.x.egg-info/installed-files.txt` file before the upgrade.