### PR TITLE
carbonlink: set the type of the recv buffer explicitly to bytes

### DIFF
--- a/webapp/graphite/carbonlink.py
+++ b/webapp/graphite/carbonlink.py
@@ -180,7 +180,7 @@ class CarbonLinkPool(object):
 
   @staticmethod
   def recv_exactly(conn, num_bytes):
-    buf = ''
+    buf = b''
     while len(buf) < num_bytes:
       data = conn.recv(num_bytes - len(buf))
       if not data:


### PR DESCRIPTION
This is needed for python3 to treat it as bytes. For py2 bytes is
the same as str so does not change the behavior.

fixes: https://github.com/graphite-project/carbon/issues/756