### PR TITLE
Upgrading minimal Django version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 ## Requirements for documentation
-Django>=1.4,<1.8
-django-tagging==0.3.1
+Django>=1.11.19,<2.3
+django-tagging==0.4.6
 sphinx
 sphinx_rtd_theme
 pytz

--- a/tox.ini
+++ b/tox.ini
@@ -28,9 +28,6 @@ deps =
 	git+git://github.com/graphite-project/whisper.git#egg=whisper
 	git+git://github.com/graphite-project/ceres.git#egg=ceres
 	pyparsing2: pyparsing
-	django18: Django>=1.8,<1.8.99
-	django19: Django>=1.9,<1.9.99
-	django110: Django>=1.10,<1.10.99
 	django111: Django>=1.11,<1.11.99
 	django20: Django>=2.0,<2.0.99
 	django21: Django>=2.1,<2.1.99
@@ -53,7 +50,7 @@ deps =
 	pytz
 	git+git://github.com/graphite-project/whisper.git#egg=whisper
 	git+git://github.com/graphite-project/ceres.git#egg=ceres
-	Django<2.0
+	Django<2.3
 	pyparsing
 	Sphinx<1.4
 	sphinx_rtd_theme


### PR DESCRIPTION
According to https://www.djangoproject.com/download/ 1.11 is single 1.x supported version now.
According to https://github.com/graphite-project/graphite-web/network/alert/docs/requirements.txt/django/open versions <1.11.19 vulnerable to CVE-2019-6975 and CVE-2019-3498