### PR TITLE
Adding support for json responses from CLUSTER_SERVERS

### DIFF
--- a/webapp/graphite/finders/remote.py
+++ b/webapp/graphite/finders/remote.py
@@ -107,7 +107,11 @@ class RemoteFinder(BaseFinder):
                 timeout=settings.FIND_TIMEOUT)
 
             try:
-                if result.getheader('content-type') == 'application/x-msgpack':
+                content_type = result.getheader('content-type')
+                if content_type == 'application/json':
+                  results = json.load(BufferedHTTPReader(
+                    result, buffer_size=settings.REMOTE_BUFFER_SIZE))
+                elif content_type == 'application/x-msgpack':
                   results = msgpack.load(BufferedHTTPReader(
                     result, buffer_size=settings.REMOTE_BUFFER_SIZE), encoding='utf-8')
                 else:

--- a/webapp/tests/test_finders_remote.py
+++ b/webapp/tests/test_finders_remote.py
@@ -194,7 +194,7 @@ class RemoteFinderTest(TestCase):
         },
       ]
       responseObject = HTTPResponse(
-        body=BytesIO(json.dumps(data)),
+        body=BytesIO(json.dumps(data).encode("UTF-8")),
         status=200,
         preload_content=False,
         headers={'Content-Type': 'application/json'})
@@ -351,7 +351,7 @@ class RemoteFinderTest(TestCase):
         }
       ]
       responseObject = HTTPResponse(
-        body=BytesIO(json.dumps(data)),
+        body=BytesIO(json.dumps(data).encode("UTF-8")),
         status=200,
         preload_content=False,
         headers={'Content-Type': 'application/json'})

--- a/webapp/tests/test_readers_remote.py
+++ b/webapp/tests/test_readers_remote.py
@@ -211,7 +211,7 @@ class RemoteReaderTests(TestCase):
                 }
                ]
         responseObject = HTTPResponse(
-          body=BytesIO(json.dumps(data)),
+          body=BytesIO(json.dumps(data).encode("UTF-8")),
           status=200,
           preload_content=False,
           headers={'Content-Type': 'application/json'}


### PR DESCRIPTION
Adding json support to RemoteFinder and RemoteReader. Some existing tests verified on inconsistent behavior, and this calls for thorough review.