### PR TITLE
improve performance of keepLastValue

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -642,29 +642,24 @@ def keepLastValue(requestContext, seriesList, limit = INF):
     series.name = "keepLastValue(%s)" % (series.name)
     series.pathExpression = series.name
     consecutiveNones = 0
+    lastVal = None
     for i,value in enumerate(series):
-      series[i] = value
-
-      # No 'keeping' can be done on the first value because we have no idea
-      # what came before it.
-      if i == 0:
-         continue
-
       if value is None:
         consecutiveNones += 1
       else:
-         if 0 < consecutiveNones <= limit:
+         if 0 < consecutiveNones <= limit and lastVal is not None:
            # If a non-None value is seen before the limit of Nones is hit,
            # backfill all the missing datapoints with the last known value.
            for index in range(i - consecutiveNones, i):
-             series[index] = series[i - consecutiveNones - 1]
+             series[index] = lastVal
 
          consecutiveNones = 0
+         lastVal = value
 
     # If the series ends with some None values, try to backfill a bit to cover it.
-    if 0 < consecutiveNones <= limit:
+    if 0 < consecutiveNones <= limit and lastVal is not None:
       for index in range(len(series) - consecutiveNones, len(series)):
-        series[index] = series[len(series) - consecutiveNones - 1]
+        series[index] = lastVal
 
   return seriesList
 

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -811,7 +811,8 @@ class FunctionsTest(TestCase):
                 'collectd.test-db2.load.value',
                 'collectd.test-db3.load.value',
                 'collectd.test-db4.load.value',
-                'collectd.test-db5.load.value'
+                'collectd.test-db5.load.value',
+                'collectd.test-db6.load.value',
             ],
             end=1,
             data=[
@@ -819,7 +820,8 @@ class FunctionsTest(TestCase):
                 [None,2,None,4,None,6,None,8,None,10,None,12,None,14,None,16,None,18,None,20],
                 [1,2,None,None,None,6,7,8,9,10,11,12,13,14,15,16,17,None,None,None],
                 [1,2,3,4,None,6,None,None,9,10,11,None,13,None,None,None,None,18,19,20],
-                [1,2,None,None,None,6,7,8,9,10,11,12,13,14,15,16,17,18,None,None]
+                [1,2,None,None,None,6,7,8,9,10,11,12,13,14,15,16,17,18,None,None],
+                [1,None,3,None,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,None],
             ]
         )
 
@@ -829,6 +831,7 @@ class FunctionsTest(TestCase):
             TimeSeries('keepLastValue(collectd.test-db3.load.value)',0,1,1,[1,2,None,None,None,6,7,8,9,10,11,12,13,14,15,16,17,None,None,None]),
             TimeSeries('keepLastValue(collectd.test-db4.load.value)',0,1,1,[1,2,3,4,4,6,6,6,9,10,11,11,13,None,None,None,None,18,19,20]),
             TimeSeries('keepLastValue(collectd.test-db5.load.value)',0,1,1,[1,2,None,None,None,6,7,8,9,10,11,12,13,14,15,16,17,18,18,18]),
+            TimeSeries('keepLastValue(collectd.test-db6.load.value)',0,1,1,[1,1,3,3,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,19]),
         ]
         results = functions.keepLastValue({}, seriesList, 2)
         self.assertEqual(results, expectedResult)


### PR DESCRIPTION
This PR aims to improve the performance of `keepLastValue` by avoiding overwriting every point unnecessarily, and avoiding the array lookup & calculation for every point backfilled.