### PR TITLE
fix dashboard graph metric list icon paths with URL_PREFIX

### DIFF
--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -4,7 +4,7 @@
 /*global AUTOCOMPLETE_DELAY CALENDAR_ICON CLOCK_ICON CONTEXT_FIELD_WIDTH FINDER_QUERY_DELAY*/
 /*global HELP_ICON NEW_DASHBOARD_REMOVE_GRAPHS REFRESH_ICON REMOVE_ICON RESIZE_ICON*/
 /*global SHARE_ICON UI_CONFIG initialState initialError permissions queryString userName*/
-/*global permissionsUnauthenticated schemes*/
+/*global UP_ICON DOWN_ICON TRASH_ICON permissionsUnauthenticated schemes*/
 // Defined in composer_widgets.js
 /*global createFunctionsMenu createOptionsMenu updateCheckItems*/
 
@@ -1922,7 +1922,7 @@ function graphClicked(graphView, graphIndex, element, evt) {
             width: 30,
             sortable: false,
             items: [{
-                icon: '/static/img/move_up.png',
+                icon: UP_ICON,
                 tooltip: 'Move Up',
                 handler: function(grid, rowIndex, colIndex) {
                     var record = targetStore.getAt(rowIndex);
@@ -1941,7 +1941,7 @@ function graphClicked(graphView, graphIndex, element, evt) {
             width: 30,
             sortable: false,
             items: [{
-                icon: '/static/img/move_down.png',
+                icon: DOWN_ICON,
                 tooltip: 'Move Down',
                 handler: function(grid, rowIndex, colIndex) {
                     var record = targetStore.getAt(rowIndex);
@@ -1960,7 +1960,7 @@ function graphClicked(graphView, graphIndex, element, evt) {
             width: 30,
             sortable: false,
             items: [{
-                icon: '/static/img/trash.png',
+                icon: TRASH_ICON,
                 tooltip: 'Delete Row',
                 handler: function(grid, rowIndex, colIndex) {
                     var record = targetStore.getAt(rowIndex);

--- a/webapp/graphite/templates/dashboard.html
+++ b/webapp/graphite/templates/dashboard.html
@@ -19,14 +19,12 @@
     var REMOVE_ICON   = '{% static "js/ext/resources/icons/fam/cross.gif" %}';
     var REFRESH_ICON  = '{% static "js/ext/resources/icons/fam/table_refresh.png" %}';
     var SHARE_ICON    = '{% static "js/ext/resources/icons/fam/application_go.png" %}';
+    var HELP_ICON     = '{% static "js/ext/resources/icons/fam/information.png" %}';
     var CALENDAR_ICON = '{% static "js/ext/resources/images/default/shared/calendar.gif" %}';
     var CLOCK_ICON    = '{% static "img/clock_16.png" %}';
-    var HELP_ICON     = '{% static "js/ext/resources/icons/fam/information.png" %}';
-
-    // Prefetch images for use in Target grid
-    (new Image()).src = '{% static "img/move_up.png" %}';
-    (new Image()).src = '{% static "img/move_down.png" %}';
-    (new Image()).src = '{% static "img/trash.png" %}';
+    var UP_ICON       = '{% static "img/move_up.png" %}';
+    var DOWN_ICON     = '{% static "img/move_down.png" %}';
+    var TRASH_ICON    = '{% static "img/trash.png" %}';
 
     {% if initialState %}
     var initialState = JSON.parse('{{ initialState|escapejs }}');


### PR DESCRIPTION
I configure graphite-web with `URL_PREFIX = "/graphite"` and these icon urls ended up wrong. This seems to fix it. All other icons in the dashboard and composer seem to be working. But maybe there's an even more correct way, related to the "static" template function? Should it be saved to a variable name like the others here:

https://github.com/graphite-project/graphite-web/blob/1.1.5/webapp/graphite/templates/dashboard.html#L27

EDIT: I went ahead and re-did this the global var way

----
for reference where this is:

before:

![screen shot 2019-02-05 at 20 37 27](https://user-images.githubusercontent.com/649835/52315688-0bb0bf80-2986-11e9-9bf3-e466f54009c3.png)

after:

![screen shot 2019-02-05 at 20 39 01](https://user-images.githubusercontent.com/649835/52315696-179c8180-2986-11e9-8f55-463ded243357.png)
