### PR TITLE
Better support for variant in ceres

### DIFF
--- a/webapp/graphite/finders/__init__.py
+++ b/webapp/graphite/finders/__init__.py
@@ -26,14 +26,6 @@ def fs_to_metric(path):
     return os.path.join(dirpath, filename.split('.')[0]).replace(os.sep, '.')
 
 
-def _deduplicate(entries):
-    yielded = set()
-    for entry in entries:
-        if entry not in yielded:
-            yielded.add(entry)
-            yield entry
-
-
 def extract_variants(pattern):
     """Extract the pattern variants (ie. {foo,bar}baz = foobaz or barbaz)."""
     v1, v2 = pattern.find('{'), pattern.find('}')
@@ -43,7 +35,7 @@ def extract_variants(pattern):
 
     else:
         variants = [pattern]
-    return list(_deduplicate(variants))
+    return list(set(variants))
 
 
 def match_entries(entries, pattern):
@@ -53,7 +45,7 @@ def match_entries(entries, pattern):
     for variant in expand_braces(pattern):
         matching.extend(fnmatch.filter(entries, variant))
 
-    return list(_deduplicate(matching))
+    return list(set(matching))
 
 
 """

--- a/webapp/graphite/finders/__init__.py
+++ b/webapp/graphite/finders/__init__.py
@@ -32,10 +32,9 @@ def extract_variants(pattern):
     if v1 > -1 and v2 > v1:
         variations = pattern[v1 + 1:v2].split(',')
         variants = [pattern[:v1] + v + pattern[v2 + 1:] for v in variations]
-
+        return list({r for v in variants for r in extract_variants(v)})
     else:
-        variants = [pattern]
-    return list(set(variants))
+        return [pattern]
 
 
 def match_entries(entries, pattern):

--- a/webapp/tests/test_finders.py
+++ b/webapp/tests/test_finders.py
@@ -371,6 +371,9 @@ class CeresFinderTest(TestCase):
         nodes = finder.find_nodes(FindQuery('*.ba?.{baz,foo}', None, None))
         self.assertEqual(len(list(nodes)), 2)
 
+        nodes = finder.find_nodes(FindQuery('{bar,foo}.{bar,baz}.{baz,foo}', None, None))
+        self.assertEqual(len(list(nodes)), 2)
+
         nodes = finder.find_nodes(FindQuery('foo;bar=baz', None, None))
         self.assertEqual(len(list(nodes)), 1)
 


### PR DESCRIPTION
Currently, a FindQuery for `{foo,bar}.{foz,baz}` will search on a ceres database for `foo.{foz,baz}` and `bar.{foz,baz}`; it's expanding only the first match.

This PR contains a test for triggering this issue and a fix for this issue.