### PR TITLE
Add support for WhiteNoise 4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ cairocffi
 git+git://github.com/graphite-project/whisper.git#egg=whisper
 # Ceres is optional
 # git+git://github.com/graphite-project/ceres.git#egg=ceres
-whitenoise==3.3.1
+whitenoise
 scandir
 urllib3
 six

--- a/webapp/graphite/app_settings.py
+++ b/webapp/graphite/app_settings.py
@@ -20,6 +20,17 @@ try:
     import raven
 except ImportError:
     raven = None
+try:
+    import whitenoise
+except ImportError:
+    whitenoise = False
+else:
+    whitenoise_version = tuple(map(
+            int, getattr(whitenoise, '__version__', '0').split('.')))
+    # Configure WhiteNoise < 3.2 from wsgi.py
+    # http://whitenoise.evans.io/en/stable/changelog.html#v4-0
+    if whitenoise_version < (3, 2):
+        whitenoise = False
 
 #Django settings below, do not touch!
 APPEND_SLASH = False
@@ -70,6 +81,10 @@ MIDDLEWARE = (
   'django.contrib.auth.middleware.AuthenticationMiddleware',
   'django.contrib.messages.middleware.MessageMiddleware',
 )
+
+if whitenoise:
+    MIDDLEWARE += ('whitenoise.middleware.WhiteNoiseMiddleware', )
+
 # SessionAuthenticationMiddleware is enabled by default since 1.10 and
 # deprecated since 2.0
 if DJANGO_VERSION < (1, 10):

--- a/webapp/graphite/wsgi.py
+++ b/webapp/graphite/wsgi.py
@@ -18,12 +18,16 @@ try:
 except ImportError:
     whitenoise = False
 else:
+    whitenoise_version = tuple(map(
+            int, getattr(whitenoise, '__version__', '0').split('.')))
     # WhiteNoise < 2.0.1 does not support Python 2.6
     if sys.version_info[:2] < (2, 7):
-        whitenoise_version = tuple(map(
-                int, getattr(whitenoise, '__version__', '0').split('.')))
         if whitenoise_version < (2, 0, 1):
             whitenoise = False
+    # Configure WhiteNoise >= 3.2 as middleware from app_settings.py
+    # http://whitenoise.evans.io/en/stable/changelog.html#v4-0
+    if whitenoise_version >= (3, 2):
+        whitenoise = False
 
 if whitenoise:
     from whitenoise.django import DjangoWhiteNoise


### PR DESCRIPTION
https://github.com/graphite-project/graphite-web/issues/2332
https://github.com/graphite-project/graphite-web/pull/2331

This should fix support for WhiteNoise 4. Note that you'll need Django > 1.10 (I think).

I've only tested with gunicorn. Had to rerun manage.py collectstatic.