### PR TITLE
add tag formatting docs

### DIFF
--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -17,7 +17,7 @@ Carbon will automatically decode the tags, normalize the tag order, and register
 
 .. _querying-tagged-series:
 
-Tag names must have a length of  ``>=1`` and they may contain any Ascii characters, except ``;!^=``. Tag values must also have a length of ``>=1``, and they may contain any Ascii characters, except ``;~``. UTF-8 characters may work for names and values, but they are not well tested and it is not recommendable to use UTF-8 anywhere in metric names or tags.
+Tag names must have a length >= 1 and may contain any ascii characters except ``;!^=``. Tag values must also have a length >= 1, and they may contain any ascii characters except ``;~``. UTF-8 characters may work for names and values, but they are not well tested and it is not recommended to use non-ascii characters in metric names or tags.
 
 Querying
 --------

--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -17,6 +17,8 @@ Carbon will automatically decode the tags, normalize the tag order, and register
 
 .. _querying-tagged-series:
 
+Tag names must have a length of  ``>=1`` and they may contain any Ascii characters, except ``;!^=``. Tag values must also have a length of ``>=1``, and they may contain any Ascii characters, except ``;~``. UTF-8 characters may work for names and values, but they are not well tested and it is not recommendable to use UTF-8 anywhere in metric names or tags.
+
 Querying
 --------
 
@@ -87,6 +89,8 @@ Finally, the `aliasByTags <functions.html#graphite.render.functions.aliasByTags>
     # will return
     # web01.disk.used
     # web02.disk.used
+
+If a tag name or value contains quotes (``'"``), then they will need to be escaped properly. For example a series with a tag ``tagName='quotedValue'`` could be queried with ``seriesByTag('tagName=\'quotedValue\'')`` or alternatively ``seriesByTag("tagName='quotedValue'")``.
 
 Database Storage
 ----------------


### PR DESCRIPTION
Defining which characters are allowed, and how to query for values containing quotes.

If you agree with the rules defined in this change, then I can also add an according validator to the TagDB