### PR TITLE
Django22 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,18 @@ matrix:
       env:
         - TOXENV=pypy-django111-pyparsing2
     - python: 3.5
+      sudo: true
+      dist: xenial
       env:
         - TOXENV=py35-django21-pyparsing2
     - python: 3.5
+      sudo: true
+      dist: xenial
       env:
         - TOXENV=py35-django22-pyparsing2
     - python: 3.6
+      sudo: true
+      dist: xenial
       env:
         - TOXENV=py36-django22-pyparsing2
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,38 +9,35 @@ matrix:
     - python: pypy
       env:
         - TOXENV=pypy-django111-pyparsing2
-    - python: 3.4
-      env:
-        - TOXENV=py34-django20-pyparsing2
     - python: 3.5
       env:
         - TOXENV=py35-django21-pyparsing2
     - python: 3.5
       env:
-        - TOXENV=py35-django21-pyparsing2
+        - TOXENV=py35-django22-pyparsing2
     - python: 3.6
       env:
-        - TOXENV=py36-django21-pyparsing2
+        - TOXENV=py36-django22-pyparsing2
     - python: 3.7
       sudo: true
       dist: xenial
       env:
-        - TOXENV=py37-django21-pyparsing2-msgpack
+        - TOXENV=py37-django22-pyparsing2-msgpack
     - python: 3.7
       sudo: true
       dist: xenial
       env:
-        - TOXENV=py37-django21-pyparsing2-pyhash
+        - TOXENV=py37-django22-pyparsing2-pyhash
     - python: 3.7
       sudo: true
       dist: xenial
       env:
-        - TOXENV=py37-django21-pyparsing2-mysql TEST_MYSQL_PASSWORD=graphite
+        - TOXENV=py37-django22-pyparsing2-mysql TEST_MYSQL_PASSWORD=graphite
     - python: 3.7
       sudo: true
       dist: xenial
       env:
-        - TOXENV=py37-django21-pyparsing2-postgresql TEST_POSTGRESQL_PASSWORD=graphite
+        - TOXENV=py37-django22-pyparsing2-postgresql TEST_POSTGRESQL_PASSWORD=graphite
     - python: 3.7
       sudo: true
       dist: xenial
@@ -48,7 +45,6 @@ matrix:
         - TOXENV=lint
 
 env:
-  - TOXENV=py27-django18-pyparsing2
   - TOXENV=py27-django111-pyparsing2-msgpack
   - TOXENV=py27-django111-pyparsing2-pyhash
   - TOXENV=py27-django111-pyparsing2-mysql TEST_MYSQL_PASSWORD=graphite

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@
 #   deactivate
 #
 
-Django>=1.8,<2.1.99
+Django>=1.8,<2.3
 python-memcached==1.58
 txAMQP==0.8
 django-tagging==0.4.6

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ try:
         ['templates/*', 'local_settings.py.example']},
       scripts=glob('bin/*'),
       data_files=list(webapp_content.items()) + storage_dirs + conf_files + examples,
-      install_requires=['Django>=1.8,<2.1', 'django-tagging==0.4.3', 'pytz', 'pyparsing', 'cairocffi', 'urllib3', 'scandir', 'six'],
+      install_requires=['Django>=1.8,<2.3', 'django-tagging==0.4.3', 'pytz', 'pyparsing', 'cairocffi', 'urllib3', 'scandir', 'six'],
       classifiers=[
           'Intended Audience :: Developers',
           'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,7 @@
 [tox]
-# Django 21 does not support Python 3.4
-# Django 1.11 has a bug and does not work with Python 3.7 (this will be fixed)
 envlist =
-  py{27,py}-django1{8,11}-pyparsing2{,-msgpack,-pyhash},
-  py{34}-django{18,111,20}-pyparsing2{,-msgpack,-pyhash},
-  py{35,36}-django{18,111,20,21}-pyparsing2{,-msgpack,-pyhash},
-  py37-django{20,21}-pyparsing2{,-msgpack,-pyhash},
+  py{27,py}-django111-pyparsing2{,-msgpack,-pyhash},
+  py{35,36}-django{111,21,22}-pyparsing2{,-msgpack,-pyhash},
   lint, docs
 
 [testenv]
@@ -38,6 +34,7 @@ deps =
 	django111: Django>=1.11,<1.11.99
 	django20: Django>=2.0,<2.0.99
 	django21: Django>=2.1,<2.1.99
+	django22: Django>=2.2,<2.2.99
 	scandir
 	urllib3
 	redis

--- a/webapp/graphite/app_settings.py
+++ b/webapp/graphite/app_settings.py
@@ -109,6 +109,7 @@ INSTALLED_APPS = (
   'django.contrib.sessions',
   'django.contrib.admin',
   'django.contrib.contenttypes',
+  'django.contrib.messages',
   'django.contrib.staticfiles',
   'tagging',
 )


### PR DESCRIPTION
Adds "django.contrib.messages" to INSTALLED_APPS in local_settings.py for Django22 compatibility.

Adds Django 2.2 to testing, removes Django 1.8, 2.0 and Python 3.4 from testing (EOL).