### PR TITLE
[1.1.x] Adding dummy.txt to storage dirs | Fix test_delay list nesting | Add test for delay func where step > len(series) | Add tests for delay render function with negative step | Simplify logic of delay fun

### DIFF
--- a/docs/config-webapp.rst
+++ b/docs/config-webapp.rst
@@ -253,6 +253,10 @@ Finally, configure the nginx vhost:
     server {
         listen 80;
 
+        location /static/ {
+            alias /opt/graphite/webapp/content/;
+        }
+
         location / {
             include uwsgi_params;
             uwsgi_pass localhost:8080;

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ else:
 
 storage_dirs = []
 
-for subdir in ('whisper', 'ceres', 'rrd', 'log', 'log/webapp'):
+for subdir in ('whisper/dummy.txt', 'ceres/dummy.txt', 'rrd/dummy.txt', 'log/dummy.txt', 'log/webapp/dummy.txt'):
   storage_dirs.append( ('storage/%s' % subdir, []) )
 
 webapp_content = defaultdict(list)

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -130,15 +130,19 @@ def safeLast(values):
   for v in reversed(values):
     if v is not None: return v
 
-def safeMin(values):
+def safeMin(values, default=None):
   safeValues = [v for v in values if v is not None]
   if safeValues:
     return min(safeValues)
+  else:
+    return default
 
-def safeMax(values):
+def safeMax(values, default=None):
   safeValues = [v for v in values if v is not None]
   if safeValues:
     return max(safeValues)
+  else:
+    return default
 
 def safeMap(function, values):
   safeValues = [v for v in values if v is not None]
@@ -3252,7 +3256,7 @@ def sortByMinima(requestContext, seriesList):
     &target=sortByMinima(server*.instance*.memory.free)
 
   """
-  newSeries = [series for series in seriesList if safeMax(series) > 0]
+  newSeries = [series for series in seriesList if safeMax(series, default=0) > 0]
   newSeries.sort(key=keyFunc(safeMin))
   return newSeries
 
@@ -5255,12 +5259,8 @@ def minMax(requestContext, seriesList):
   for series in seriesList:
     series.name = "minMax(%s)" % (series.name)
     series.pathExpression = series.name
-    min_val = safeMin(series)
-    max_val = safeMax(series)
-    if min_val is None:
-      min_val = 0.0
-    if max_val is None:
-      max_val = 0.0
+    min_val = safeMin(series, default=0.0)
+    max_val = safeMax(series, default=0.0)
     for i, val in enumerate(series):
       if series[i] is not None:
         try:

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1930,15 +1930,7 @@ def delay(requestContext, seriesList, steps):
   """
   results = []
   for series in seriesList:
-    newValues = []
-    prev = []
-    for val in series:
-      if len(prev) < steps:
-        newValues.append(None)
-        prev.append(val)
-        continue
-      newValues.append(prev.pop(0))
-      prev.append(val)
+    newValues = [None] * min(steps, len(series)) + series[:-steps]
     series.tags['delay'] = steps
     newName = "delay(%s,%d)" % (series.name, steps)
     newSeries = series.copy(name=newName, values=newValues)

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1930,7 +1930,10 @@ def delay(requestContext, seriesList, steps):
   """
   results = []
   for series in seriesList:
-    newValues = [None] * min(steps, len(series)) + series[:-steps]
+    if steps < 0:
+      newValues = series[-steps:] + [None] * min(-steps, len(series))
+    else:
+      newValues = [None] * min(steps, len(series)) + series[:-steps]
     series.tags['delay'] = steps
     newName = "delay(%s,%d)" % (series.name, steps)
     newSeries = series.copy(name=newName, values=newValues)

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -876,11 +876,11 @@ class FunctionsTest(TestCase):
 
     def test_delay(self):
         source = [
-            TimeSeries('collectd.test-db1.load.value',0,1,1,[list(range(18))] + [None, None]),
+            TimeSeries('collectd.test-db1.load.value',0,1,1,list(range(18)) + [None, None]),
         ]
         delay = 2
         expectedList = [
-            TimeSeries('delay(collectd.test-db1.load.value,2)',0,1,1,[None, None] + [list(range(18))]),
+            TimeSeries('delay(collectd.test-db1.load.value,2)',0,1,1,[None, None] + list(range(18))),
         ]
         gotList = functions.delay({}, source, delay)
         self.assertEqual(len(gotList), len(expectedList))

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -900,6 +900,32 @@ class FunctionsTest(TestCase):
         for got, expected in zip(gotList, expectedList):
             self.assertEqual(got, expected)
 
+    def test_delay_negative(self):
+        source = [
+            TimeSeries('collectd.test-db1.load.value',0,1,1,[None,None] + list(range(2,20))),
+        ]
+        delay = -2
+        expectedList = [
+            TimeSeries('delay(collectd.test-db1.load.value,-2)',0,1,1,list(range(2,20)) + [None,None]),
+        ]
+        gotList = functions.delay({}, source, delay)
+        self.assertEqual(len(gotList), len(expectedList))
+        for got, expected in zip(gotList, expectedList):
+            self.assertEqual(got, expected)
+
+    def test_delay_negative_too_many_steps(self):
+        source = [
+            TimeSeries('collectd.test-db1.load.value',0,1,1,list(range(20))),
+        ]
+        delay = -25
+        expectedList = [
+            TimeSeries('delay(collectd.test-db1.load.value,-25)',0,1,1,[None]*20),
+        ]
+        gotList = functions.delay({}, source, delay)
+        self.assertEqual(len(gotList), len(expectedList))
+        for got, expected in zip(gotList, expectedList):
+            self.assertEqual(got, expected)
+
     def test_asPercent_error(self):
         seriesList = self._gen_series_list_with_data(
             key=[

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -887,6 +887,19 @@ class FunctionsTest(TestCase):
         for got, expected in zip(gotList, expectedList):
             self.assertEqual(got, expected)
 
+    def test_delay_too_many_steps(self):
+        source = [
+            TimeSeries('collectd.test-db1.load.value',0,1,1,list(range(20))),
+        ]
+        delay = 25
+        expectedList = [
+            TimeSeries('delay(collectd.test-db1.load.value,25)',0,1,1,[None]*20),
+        ]
+        gotList = functions.delay({}, source, delay)
+        self.assertEqual(len(gotList), len(expectedList))
+        for got, expected in zip(gotList, expectedList):
+            self.assertEqual(got, expected)
+
     def test_asPercent_error(self):
         seriesList = self._gen_series_list_with_data(
             key=[


### PR DESCRIPTION
Backports the following commits to 1.1.x:
 - Adding dummy.txt to storage dirs (#2259)
 - Fix test_delay list nesting (#2262)
 - Add test for delay func where step > len(series) (#2262)
 - Add tests for delay render function with negative step (#2262)
 - Simplify logic of delay function (#2262)
 - Support negative steps in delay render function (#2262)
 - fixed missing static location in nginx + uwsgi conf #2260 (#2264)
 - graphite functions: handle max on empty sequences better (#2266)