### PR TITLE
[1.1.x] Prepare documentation for 1.1.6 release (#2504) | More changes (#2504) | Amended security issue description (#2504)

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -35,7 +35,7 @@ Basic Graphite requirements:
 * a UNIX-like Operating System
 * Python 2.7 or greater (including experimental Python3 support)
 * `cairocffi`_
-* `Django`_ 1.8 - 1.11 (for Python3 - 1.11 only)
+* `Django`_ 1.8 - 2.2 (for Python3 - 1.11 and newer), 1.11.19 or newer is recommended 
 * `django-tagging`_ 0.4.6 (not `django-taggit` yet)
 * `pytz`_
 * `scandir`_

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -5,6 +5,7 @@ Release Notes
    :maxdepth: 1
    :glob:
 
+   releases/1_1_6
    releases/1_1_5
    releases/1_1_4
    releases/1_1_3

--- a/docs/releases/1_1_6.rst
+++ b/docs/releases/1_1_6.rst
@@ -1,0 +1,124 @@
+.. _1-1-6:
+
+1.1.6
+===========================
+*10/24/2019*
+
+Graphite 1.1.6 is now available for usage. Please note that this is a bugfix / securityfix release for the stable Graphite 1.1.x branch and it's recommended for production usage. It also contains some improvements backported from the master branch.
+
+Highlights
+-------------
+* Better error handling (return 4XX instead of 5XX in case of wrong function parameters)
+* Python 3.8 and Django 2.x support
+* New functions: add, sigmoid, logit, exp
+* Python 3 fixes for Whisper and Carbon
+* Carbonate have Python 3 support now
+* Many improvements for Docker image, check its `release page <https://github.com/graphite-project/docker-graphite-statsd/releases>`_ for details 
+
+Thanks a lot for all Graphite contributors and users! You are the best!
+
+Source bundles are available from GitHub:
+
+* https://github.com/graphite-project/graphite-web/archive/1.1.6.tar.gz
+* https://github.com/graphite-project/carbon/archive/1.1.6.tar.gz
+* https://github.com/graphite-project/whisper/archive/1.1.6.tar.gz
+* https://github.com/graphite-project/carbonate/archive/1.1.6.tar.gz
+
+Graphite can also be installed from `PyPI <http://pypi.python.org/>`_ via
+`pip <http://www.pip-installer.org/en/latest/index.html>`_. PyPI bundles are here:
+
+* http://pypi.python.org/pypi/graphite-web/
+* http://pypi.python.org/pypi/carbon/
+* http://pypi.python.org/pypi/whisper/
+* http://pypi.python.org/pypi/carbonate/
+
+You can also use docker image from https://hub.docker.com/r/graphiteapp/graphite-statsd/
+
+Upgrading
+---------
+Please upgrade whisper, carbon and graphite-web - they contain valuable bugfixes and improvements.
+
+Incompatible changes
+--------------------
+WHISPER_FALLOCATE_CREATE set to `False` by default in docker image (because True often causing issues in Docker).
+
+Security Notes
+--------------
+SSRF vulnerability `CVE-2017-18638 <https://nvd.nist.gov/vuln/detail/CVE-2017-18638>`_ was fixed in this release. Please check `security advisory <https://github.com/graphite-project/graphite-web/security/advisories/GHSA-vfj6-275q-4pvm>`_ for details.
+Also, recommended Django version was increased to 1.11.19 because previous Django versions are vulnerable to `CVE-2019-6975 <https://nvd.nist.gov/vuln/detail/CVE-2019-6975>`_ and `CVE-2019-3498 <https://nvd.nist.gov/vuln/detail/CVE-2019-3498>`_.
+Despite that, Graphite 1.1.6 functionally still supports Django >= 1.8.
+
+New features
+------------
+
+Graphite-Web
+^^^^^^^^^^^^
+* set package long description (#2407, @YevhenLukomskyi)
+* fix dashboard graph metric list icon paths with URL_PREFIX (#2424, @ploxiln)
+* docs: for sql db migration to 1.1 recommend --fake-initial (#2425, @ploxiln)
+* add tag formatting docs (#2426, @replay)
+* Fix dashboard template loading from URL (#2431, @cbowman0)
+* Dashboard render urls missing document.body.dataset.baseUrl (#2433, @cbowman0)
+* Accept IPv6 addresses in CARBONLINK_HOSTS (#2436, @RoEdAl)
+* fixed small errors in docs (#2443, 0xflotus)
+* Copy requestContext() and empty prefetch (#2450, @cbowman0)
+* update aggregation function docs for aggregate and groupbytags (#2451, @Dieterbe)
+* Add Statusengine to list of integrations (Forwarding) (#2452, @nook24)
+* Django22 compatibility (#2462, @piotr1212)
+* Fix a broken link to structured_metrics in doc (#2463, @izeye)
+* Python 3.8 support (#2464, @piotr1212)
+* New functions: add, sigmoid, logit, exp (#2466, @piotr1212)
+* Better error handling (return 4XX instead of 5XX in case of wrong function parameters) (#2467, @replay)
+* Pass maxDataPoints to the requestContext for Finder (#2479, @Felixoid)
+* Add redis password support for tagdb (#2483)
+* added space before \ (#2487)
+* Created issue template (#2488)
+* docs: add netdata to 'tools that work with graphite' (#2490)
+* Updated minimumBelow() docstring (#2493)
+* xFilesFactor is an optional parameter for removeEmptySeries (#2495)
+* fix functions that aggregate to include the aliases in their params (#2496)
+* the callback parameter for groupByNode is optional (#2497)
+* fix order (#2496)
+* Fix for CVE-2017-18638 (#2499, @deniszh)
+* Upgrading minimal Django version (#2502, @deniszh)
+
+
+Carbon
+^^^^^^
+* Add testing for Python 3.8 (#859, @piotr1212)
+
+Whisper
+^^^^^^^
+* set package long description (#271, @YevhenLukomskyi)
+* Dump as raw values (#282, @Glandos)
+
+Carbonate
+^^^^^^^^^
+* Python 3 support (PR#107, @piotr1212)
+* Use --copy-dest, enabling the rsync algorithm when copying from remote to staging (PR#106, @luke-heberling)
+
+
+Bug Fixes
+---------
+
+Graphite-Web
+^^^^^^^^^^^^
+* 
+
+Carbon
+^^^^^^
+* set package long description (#834, @YevhenLukomskyi)
+* Remove pidfile on ValueError exception (#853, @albang)
+
+Whisper
+^^^^^^^
+* Switch to setuptools (#272, @piotr1212)
+* adding appropriate 'type' to sleep variable (#273, @piotr1212)
+* Add testing for Python 3.8, remove 3.4 (eol)(#277, @piotr1212)
+* Altering rrd2whisper.py for py3 compatibility (#280, @FliesLikeABrick)
+
+Carbonate
+^^^^^^^^^
+* fix lint errors (PR#105, @YevhenLukomskyi)
+* specify long_description_content_type, so that package description is properly rendered on pypi.org (PR#104, @YevhenLukomskyi)
+

--- a/docs/releases/1_1_6.rst
+++ b/docs/releases/1_1_6.rst
@@ -46,6 +46,8 @@ WHISPER_FALLOCATE_CREATE set to `False` by default in docker image (because True
 Security Notes
 --------------
 SSRF vulnerability `CVE-2017-18638 <https://nvd.nist.gov/vuln/detail/CVE-2017-18638>`_ was fixed in this release. Please check `security advisory <https://github.com/graphite-project/graphite-web/security/advisories/GHSA-vfj6-275q-4pvm>`_ for details.
+Also patches was released for graphite-web `1.0.x <https://github.com/graphite-project/graphite-web/pull/2501>`_ and `0.9.x <https://github.com/graphite-project/graphite-web/pull/2500>`_, and we'll discuss releases of non-supported branches later.
+Check `issue 2008 <https://github.com/graphite-project/graphite-web/issues/2008>`_ for discussion.
 Also, recommended Django version was increased to 1.11.19 because previous Django versions are vulnerable to `CVE-2019-6975 <https://nvd.nist.gov/vuln/detail/CVE-2019-6975>`_ and `CVE-2019-3498 <https://nvd.nist.gov/vuln/detail/CVE-2019-3498>`_.
 Despite that, Graphite 1.1.6 functionally still supports Django >= 1.8.
 

--- a/docs/releases/1_1_6.rst
+++ b/docs/releases/1_1_6.rst
@@ -8,7 +8,8 @@ Graphite 1.1.6 is now available for usage. Please note that this is a bugfix / s
 
 Highlights
 -------------
-* Better error handling (return 4XX instead of 5XX in case of wrong function parameters)
+* Function parameters validation (disabled by default, can be enabled through ENFORCE_INPUT_VALIDATION variable)
+* Better error handling (return 4XX instead of 5XX in case of wrong function parameters) if input validation enabled
 * Python 3.8 and Django 2.x support
 * New functions: add, sigmoid, logit, exp
 * Python 3 fixes for Whisper and Carbon
@@ -54,34 +55,22 @@ New features
 Graphite-Web
 ^^^^^^^^^^^^
 * set package long description (#2407, @YevhenLukomskyi)
-* fix dashboard graph metric list icon paths with URL_PREFIX (#2424, @ploxiln)
-* docs: for sql db migration to 1.1 recommend --fake-initial (#2425, @ploxiln)
 * add tag formatting docs (#2426, @replay)
-* Fix dashboard template loading from URL (#2431, @cbowman0)
-* Dashboard render urls missing document.body.dataset.baseUrl (#2433, @cbowman0)
 * Accept IPv6 addresses in CARBONLINK_HOSTS (#2436, @RoEdAl)
-* fixed small errors in docs (#2443, 0xflotus)
-* Copy requestContext() and empty prefetch (#2450, @cbowman0)
 * update aggregation function docs for aggregate and groupbytags (#2451, @Dieterbe)
 * Add Statusengine to list of integrations (Forwarding) (#2452, @nook24)
 * Django22 compatibility (#2462, @piotr1212)
-* Fix a broken link to structured_metrics in doc (#2463, @izeye)
 * Python 3.8 support (#2464, @piotr1212)
 * New functions: add, sigmoid, logit, exp (#2466, @piotr1212)
 * Better error handling (return 4XX instead of 5XX in case of wrong function parameters) (#2467, @replay)
 * Pass maxDataPoints to the requestContext for Finder (#2479, @Felixoid)
-* Add redis password support for tagdb (#2483)
-* added space before \ (#2487)
-* Created issue template (#2488)
-* docs: add netdata to 'tools that work with graphite' (#2490)
-* Updated minimumBelow() docstring (#2493)
-* xFilesFactor is an optional parameter for removeEmptySeries (#2495)
-* fix functions that aggregate to include the aliases in their params (#2496)
-* the callback parameter for groupByNode is optional (#2497)
-* fix order (#2496)
-* Fix for CVE-2017-18638 (#2499, @deniszh)
-* Upgrading minimal Django version (#2502, @deniszh)
-
+* Add redis password support for tagdb (#2483, @ahmet2mir)
+* Created issue template (#2488, @bigpythonimish)
+* docs: add netdata to 'tools that work with graphite' (#2490, @sbasgall)
+* Updated minimumBelow() docstring (#2493, @bigpythonimish)
+* xFilesFactor is an optional parameter for removeEmptySeries (#2495, @DanCech)
+* fix functions that aggregate to include the aliases in their params (#2496, @Dieterbe)
+* the callback parameter for groupByNode is optional (#2497, @DanCech)
 
 Carbon
 ^^^^^^
@@ -103,7 +92,16 @@ Bug Fixes
 
 Graphite-Web
 ^^^^^^^^^^^^
-* 
+* fix dashboard graph metric list icon paths with URL_PREFIX (#2424, @ploxiln)
+* docs: for sql db migration to 1.1 recommend --fake-initial (#2425, @ploxiln)
+* Fix dashboard template loading from URL (#2431, @cbowman0)
+* Dashboard render urls missing document.body.dataset.baseUrl (#2433, @cbowman0)
+* fixed small errors in docs (#2443, 0xflotus)
+* Copy requestContext() and empty prefetch (#2450, @cbowman0)
+* Fix a broken link to structured_metrics in doc (#2463, @izeye)
+* added space before \ (#2487, @saikek)
+* Fix for CVE-2017-18638 (#2499, @deniszh)
+* Upgrading minimal Django version (#2502, @deniszh)
 
 Carbon
 ^^^^^^


### PR DESCRIPTION
Backports the following commits to 1.1.x:
 - Prepare documentation for 1.1.6 release (#2504)
 - More changes (#2504)
 - Amended security issue description (#2504)