### PR TITLE
Fix get_real_metric_path for paths where an intermediate directory is a symlink

### DIFF
--- a/webapp/graphite/finders/__init__.py
+++ b/webapp/graphite/finders/__init__.py
@@ -11,8 +11,8 @@ def get_real_metric_path(absolute_path, metric_path):
     if absolute_path != real_absolute_path:
         # replace left side base_fs_path that contains sym link with real fs path
         relative_fs_path = metric_path.replace('.', os.sep)
-        absolute_path_no_ext, _ext = os.path.splitext(absolute_path)
-        base_fs_path = os.path.dirname(absolute_path_no_ext[:-len(relative_fs_path)])
+        real_absolute_path_no_ext, _ext = os.path.splitext(real_absolute_path)
+        base_fs_path = os.path.dirname(real_absolute_path_no_ext[:-len(relative_fs_path)])
         real_base_fs_path = os.path.realpath(base_fs_path)
         real_relative_fs_path = real_absolute_path[len(real_base_fs_path):].lstrip(os.sep)
         return fs_to_metric(real_relative_fs_path)

--- a/webapp/tests/test_finders.py
+++ b/webapp/tests/test_finders.py
@@ -302,16 +302,27 @@ class StandardFinderTest(TestCase):
     def dummy_realpath(path):
         return path.replace("some/symbolic/path", "this/is/the/real/path")
 
+    def dummy_realpath2(path):
+        return path.replace("foo/bar", "bar")
+
     @patch('os.path.realpath', wraps=dummy_realpath)
-    def test_get_real_metric_path_symlink_outside(self, dummy_realpath):
+    def test_get_real_metric_path_symlink_before(self, dummy_realpath):
         input_abs_path='/some/symbolic/path/graphite/whisper/Env/HTTP/NumConnections.wsp'
         input_metric_path='Env.HTTP.NumConnections'
         expected_metric_path='Env.HTTP.NumConnections'
         output_metric_path = get_real_metric_path(input_abs_path, input_metric_path)
         self.assertEqual(output_metric_path, expected_metric_path)
 
+    @patch('os.path.realpath', wraps=dummy_realpath2)
+    def test_get_real_metric_path_symlink_inside(self, dummy_realpath2):
+        input_abs_path='/opt/graphite/storage/whisper/foo/bar/Env/HTTP/NumConnections.wsp'
+        input_metric_path='bar.Env.HTTP.NumConnections'
+        expected_metric_path='bar.Env.HTTP.NumConnections'
+        output_metric_path = get_real_metric_path(input_abs_path, input_metric_path)
+        self.assertEqual(output_metric_path, expected_metric_path)
+
     @patch('os.path.realpath', wraps=dummy_realpath)
-    def test_get_real_metric_path_symlink_inside(self, dummy_realpath):
+    def test_get_real_metric_path_symlink_after(self, dummy_realpath):
         input_abs_path='/opt/graphite/storage/whisper/some/symbolic/path/NumConnections.wsp'
         input_metric_path='some.symbolic.path.NumConnections'
         expected_metric_path='this.is.the.real.path.NumConnections'


### PR DESCRIPTION
See #2320 