### PR TITLE
Fix LDAP email address

### DIFF
--- a/webapp/graphite/account/ldapBackend.py
+++ b/webapp/graphite/account/ldapBackend.py
@@ -43,7 +43,7 @@ class LDAPBackend:
 
       userDN = resultData[0][0]
       try:
-        userMail = resultData[0][1]['mail'][0]
+        userMail = resultData[0][1]['mail'][0].decode("utf-8")
       except:
         userMail = "Unknown"
 


### PR DESCRIPTION
LDAP return bytes type variable: b'example@domain.com', which results this:
Traceback (most recent call last):
  File "/opt/graphite/webapp/graphite/account/ldapBackend.py", line 54, in authenticate
    user = User.objects.get(username=username)
  File "/opt/graphite/lib/python3.4/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/opt/graphite/lib/python3.4/site-packages/django/db/models/query.py", line 380, in get
    self.model._meta.object_name
django.contrib.auth.models.DoesNotExist: User matching query does not exist.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/graphite/lib/python3.4/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/opt/graphite/lib/python3.4/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/opt/graphite/lib/python3.4/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/graphite/webapp/graphite/account/views.py", line 33, in loginView
    user = authenticate(username=username,password=password)
  File "/opt/graphite/lib/python3.4/site-packages/django/contrib/auth/__init__.py", line 70, in authenticate
    user = _authenticate_with_backend(backend, backend_path, request, credentials)
  File "/opt/graphite/lib/python3.4/site-packages/django/contrib/auth/__init__.py", line 116, in _authenticate_with_backend
    return backend.authenticate(*args, **credentials)
  File "/opt/graphite/webapp/graphite/account/ldapBackend.py", line 57, in authenticate
    user = User.objects.create_user(username, userMail, randomPasswd)
  File "/opt/graphite/lib/python3.4/site-packages/django/contrib/auth/models.py", line 159, in create_user
    return self._create_user(username, email, password, **extra_fields)
  File "/opt/graphite/lib/python3.4/site-packages/django/contrib/auth/models.py", line 149, in _create_user
    email = self.normalize_email(email)
  File "/opt/graphite/lib/python3.4/site-packages/django/contrib/auth/base_user.py", line 29, in normalize_email
    email_name, domain_part = email.strip().rsplit('@', 1)
TypeError: 'str' does not support the buffer interface