### PR TITLE
handle highest/lowest thresholds specified as numeric strings

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2697,7 +2697,7 @@ def highest(requestContext, seriesList, n=1, func='average'):
   Draws the 5 servers with the highest number of busy threads.
   """
   seriesList.sort(key=keyFunc(getAggFunc(func)), reverse=True)
-  return seriesList[:n]
+  return seriesList[:int(n)]
 
 highest.group = 'Filter Series'
 highest.params = [
@@ -2721,7 +2721,7 @@ def lowest(requestContext, seriesList, n=1, func='average'):
   Draws the 5 servers with the lowest number of busy threads.
   """
   seriesList.sort(key=keyFunc(getAggFunc(func)))
-  return seriesList[:n]
+  return seriesList[:int(n)]
 
 lowest.group = 'Filter Series'
 lowest.params = [


### PR DESCRIPTION
If a user specifies the `n` parameter to any of the `highest*` or `lowest*` functions as a numeric string `'20'` rather than a bare number `20` they will receive the error `TypeError: slice indices must be integers or None or have an __index__ method` since the string value can't be used to slice the list of series.

This PR implements a very simple fix by casting the provided value to an integer before using it to slice the series list, which will avoid this issue.

Longer-term a better solution to this kind of problem is likely going to be to use the function definition to perform validation and normalization in `evaluateTokens` before calling the actual function.