### PR TITLE
Add a minValue option to nonNegativeDerivative and perSecond

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1973,11 +1973,14 @@ derivative.params = [
 ]
 
 
-def perSecond(requestContext, seriesList, maxValue=None):
+def perSecond(requestContext, seriesList, maxValue=None, minValue=None):
   """
   NonNegativeDerivative adjusted for the series time interval
   This is useful for taking a running total metric and showing how many requests
   per second were handled.
+
+  The optional ``minValue`` and ``maxValue`` parameters have the same
+  meaning as in ``nonNegativeDerivative``.
 
   Example:
 
@@ -1997,7 +2000,7 @@ def perSecond(requestContext, seriesList, maxValue=None):
     step = series.step
 
     for val in series:
-      delta, prev = _nonNegativeDelta(val, prev, maxValue)
+      delta, prev = _nonNegativeDelta(val, prev, maxValue, minValue)
 
       if delta is not None:
         # Division long by float cause OverflowError
@@ -2020,6 +2023,7 @@ perSecond.group = 'Transform'
 perSecond.params = [
   Param('seriesList', ParamTypes.seriesList, required=True),
   Param('maxValue', ParamTypes.float),
+  Param('minValue', ParamTypes.float),
 ]
 
 
@@ -2147,12 +2151,17 @@ integralByInterval.params = [
 ]
 
 
-def nonNegativeDerivative(requestContext, seriesList, maxValue=None):
+def nonNegativeDerivative(requestContext, seriesList, maxValue=None, minValue=None):
   """
   Same as the derivative function above, but ignores datapoints that trend
   down.  Useful for counters that increase for a long time, then wrap or
   reset. (Such as if a network interface is destroyed and recreated by unloading
   and re-loading a kernel module, common with USB / WiFi cards.
+
+  By default, a null value is returned in place of negative datapoints. When
+  ``maxValue`` is supplied, the missing value is computed as if the counter
+  had wrapped at ``maxValue``. When ``minValue`` is supplied, the missing
+  value is computed as if the counter had wrapped to ``minValue``.
 
   Example:
 
@@ -2168,7 +2177,7 @@ def nonNegativeDerivative(requestContext, seriesList, maxValue=None):
     prev = None
 
     for val in series:
-      delta, prev = _nonNegativeDelta(val, prev, maxValue)
+      delta, prev = _nonNegativeDelta(val, prev, maxValue, minValue)
 
       newValues.append(delta)
 
@@ -2184,12 +2193,15 @@ nonNegativeDerivative.group = 'Transform'
 nonNegativeDerivative.params = [
   Param('seriesList', ParamTypes.seriesList, required=True),
   Param('maxValue', ParamTypes.float),
+  Param('minValue', ParamTypes.float),
 ]
 
 
-def _nonNegativeDelta(val, prev, maxValue):
+def _nonNegativeDelta(val, prev, maxValue, minValue):
   # ignore values larger than maxValue
   if maxValue is not None and val > maxValue:
+    return None, None
+  if minValue is not None and val < minValue:
     return None, None
 
   # first reading
@@ -2200,12 +2212,16 @@ def _nonNegativeDelta(val, prev, maxValue):
   if val >= prev:
     return val - prev, val
 
-  # counter wrapped and we have maxValue
-  # calculate delta based on maxValue + 1 + val - prev
+  # counter wrapped and we have maxValue (and optionally minValue)
+  # calculate delta based on maxValue + 1 + val - prev - minValue
   if maxValue is not None:
-    return maxValue + 1 + val - prev, val
+    return maxValue + 1 + val - prev - (minValue or 0), val
+  # counter wrapped and we have maxValue
+  # calculate delta based on val - minValue
+  if minValue is not None:
+    return val - minValue, val
 
-  # counter wrapped or reset and we don't have maxValue
+  # counter wrapped or reset and we don't have minValue/maxValue
   # just use None
   return None, val
 

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -1637,6 +1637,18 @@ class FunctionsTest(TestCase):
         result = functions.nonNegativeDerivative({}, seriesList,5)
         self.assertEqual(expected, result, 'nonNegativeDerivative result incorrect')
 
+    def test_nonNegativeDerivative_min(self):
+        seriesList = self._gen_series_list_with_data(key='test',start=0,end=600,step=60,data=[0, 1, 2, 3, 4, 5, 2, 3, 4, 5])
+        expected = [TimeSeries('nonNegativeDerivative(test)', 0, 600, 60, [None, None, 1, 1, 1, 1, 1, 1, 1, 1])]
+        result = functions.nonNegativeDerivative({}, seriesList,None,1)
+        self.assertEqual(expected, result, 'nonNegativeDerivative result incorrect')
+
+    def test_nonNegativeDerivative_min_max(self):
+        seriesList = self._gen_series_list_with_data(key='test',start=0,end=600,step=60,data=[0, 1, 2, 3, 4, 5, 2, 3, 4, 5])
+        expected = [TimeSeries('nonNegativeDerivative(test)', 0, 600, 60, [None, None, 1, 1, 1, 1, 3, 1, 1, 1])]
+        result = functions.nonNegativeDerivative({}, seriesList,6,1)
+        self.assertEqual(expected, result, 'nonNegativeDerivative result incorrect')
+
     def test_perSecond(self):
         seriesList = self._gen_series_list_with_data(key='test',start=0,end=600,step=60,data=[0, 120, 240, 480, 960, 1920, 3840, 7680, 15360, 60 ** 256 + 15360 ])
         expected = [TimeSeries('perSecond(test)', 0, 600, 60, [None, 2, 2, 4, 8, 16, 32, 64, 128, 60 ** 255])]


### PR DESCRIPTION
It works in a way similar to maxValue: when the counter wraps, instead of
producing a null value, it computes the difference assuming the counter wrapped
to minValue.

See also #2374