### PR TITLE
docs: for sql db migration to 1.1 recommend --fake-initial

### DIFF
--- a/docs/config-database-setup.rst
+++ b/docs/config-database-setup.rst
@@ -20,7 +20,10 @@ To set up a new database and create the initial schema, run:
 
 .. code-block:: none
 
-  PYTHONPATH=$GRAPHITE_ROOT/webapp django-admin.py migrate --settings=graphite.settings --run-syncdb
+  PYTHONPATH=$GRAPHITE_ROOT/webapp django-admin.py migrate --settings=graphite.settings
+
+.. note ::
+  Graphite-Web 1.0 and earlier had some models without migrations, and with Django 1.9 or later, the ``--run-syncdb`` option was needed for migrate to create tables for these models. (Django 1.8 and earlier did not have this option, but always exhibited this behavior.) In Graphite-Web 1.1 and later all models have migrations, so ``--run-syncdb`` is no longer needed. If upgrading a database created by Graphite-Web 1.0 or earlier, you need to use the ``--fake-initial`` option for migrate: it considers an initial migration to already be applied if the tables it creates already exist.
 
 If you are experiencing problems, uncomment the following line in /opt/graphite/webapp/graphite/local_settings.py:
 

--- a/docs/config-local-settings.rst
+++ b/docs/config-local-settings.rst
@@ -373,7 +373,7 @@ The following configures the Django database settings. Graphite uses the databas
 See the `Django documentation <https://docs.djangoproject.com/en/dev/ref/settings/#databases>`_ for full documentation of the DATABASES setting.
 
 .. note ::
-  Remember, setting up a new database requires running ``PYTHONPATH=$GRAPHITE_ROOT/webapp django-admin.py migrate --settings=graphite.settings --run-syncdb`` to create the initial schema.
+  Remember, setting up a new database requires running ``PYTHONPATH=$GRAPHITE_ROOT/webapp django-admin.py migrate --settings=graphite.settings`` to create the initial schema.
 
 .. note ::
   If you are using a custom database backend (other than SQLite) you must first create a $GRAPHITE_ROOT/webapp/graphite/local_settings.py file that overrides the database related settings from settings.py. Use $GRAPHITE_ROOT/webapp/graphite/local_settings.py.example as a template.

--- a/docs/releases/1_1_1.rst
+++ b/docs/releases/1_1_1.rst
@@ -176,7 +176,9 @@ If you're not already running from the *master* branch, Graphite-Web's applicati
   sudo cp /opt/graphite/storage/graphite.db \
         /opt/graphite/storage/graphite.db.backup-`date +%Y%m%d_%H%M%S`
   sudo PYTHONPATH=/opt/graphite/webapp django-admin.py migrate \
-        --noinput --settings=graphite.settings --run-syncdb
+        --noinput --settings=graphite.settings --fake-initial
+
+In this release of Graphite-Web, migrations have been added for any Django models that did not have them. Previously, if using Django 1.9 or later, one needed the ``--run-syncdb`` option for migrate to create tables for Graphite-Web models without migrations (and Django 1.8 or earlier did not have this option but always exhibited this behavior). Django keeps track of which migrations have been applied and attempts to run any that have not, and these new initial migrations try to create tables that already exist from previous versions of Graphite-Web, and fail. This common Django situation is resolved by the ``--fake-initial`` option for migrate: it considers an initial migration to already be applied if the tables it creates already exist.
 
 
 Other Changes


### PR DESCRIPTION
... and --run-syncdb should no longer be needed.

Initial migrations were created for all models just before 1.1.0
in d1912d4bc0f0. Prior to that, some models did not have any
migrations (and no initial migration), so --run-syncdb was needed
to create tables for them. But now that they have initial migrations,
those migrations run because django knows they have never been
applied, and they fail because the tables already exist. The
--fake-initial option is designed for this situation: it considers
initial migrations already applied if the tables already exist.

fixes #2412 
replaces #2126 

conflicts with #2409 and this is a tiny change so I'd be fine with rebasing this after that lands