### PR TITLE
[1.1.x] Do not use generator for jobs need to be run in pool | fix tests | remove unused import | move deserialize into remote finder | Multi-instance settings support | Fix default values in manage.py | Fix 

### DIFF
--- a/conf/graphite.wsgi.example
+++ b/conf/graphite.wsgi.example
@@ -1,4 +1,7 @@
 import sys
+# In case of multi-instance graphite, uncomment and set appropriate name
+# import os
+# os.environ['GRAPHITE_SETTINGS_MODULE'] = 'graphite.local_settings'
 sys.path.append('/opt/graphite/webapp')
 
 from graphite.wsgi import application

--- a/docs/config-local-settings.rst
+++ b/docs/config-local-settings.rst
@@ -1,6 +1,6 @@
 Graphite-web's local_settings.py
 ================================
-Graphite-web uses the convention of importing a ``local_settings.py`` file from the webapp ``settings.py`` module. This is where Graphite-web's runtime configuration is loaded from. Also alternate local settings module can be set. This may be usable for multi-instance way.
+Graphite-web uses the convention of importing a ``local_settings.py`` file from the webapp ``settings.py`` module. This is where Graphite-web's runtime configuration is loaded from. Also alternate local settings module can be set (see below). This may be usable for multi-instance deployments.
 
 
 Config File Location

--- a/docs/config-local-settings.rst
+++ b/docs/config-local-settings.rst
@@ -1,11 +1,13 @@
 Graphite-web's local_settings.py
 ================================
-Graphite-web uses the convention of importing a ``local_settings.py`` file from the webapp ``settings.py`` module. This is where Graphite-web's runtime configuration is loaded from.
+Graphite-web uses the convention of importing a ``local_settings.py`` file from the webapp ``settings.py`` module. This is where Graphite-web's runtime configuration is loaded from. Also alternate local settings module can be set. This may be usable for multi-instance way.
 
 
 Config File Location
 --------------------
-``local_settings.py`` is generally located within the main ``graphite`` module where the webapp's code lives. In the :ref:`default installation layout <default-installation-layout>` this is ``/opt/graphite/webapp/graphite/local_settings.py``. Alternative locations can be used by symlinking to this path or by ensuring the module can be found within the Python module search path.
+By default settings module is ``local_settings.py`` and it is generally located within the main ``graphite`` module where the webapp's code lives. In the :ref:`default installation layout <default-installation-layout>` this is ``/opt/graphite/webapp/graphite/local_settings.py``. Alternative locations can be used by symlinking to this path or by ensuring the module can be found within the Python module search path.
+
+This can be change by setting ``GRAPHITE_SETTINGS_MODULE`` environment variable. For example in a wsgi file.
 
 
 General Settings

--- a/docs/feeding-carbon.rst
+++ b/docs/feeding-carbon.rst
@@ -29,15 +29,15 @@ The data sent must be in the following format: ``<metric path> <metric value> <m
 
 On Unix, the ``nc`` program (``netcat``) can be used to create a socket and send data to Carbon (by default, 'plaintext' runs on port 2003):
 
-If you use the OpenBSD implementation of ``netcat``, please follow this example:
+If you use the FreeBSD/OpenBSD implementation of ``netcat``, please follow this example:
 
   .. code-block:: none
 
    PORT=2003
    SERVER=graphite.your.org
-   echo "local.random.diceroll 4 `date +%s`" | nc -q0 ${SERVER} ${PORT}
+   echo "local.random.diceroll 4 `date +%s`" | nc -N ${SERVER} ${PORT}
 
-  The ``-q0`` parameter instructs ``nc`` to close socket once data is sent. Without this option, some ``nc`` versions would keep the connection open.
+  The ``-N`` parameter instructs ``nc`` to close socket once data is sent. Without this option, some ``nc`` versions would keep the connection open.
 
 If you use the GNU implementation of ``netcat``, please follow this example:
 

--- a/docs/feeding-carbon.rst
+++ b/docs/feeding-carbon.rst
@@ -29,25 +29,15 @@ The data sent must be in the following format: ``<metric path> <metric value> <m
 
 On Unix, the ``nc`` program (``netcat``) can be used to create a socket and send data to Carbon (by default, 'plaintext' runs on port 2003):
 
-If you use the FreeBSD/OpenBSD implementation of ``netcat``, please follow this example:
-
   .. code-block:: none
 
    PORT=2003
    SERVER=graphite.your.org
