### PR TITLE
Fix dashboard template loading from URL

### DIFF
--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -798,7 +798,7 @@ function initDashboard () {
   if(window.location.hash != '')
   {
     if (window.location.hash.indexOf('/') != -1) {
-      var nameVal = window.location.hash.substr(1).split('#');
+      var nameVal = window.location.hash.substr(1).split('/');
       sendLoadTemplateRequest(nameVal[0],nameVal[1]);
     } else {
       sendLoadRequest(window.location.hash.substr(1));


### PR DESCRIPTION
This never worked right, but the backend dealt with it until recent changes.

This only happens when the dashboard template is loaded directly from the URL