### PR TITLE
Allow history tracking in composer

### DIFF
--- a/webapp/content/js/composer.js
+++ b/webapp/content/js/composer.js
@@ -97,7 +97,7 @@ GraphiteComposer.prototype = {
     }
     this.window.updateTimeDisplay(timeInfo);
     this.window.updateUI();
-    this.updateImage();
+    this.updateImage(true);
   },
 
   syncTargetList: function () {
@@ -107,7 +107,7 @@ GraphiteComposer.prototype = {
     }, this);
   },
 
-  updateImage: function () {
+  updateImage: function (urlLoad) {
     /* Set the image's url to reflect this.url's current params */
     var img = this.window.getImage();
     if (img) {
@@ -115,6 +115,20 @@ GraphiteComposer.prototype = {
       var unixTime = now.valueOf() / 1000;
       this.url.setParam('_salt', unixTime.toString() );
       img.src = this.url.getURL();
+      if (this.topWindow && !urlLoad) {
+        this.url.removeParam('_salt');
+        this.topWindow.history.pushState('', '', '?' + this.url.queryString);
+      }
+    }
+  },
+
+  enableHistory: function (topWindow) {
+    if (topWindow.history && topWindow.history.pushState) {
+      this.topWindow = topWindow;
+      var that = this;
+      topWindow.onpopstate = function(e) {
+        that.loadURL(topWindow.location.href);
+      };
     }
   },
 

--- a/webapp/content/js/composer.js
+++ b/webapp/content/js/composer.js
@@ -126,7 +126,7 @@ GraphiteComposer.prototype = {
     if (topWindow.history && topWindow.history.pushState) {
       this.topWindow = topWindow;
       var that = this;
-      topWindow.onpopstate = function(e) {
+      topWindow.onpopstate = function() {
         that.loadURL(topWindow.location.href);
       };
     }

--- a/webapp/graphite/templates/composer.html
+++ b/webapp/graphite/templates/composer.html
@@ -134,7 +134,8 @@ limitations under the License. -->
           recursiveExpand.expand(Browser.trees.graphite, parts);
 
         }
-
+        /* Enable forward / backward functionality */
+        Composer.enableHistory(window.top);
       } // init
 
 </script>


### PR DESCRIPTION
Adds forward / backward functionality too the composer for easier navigation. Also, the url updates whenever the composer is modified, allowing the (long) url to be copy-pasted from the address bar.

Test locally in Firefox, Chrome, and Safari.