### PR TITLE
Fix AttributeError if parameter validation fails

### DIFF
--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -106,7 +106,7 @@ def evaluateTokens(requestContext, tokens, replacements=None, pipedArg=None):
       if not getattr(handleInvalidParameters, 'alreadyLogged', False):
         log.warning(
           'Received invalid parameters ({msg}): {func} ({args})'.format(
-            msg=str(e.message),
+            msg=str(e),
             func=tokens.call.funcname,
             args=', '.join(
               argList


### PR DESCRIPTION
Since Graphite 1.1.6 we get a lot of failed parameter validation errors (not sure why but this is irrelevant here). In any case, although `ENFORCE_INPUT_VALIDATION` is disabled (by default), the code from #2467 logs the error, and while doing so produces an `AttributeError` because there is no `message` field on the exception object. This of course lets the request fail and means that `ENFORCE_INPUT_VALIDATION=False` is currently useless.

The fix just uses `str(e)` instead of `str(e.message)`, I tested on Python 2.7 and 3.6 that it returns the desired string.

With this fix, the problematic requests are processed successfully and the expected warning is logged.

Please backport this to the next 1.1.x release (and I guess it would make sense to make a new release relatively soon because of this?).

Example stack trace that we see on failed parameter validation:
```
Graphite encountered an unexpected error while handling your request.
Please contact your site administrator if the problem persists.

Traceback (most recent call last):
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 128, in evaluateTokens
    validateParams(tokens.call.funcname, func.params, args, kwargs)
  File "/opt/graphite/webapp/graphite/functions/params.py", line 147, in validateParams
    type=params[i].type, param=params[i].name, func=func))
graphite.errors.InputParameterError: Invalid boolean value specified for function "sortByName" parameter "natural"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/graphite/lib/python3.6/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/opt/graphite/lib/python3.6/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/opt/graphite/lib/python3.6/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/graphite/webapp/graphite/render/views.py", line 52, in new_f
    return f(*args, **kwargs)
  File "/opt/graphite/webapp/graphite/render/views.py", line 130, in renderView
    data.extend(evaluateTarget(requestContext, targets))
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 32, in evaluateTarget
    result = evaluateTokens(requestContext, target)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 61, in evaluateTokens
    return evaluateTokens(requestContext, tokens.expression, replacements)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 130, in evaluateTokens
    handleInvalidParameters(e)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 109, in handleInvalidParameters
    msg=str(e.message),
AttributeError: 'InputParameterError' object has no attribute 'message'
```

Warning that appears in log after the fix:
```
2019-11-11,08:34:47.377 :: Received invalid parameters (Invalid boolean value specified for function "sortByName" parameter "natural"): sortByName ([TimeSeries(name=0, start=1573439700, end=1573461300, step=60, valuesPerPoint=1, consolidationFunc=average, xFilesFactor=0.0), TimeSeries(name=1, start=1573439700, end=1573461300, step=60, valuesPerPoint=1, consolidationFunc=average, xFilesFactor=0.0), TimeSeries(name=2, start=1573439700, end=1573461300, step=60, valuesPerPoint=1, consolidationFunc=average, xFilesFactor=0.0), TimeSeries(name=3, start=1573439700, end=1573461300, step=60, valuesPerPoint=1, consolidationFunc=average, xFilesFactor=0.0)], true)
```