-   echo "local.random.diceroll 4 `date +%s`" | nc -N ${SERVER} ${PORT}
-
-  The ``-N`` parameter instructs ``nc`` to close socket once data is sent. Without this option, some ``nc`` versions would keep the connection open.
-
-If you use the GNU implementation of ``netcat``, please follow this example:
-
-  .. code-block:: none
-
-   PORT=2003
-   SERVER=graphite.your.org
-   echo "local.random.diceroll 4 `date +%s`" | nc -c ${SERVER} ${PORT}
-
-  The ``-c`` parameter instructs ``nc`` to close socket once data is sent. Without this option, ``nc`` will keep the connection open and won't end.
+   echo "local.random.diceroll 4 `date +%s`" | nc ${SERVER} ${PORT}
+  
+  As many ``netcat`` implementations exist, a parameter may be needed to instruct ``nc`` to close the socket once data is sent. Such param will usually be ``-q0``, ``-c`` or ``-N``. Refer to your ``nc`` implementation man page to determine it.
+  
+  Note that if your Carbon instance is listening using the UDP protocol, you also need the ``-u`` parameter.
 
 The pickle protocol
 -------------------

--- a/webapp/graphite/finders/remote.py
+++ b/webapp/graphite/finders/remote.py
@@ -106,21 +106,7 @@ class RemoteFinder(BaseFinder):
                 headers=query.headers,
                 timeout=settings.FIND_TIMEOUT)
 
-            try:
-                if result.getheader('content-type') == 'application/x-msgpack':
-                  results = msgpack.load(BufferedHTTPReader(
-                    result, buffer_size=settings.REMOTE_BUFFER_SIZE), encoding='utf-8')
-                else:
-                  results = unpickle.load(BufferedHTTPReader(
-                    result, buffer_size=settings.REMOTE_BUFFER_SIZE))
-            except Exception as err:
-                self.fail()
-                log.exception(
-                    "RemoteFinder[%s] Error decoding find response from %s: %s" %
-                    (self.host, result.url_full, err))
-                raise Exception("Error decoding find response from %s: %s" % (result.url_full, err))
-            finally:
-                result.release_conn()
+            results = self.deserialize(result)
 
             cache.set(cacheKey, results, settings.FIND_CACHE_DURATION)
 
@@ -286,3 +272,67 @@ class RemoteFinder(BaseFinder):
 
         log.debug("RemoteFinder[%s] Fetched %s" % (self.host, url_full))
         return result
+
+    def deserialize(self, result):
+        """
+        Based on configuration, either stream-deserialize a response in settings.REMOTE_BUFFER_SIZE chunks,
+        or read the entire payload and use inline deserialization.
+        :param result: an http response object
+        :return: deserialized response payload from cluster server
+        """
+        start = time.time()
+        try:
+            should_buffer = settings.REMOTE_BUFFER_SIZE > 0
+            measured_reader = MeasuredReader(BufferedHTTPReader(result, settings.REMOTE_BUFFER_SIZE))
+
+            if should_buffer:
+                log.debug("Using streaming deserializer.")
+                reader = BufferedHTTPReader(measured_reader, settings.REMOTE_BUFFER_SIZE)
+                return self._deserialize_stream(reader, result.getheader('content-type'))
+
+            log.debug("Using inline deserializer for small payload")
+            return self._deserialize_buffer(measured_reader.read(), result.getheader('content-type'))
+        except Exception as err:
+            self.fail()
+            log.exception(
+                "RemoteFinder[%s] Error decoding response from %s: %s" %
+                (self.host, result.url_full, err))
+            raise Exception("Error decoding response from %s: %s" % (result.url_full, err))
+        finally:
+            log.debug("Processed %d bytes in %f seconds." % (measured_reader.bytes_read, time.time() - start))
+            result.release_conn()
+
+    @staticmethod
+    def _deserialize_buffer(byte_buffer, content_type):
+        if content_type == 'application/x-msgpack':
+            data = msgpack.unpackb(byte_buffer, encoding='utf-8')
+        else:
+            data = unpickle.loads(byte_buffer)
+
+        return data
+
+    @staticmethod
+    def _deserialize_stream(stream, content_type):
+        if content_type == 'application/x-msgpack':
+            data = msgpack.load(stream, encoding='utf-8')
+        else:
+            data = unpickle.load(stream)
+
+        return data
+
+
+class MeasuredReader(object):
+    def __init__(self, reader):
+        self.reader = reader
+        self.bytes_read = 0
+
+    def read(self, amt=None):
+        b = b''
+        try:
+            if amt:
+                b = self.reader.read(amt)
+            else:
+                b = self.reader.read()
+            return b
+        finally:
+            self.bytes_read += len(b)

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -207,7 +207,7 @@ DATABASES = None
 FLUSHRRDCACHED = ''
 
 ## Load our local_settings
