### PR TITLE
fix functions that aggregate to include the aliases in their params

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -286,7 +286,7 @@ aggFuncAliases = {
   'current': aggFuncs['last'],
 }
 
-aggFuncNames = sorted(aggFuncs.keys())
+aggFuncNames = sorted(aggFuncs.keys() + aggFuncAliases.keys())
 
 
 def getAggFunc(func, rawFunc=None):

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -286,7 +286,7 @@ aggFuncAliases = {
   'current': aggFuncs['last'],
 }
 
-aggFuncNames = sorted(list(aggFuncs.keys()) + list(aggFuncAliases.keys()))
+aggFuncNames = sorted(aggFuncs.keys()) + sorted(aggFuncAliases.keys())
 
 
 def getAggFunc(func, rawFunc=None):

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -286,7 +286,7 @@ aggFuncAliases = {
   'current': aggFuncs['last'],
 }
 
-aggFuncNames = sorted(aggFuncs.keys() + aggFuncAliases.keys())
+aggFuncNames = sorted(list(aggFuncs.keys()) + list(aggFuncAliases.keys()))
 
 
 def getAggFunc(func, rawFunc=None):


### PR DESCRIPTION
This should fix the validation not being aware of legal aliases.
fix #2494

@DanCech will this break anything else that relies on `.params` ? i see this property is used in quite many places but didn't investigate them all