### PR TITLE
Latest whitenoise is not supported by graphite

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ cairocffi
 git+git://github.com/graphite-project/whisper.git#egg=whisper
 # Ceres is optional
 # git+git://github.com/graphite-project/ceres.git#egg=ceres
-whitenoise
+whitenoise==3.3.1
 scandir
 urllib3
 six


### PR DESCRIPTION
This is a temporary fix to use an older version