### PR TITLE
Dashboard render urls missing document.body.dataset.baseUrl

### DIFF
--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -1406,7 +1406,7 @@ function newEmptyGraph() {
   var record = new GraphRecord({
    target: graphTargetString,
     params: myParams,
-    url: '/render?' + Ext.urlEncode(urlParams),
+    url: document.body.dataset.baseUrl + 'render?' + Ext.urlEncode(urlParams),
    'width': GraphSize.width,
    'height': GraphSize.height,
     });
@@ -1572,7 +1572,7 @@ function newFromMetric() {
     var record = new GraphRecord({
       target: graphTargetString,
       params: myParams,
-      url: '/render?' + Ext.urlEncode(urlParams)
+      url: document.body.dataset.baseUrl + 'render?' + Ext.urlEncode(urlParams)
       });
     graphStore.add([record]);
     updateGraphRecords();


### PR DESCRIPTION
This makes these url settings match the others in dashboard.js like in PR #797

I don't run on a different baseUrl, but I believe these should match the others.