-SETTINGS_MODULE = os.environ['GRAPHITE_SETTINGS_MODULE']
+SETTINGS_MODULE = os.environ.get('GRAPHITE_SETTINGS_MODULE', 'graphite.local_settings')
 try:
   globals().update(import_module(SETTINGS_MODULE).__dict__)
 except ImportError:

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -18,6 +18,7 @@ import os
 import sys
 from os.path import abspath, dirname, join
 from warnings import warn
+from importlib import import_module
 
 from django import VERSION as DJANGO_VERSION
 try:
@@ -206,10 +207,11 @@ DATABASES = None
 FLUSHRRDCACHED = ''
 
 ## Load our local_settings
+SETTINGS_MODULE = os.environ['GRAPHITE_SETTINGS_MODULE']
 try:
-  from graphite.local_settings import *  # noqa
+  globals().update(import_module(SETTINGS_MODULE).__dict__)
 except ImportError:
-  print("Could not import graphite.local_settings, using defaults!", file=sys.stderr)
+  print("Could not import {0}, using defaults!".format(SETTINGS_MODULE), file=sys.stderr)
 
 ## Load Django settings if they werent picked up in local_settings
 if not GRAPHITE_WEB_APP_SETTINGS_LOADED:

--- a/webapp/graphite/tags/localdatabase.py
+++ b/webapp/graphite/tags/localdatabase.py
@@ -121,7 +121,8 @@ class LocalDatabaseTagDB(BaseTagDB):
   def get_series(self, path, requestContext=None):
     return self._get_series(self._path_hash(path))
 
-  def _get_series(self, path_hash):
+  @staticmethod
+  def _get_series(path_hash):
     with connection.cursor() as cursor:
       sql = 'SELECT s.id, t.tag, v.value'
       sql += ' FROM tags_series AS s'

--- a/webapp/graphite/wsgi.py
+++ b/webapp/graphite/wsgi.py
@@ -7,6 +7,7 @@ except ImportError:
     from django.utils.importlib import import_module
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'graphite.settings')  # noqa
+os.environ.setdefault('GRAPHITE_SETTINGS_MODULE', 'graphite.local_settings')  # noqa
 
 from django.conf import settings
 from django.core.wsgi import get_wsgi_application

--- a/webapp/manage.py
+++ b/webapp/manage.py
@@ -5,6 +5,7 @@ import sys
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "graphite.settings")
+    os.environ.setdefault('GRAPHITE_SETTINGS_MODULE', 'graphite.local_settings')
 
     from django.core.management import execute_from_command_line
 

--- a/webapp/tests/test_finders_remote.py
+++ b/webapp/tests/test_finders_remote.py
@@ -158,7 +158,7 @@ class RemoteFinderTest(TestCase):
       responseObject = HTTPResponse(body=BytesIO(b'error'), status=200, preload_content=False)
       http_request.return_value = responseObject
 
-      with self.assertRaisesRegexp(Exception, 'Error decoding find response from https://[^ ]+: .+'):
+      with self.assertRaisesRegexp(Exception, 'Error decoding response from https://[^ ]+: .+'):
         finder.find_nodes(query)
 
     @patch('graphite.finders.remote.cache.get')

--- a/webapp/tests/test_finders_remote.py
+++ b/webapp/tests/test_finders_remote.py
@@ -82,9 +82,7 @@ class RemoteFinderTest(TestCase):
       http_request.return_value = responseObject
 
       query = FindQuery('a.b.c', startTime, endTime)
