### PR TITLE
Fix Dashboard Completer UI to work with changes to /metrics/find

### DIFF
--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -389,6 +389,9 @@ function initDashboard () {
   var autocompleteTask = new Ext.util.DelayedTask(function () {
     var query = metricSelectorTextField.getValue();
     var store = metricSelectorGrid.getStore();
+    if (query === '') {
+      query = '*'
+    }
     store.setBaseParam('query', query);
     store.load();
   });

--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -337,7 +337,7 @@ function initDashboard () {
         url: document.body.dataset.baseUrl + 'metrics/find/',
         autoLoad: true,
         baseParams: {
-          query: '',
+          query: '*',
           format: 'completer',
           automatic_variants: (UI_CONFIG.automatic_variants) ? '1' : '0'
         },


### PR DESCRIPTION
PR #2295 broke the Completer in Dashboard.  Default value for query for the past 7+ years has been ''.  Change to be '\*' and override input of '' to be '\*' where I found them.

This fixes for my minimal testing of master.  It's possible there are other places that will need to be corrected.