### PR TITLE
move deserialize into remote finder

### DIFF
--- a/webapp/graphite/finders/remote.py
+++ b/webapp/graphite/finders/remote.py
@@ -106,21 +106,7 @@ class RemoteFinder(BaseFinder):
                 headers=query.headers,
                 timeout=settings.FIND_TIMEOUT)
 
-            try:
-                if result.getheader('content-type') == 'application/x-msgpack':
-                  results = msgpack.load(BufferedHTTPReader(
-                    result, buffer_size=settings.REMOTE_BUFFER_SIZE), encoding='utf-8')
-                else:
-                  results = unpickle.load(BufferedHTTPReader(
-                    result, buffer_size=settings.REMOTE_BUFFER_SIZE))
-            except Exception as err:
-                self.fail()
-                log.exception(
-                    "RemoteFinder[%s] Error decoding find response from %s: %s" %
-                    (self.host, result.url_full, err))
-                raise Exception("Error decoding find response from %s: %s" % (result.url_full, err))
-            finally:
-                result.release_conn()
+            results = self.deserialize(result)
 
             cache.set(cacheKey, results, settings.FIND_CACHE_DURATION)
 
@@ -286,3 +272,67 @@ class RemoteFinder(BaseFinder):
 
         log.debug("RemoteFinder[%s] Fetched %s" % (self.host, url_full))
         return result
+
+    def deserialize(self, result):
+        """
+        Based on configuration, either stream-deserialize a response in settings.REMOTE_BUFFER_SIZE chunks,
+        or read the entire payload and use inline deserialization.
+        :param result: an http response object
+        :return: deserialized response payload from cluster server
+        """
+        start = time.time()
+        try:
+            should_buffer = settings.REMOTE_BUFFER_SIZE > 0
+            measured_reader = MeasuredReader(BufferedHTTPReader(result, settings.REMOTE_BUFFER_SIZE))
+
+            if should_buffer:
+                log.debug("Using streaming deserializer.")
+                reader = BufferedHTTPReader(measured_reader, settings.REMOTE_BUFFER_SIZE)
+                return self._deserialize_stream(reader, result.getheader('content-type'))
+
+            log.debug("Using inline deserializer for small payload")
+            return self._deserialize_buffer(measured_reader.read(), result.getheader('content-type'))
+        except Exception as err:
+            self.fail()
+            log.exception(
+                "RemoteFinder[%s] Error decoding response from %s: %s" %
+                (self.host, result.url_full, err))
+            raise Exception("Error decoding response from %s: %s" % (result.url_full, err))
+        finally:
+            log.debug("Processed %d bytes in %f seconds." % (measured_reader.bytes_read, time.time() - start))
+            result.release_conn()
+
+    @staticmethod
+    def _deserialize_buffer(byte_buffer, content_type):
+        if content_type == 'application/x-msgpack':
+            data = msgpack.unpackb(byte_buffer, encoding='utf-8')
+        else:
+            data = unpickle.loads(byte_buffer)
+
+        return data
+
+    @staticmethod
+    def _deserialize_stream(stream, content_type):
+        if content_type == 'application/x-msgpack':
+            data = msgpack.load(stream, encoding='utf-8')
+        else:
+            data = unpickle.load(stream)
+
+        return data
+
+
+class MeasuredReader(object):
+    def __init__(self, reader):
+        self.reader = reader
+        self.bytes_read = 0
+
+    def read(self, amt=None):
+        b = b''
+        try:
+            if amt:
+                b = self.reader.read(amt)
+            else:
+                b = self.reader.read()
+            return b
+        finally:
+            self.bytes_read += len(b)

--- a/webapp/tests/test_finders_remote.py
+++ b/webapp/tests/test_finders_remote.py
@@ -158,7 +158,7 @@ class RemoteFinderTest(TestCase):
       responseObject = HTTPResponse(body=BytesIO(b'error'), status=200, preload_content=False)
       http_request.return_value = responseObject
 
-      with self.assertRaisesRegexp(Exception, 'Error decoding find response from https://[^ ]+: .+'):
+      with self.assertRaisesRegexp(Exception, 'Error decoding response from https://[^ ]+: .+'):
         finder.find_nodes(query)
 
     @patch('graphite.finders.remote.cache.get')

--- a/webapp/tests/test_finders_remote.py
+++ b/webapp/tests/test_finders_remote.py
@@ -57,11 +57,19 @@ class RemoteFinderTest(TestCase):
       with patch('graphite.finders.remote.time.time', lambda: 110):
         self.assertFalse(finder.disabled)
 
+    @override_settings(REMOTE_BUFFER_SIZE=1024 * 1024)
+    def test_find_nodes_with_buffering(self):
+      self._test_find_nodes()
+
+    @override_settings(REMOTE_BUFFER_SIZE=0)
+    def test_find_nodes_without_buffering(self):
+      self._test_find_nodes()
+
     @patch('urllib3.PoolManager.request')
     @override_settings(INTRACLUSTER_HTTPS=False)
     @override_settings(REMOTE_STORE_USE_POST=True)
     @override_settings(FIND_TIMEOUT=10)
-    def test_find_nodes(self, http_request):
+    def _test_find_nodes(self, http_request):
       finder = RemoteFinder('127.0.0.1')
 
       startTime = 1496262000

--- a/webapp/tests/test_readers_remote.py
+++ b/webapp/tests/test_readers_remote.py
@@ -148,7 +148,7 @@ class RemoteReaderTests(TestCase):
         responseObject = HTTPResponse(body=BytesIO(b'error'), status=200, preload_content=False)
         http_request.return_value = responseObject
 
-        with self.assertRaisesRegexp(Exception, 'Error decoding render response from http://[^ ]+: .+'):
+        with self.assertRaisesRegexp(Exception, 'Error decoding response from http://[^ ]+: .+'):
           reader.fetch(startTime, endTime)
 
         # invalid response data


### PR DESCRIPTION
This addresses the issue outlined in #2352 by moving the `deserialize` functions into the remote finder and using them in `find_nodes`.

While this code passes all tests I have not actually tried it yet and would appreciate feedback from anyone who has time to experiment with it.