### PR TITLE
added space before \

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -8,14 +8,14 @@ Try Graphite in Docker and have it running in seconds:
 
 .. code-block:: none
 
-    docker run -d\
-     --name graphite\
-     --restart=always\
-     -p 80:80\
-     -p 2003-2004:2003-2004\
-     -p 2023-2024:2023-2024\
-     -p 8125:8125/udp\
-     -p 8126:8126\
+    docker run -d \
+     --name graphite \
+     --restart=always \
+     -p 80:80 \
+     -p 2003-2004:2003-2004 \
+     -p 2023-2024:2023-2024 \
+     -p 8125:8125/udp \
+     -p 8126:8126 \
      graphiteapp/graphite-statsd
 
 Check `docker repo`_ for details.


### PR DESCRIPTION
I've encountered issues with current code snippet on some instances of centos, which can is fixed by adding extra spaces before \ signs.