### PR TITLE
Do not use generator for jobs need to be run in pool

### DIFF
--- a/webapp/tests/test_finders_remote.py
+++ b/webapp/tests/test_finders_remote.py
@@ -82,9 +82,7 @@ class RemoteFinderTest(TestCase):
       http_request.return_value = responseObject
 
       query = FindQuery('a.b.c', startTime, endTime)
-      result = finder.find_nodes(query)
-
-      nodes = list(result)
+      nodes = finder.find_nodes(query)
 
       self.assertEqual(http_request.call_args[0], (
         'POST',
@@ -132,9 +130,7 @@ class RemoteFinderTest(TestCase):
       http_request.return_value = responseObject
 
       query = FindQuery('a.b.c', None, None)
-      result = finder.find_nodes(query)
-
-      nodes = list(result)
+      nodes = finder.find_nodes(query)
 
       self.assertEqual(http_request.call_args[0], (
         'POST',
@@ -163,10 +159,8 @@ class RemoteFinderTest(TestCase):
       responseObject = HTTPResponse(body=BytesIO(b'error'), status=200, preload_content=False)
       http_request.return_value = responseObject
 
-      result = finder.find_nodes(query)
-
       with self.assertRaisesRegexp(Exception, 'Error decoding find response from https://[^ ]+: .+'):
-        list(result)
+        finder.find_nodes(query)
 
     @patch('graphite.finders.remote.cache.get')
     @patch('urllib3.PoolManager.request')
@@ -189,9 +183,7 @@ class RemoteFinderTest(TestCase):
       cache_get.return_value = data
 
       query = FindQuery('a.b.c', startTime, endTime)
-      result = finder.find_nodes(query)
-
-      nodes = list(result)
+      nodes = finder.find_nodes(query)
 
       self.assertEqual(http_request.call_count, 0)
 

--- a/webapp/tests/test_finders_remote.py
+++ b/webapp/tests/test_finders_remote.py
@@ -84,8 +84,6 @@ class RemoteFinderTest(TestCase):
       query = FindQuery('a.b.c', startTime, endTime)
       result = finder.find_nodes(query)
 
-      self.assertIsInstance(result, types.GeneratorType)
-
       nodes = list(result)
 
       self.assertEqual(http_request.call_args[0], (
@@ -135,8 +133,6 @@ class RemoteFinderTest(TestCase):
 
       query = FindQuery('a.b.c', None, None)
       result = finder.find_nodes(query)
-
-      self.assertIsInstance(result, types.GeneratorType)
 
       nodes = list(result)
 
@@ -194,8 +190,6 @@ class RemoteFinderTest(TestCase):
 
       query = FindQuery('a.b.c', startTime, endTime)
       result = finder.find_nodes(query)
-
-      self.assertIsInstance(result, types.GeneratorType)
 
       nodes = list(result)
 

--- a/webapp/tests/test_finders_remote.py
+++ b/webapp/tests/test_finders_remote.py
@@ -1,5 +1,4 @@
 import logging
-import types
 
 from urllib3.response import HTTPResponse
 


### PR DESCRIPTION
As generators are lazy, in context of pool exceution it will return
immediately and exceptions can not be caught as expected.