-      result = finder.find_nodes(query)
-
-      nodes = list(result)
+      nodes = finder.find_nodes(query)
 
       self.assertEqual(http_request.call_args[0], (
         'POST',
@@ -132,9 +130,7 @@ class RemoteFinderTest(TestCase):
       http_request.return_value = responseObject
 
       query = FindQuery('a.b.c', None, None)
-      result = finder.find_nodes(query)
-
-      nodes = list(result)
+      nodes = finder.find_nodes(query)
 
       self.assertEqual(http_request.call_args[0], (
         'POST',
@@ -163,10 +159,8 @@ class RemoteFinderTest(TestCase):
       responseObject = HTTPResponse(body=BytesIO(b'error'), status=200, preload_content=False)
       http_request.return_value = responseObject
 
-      result = finder.find_nodes(query)
-
       with self.assertRaisesRegexp(Exception, 'Error decoding find response from https://[^ ]+: .+'):
-        list(result)
+        finder.find_nodes(query)
 
     @patch('graphite.finders.remote.cache.get')
     @patch('urllib3.PoolManager.request')
@@ -189,9 +183,7 @@ class RemoteFinderTest(TestCase):
       cache_get.return_value = data
 
       query = FindQuery('a.b.c', startTime, endTime)
-      result = finder.find_nodes(query)
-
-      nodes = list(result)
+      nodes = finder.find_nodes(query)
 
       self.assertEqual(http_request.call_count, 0)
 

--- a/webapp/tests/test_finders_remote.py
+++ b/webapp/tests/test_finders_remote.py
@@ -84,8 +84,6 @@ class RemoteFinderTest(TestCase):
       query = FindQuery('a.b.c', startTime, endTime)
       result = finder.find_nodes(query)
 
-      self.assertIsInstance(result, types.GeneratorType)
-
       nodes = list(result)
 
       self.assertEqual(http_request.call_args[0], (
@@ -135,8 +133,6 @@ class RemoteFinderTest(TestCase):
 
       query = FindQuery('a.b.c', None, None)
       result = finder.find_nodes(query)
-
-      self.assertIsInstance(result, types.GeneratorType)
 
       nodes = list(result)
 
@@ -194,8 +190,6 @@ class RemoteFinderTest(TestCase):
 
       query = FindQuery('a.b.c', startTime, endTime)
       result = finder.find_nodes(query)
-
-      self.assertIsInstance(result, types.GeneratorType)
 
       nodes = list(result)
 

--- a/webapp/tests/test_finders_remote.py
+++ b/webapp/tests/test_finders_remote.py
@@ -1,5 +1,4 @@
 import logging
-import types
 
 from urllib3.response import HTTPResponse
 

--- a/webapp/tests/test_finders_remote.py
+++ b/webapp/tests/test_finders_remote.py
@@ -57,11 +57,19 @@ class RemoteFinderTest(TestCase):
       with patch('graphite.finders.remote.time.time', lambda: 110):
         self.assertFalse(finder.disabled)
 
+    @override_settings(REMOTE_BUFFER_SIZE=1024 * 1024)
+    def test_find_nodes_with_buffering(self):
+      self._test_find_nodes()
+
+    @override_settings(REMOTE_BUFFER_SIZE=0)
+    def test_find_nodes_without_buffering(self):
+      self._test_find_nodes()
+
     @patch('urllib3.PoolManager.request')
     @override_settings(INTRACLUSTER_HTTPS=False)
     @override_settings(REMOTE_STORE_USE_POST=True)
     @override_settings(FIND_TIMEOUT=10)
-    def test_find_nodes(self, http_request):
+    def _test_find_nodes(self, http_request):
       finder = RemoteFinder('127.0.0.1')
 
       startTime = 1496262000

--- a/webapp/tests/test_readers_remote.py
+++ b/webapp/tests/test_readers_remote.py
@@ -148,7 +148,7 @@ class RemoteReaderTests(TestCase):
         responseObject = HTTPResponse(body=BytesIO(b'error'), status=200, preload_content=False)
         http_request.return_value = responseObject
 
-        with self.assertRaisesRegexp(Exception, 'Error decoding render response from http://[^ ]+: .+'):
+        with self.assertRaisesRegexp(Exception, 'Error decoding response from http://[^ ]+: .+'):
           reader.fetch(startTime, endTime)
 
         # invalid response data


### PR DESCRIPTION
Backports the following commits to 1.1.x:
 - Do not use generator for jobs need to be run in pool (#2350)
 - fix tests (#2350)
 - remove unused import (#2350)
 - move deserialize into remote finder (#2354)
 - Multi-instance settings support (#2358)
 - Fix default values in manage.py (#2358)
 - Fix - a fallback have been added (#2358)
 - Update config-local-settings.rst (#2358)
 - test with and without buffering (#2354)
 - Update FreeBSD/OpenBSD netcat switch (#2366)
 - Generalized nc example (#2366)
 - use path hash to locate tagged series (#2368)
 - reduce duplication, maintain get_series interface (#2368)
 - make _get_series a static method (#2368)