### PR TITLE
graphite functions: handle max on empty sequences better

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -130,15 +130,19 @@ def safeLast(values):
   for v in reversed(values):
     if v is not None: return v
 
-def safeMin(values):
+def safeMin(values, default=None):
   safeValues = [v for v in values if v is not None]
   if safeValues:
     return min(safeValues)
+  else:
+    return default
 
-def safeMax(values):
+def safeMax(values, default=None):
   safeValues = [v for v in values if v is not None]
   if safeValues:
     return max(safeValues)
+  else:
+    return default
 
 def safeMap(function, values):
   safeValues = [v for v in values if v is not None]
@@ -3257,7 +3261,7 @@ def sortByMinima(requestContext, seriesList):
     &target=sortByMinima(server*.instance*.memory.free)
 
   """
-  newSeries = [series for series in seriesList if safeMax(series) > 0]
+  newSeries = [series for series in seriesList if safeMax(series, default=0) > 0]
   newSeries.sort(key=keyFunc(safeMin))
   return newSeries
 
@@ -5260,12 +5264,8 @@ def minMax(requestContext, seriesList):
   for series in seriesList:
     series.name = "minMax(%s)" % (series.name)
     series.pathExpression = series.name
-    min_val = safeMin(series)
-    max_val = safeMax(series)
-    if min_val is None:
-      min_val = 0.0
-    if max_val is None:
-      max_val = 0.0
+    min_val = safeMin(series, default=0.0)
+    max_val = safeMax(series, default=0.0)
     for i, val in enumerate(series):
       if series[i] is not None:
         try:


### PR DESCRIPTION
I was seeing errors due to code like safeMax(series) > 0, where safeMax
returned None.