### PR TITLE
Pinning whitenoise to 2.x for Django 1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,4 +40,4 @@ sphinx
 sphinx_rtd_theme
 cairocffi
 git+git://github.com/graphite-project/whisper.git@0.9.13#egg=whisper
-whitenoise
+whitenoise==2.0.6


### PR DESCRIPTION
Fixing #2378