### PR TITLE
docs: add netdata to 'tools that work with graphite'

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -58,7 +58,7 @@ Collection
   A java program which regularly queries metrics from a configured set of inputs, selects and renames them using regular expressions and sends them to a configured set of outputs. It supports JMX and JDBC as inputs and Graphite as output out of the box.
 
 `netdata`_
-  A fast and efficient monitoring agent that supports graphite backends. It has collection, forwarding, visualization and and monitoring features. Netdata collects common system metrics and a variety of other sources through plugins. 
+  A fast and efficient monitoring agent that supports graphite backends. It has collection, forwarding, visualization and monitoring features. Netdata collects common system metrics and a variety of other sources through plugins. 
 
 `Sensu`_
   A monitoring framework that can route metrics to Graphite. Servers subscribe to sets of checks, so getting metrics from a new server to Graphite is as simple as installing the Sensu client and subscribing.

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -57,6 +57,9 @@ Collection
 `metrics-sampler`_
   A java program which regularly queries metrics from a configured set of inputs, selects and renames them using regular expressions and sends them to a configured set of outputs. It supports JMX and JDBC as inputs and Graphite as output out of the box.
 
+`netdata`_
+  A fast and efficient monitoring agent that supports graphite backends. It has collection, forwarding, visualization and and monitoring features. Netdata collects common system metrics and a variety of other sources through plugins. 
+
 `Sensu`_
   A monitoring framework that can route metrics to Graphite. Servers subscribe to sets of checks, so getting metrics from a new server to Graphite is as simple as installing the Sensu client and subscribing.
 
@@ -384,6 +387,7 @@ Other
 .. _metrics-sampler: https://github.com/dimovelev/metrics-sampler
 .. _metrictank: https://github.com/grafana/metrictank
 .. _Moira: http://moira.readthedocs.io
+.. _netdata: https://github.com/netdata/netdata
 .. _New Relic: https://newrelic.com/platform
 .. _Pencil: https://github.com/fetep/pencil
 .. _pipe-to-graphite: https://github.com/iFixit/pipe-to-graphite


### PR DESCRIPTION
netdata is a project missing from this list. I hope people can benefit from having it linked here.