### PR TITLE
relax enforcement of options sets in validation

### DIFF
--- a/webapp/graphite/functions/__init__.py
+++ b/webapp/graphite/functions/__init__.py
@@ -7,6 +7,7 @@ from os.path import dirname, join, splitext
 from django.conf import settings
 
 from graphite.functions.params import Param, ParamTypes, ParamTypeAggFunc  # noqa
+from graphite.functions.aggfuncs import getAggFunc  # noqa
 from graphite.logger import log
 
 customDir = join(dirname(__file__), 'custom')

--- a/webapp/graphite/functions/__init__.py
+++ b/webapp/graphite/functions/__init__.py
@@ -6,7 +6,7 @@ from os.path import dirname, join, splitext
 
 from django.conf import settings
 
-from graphite.functions.params import Param, ParamTypes  # noqa
+from graphite.functions.params import Param, ParamTypes, ParamTypeAggFunc  # noqa
 from graphite.logger import log
 
 customDir = join(dirname(__file__), 'custom')

--- a/webapp/graphite/functions/aggfuncs.py
+++ b/webapp/graphite/functions/aggfuncs.py
@@ -1,0 +1,34 @@
+from graphite.errors import InputParameterError
+from graphite.functions import safe
+
+
+aggFuncs = {
+  'average': safe.safeAvg,
+  'avg_zero': safe.safeAvgZero,
+  'median': safe.safeMedian,
+  'sum': safe.safeSum,
+  'min': safe.safeMin,
+  'max': safe.safeMax,
+  'diff': safe.safeDiff,
+  'stddev': safe.safeStdDev,
+  'count': safe.safeLen,
+  'range': lambda row: safe.safeSubtract(safe.safeMax(row), safe.safeMin(row)),
+  'multiply': lambda row: safe.safeMul(*row),
+  'last': safe.safeLast,
+}
+
+
+aggFuncAliases = {
+  'rangeOf': aggFuncs['range'],
+  'avg': aggFuncs['average'],
+  'total': aggFuncs['sum'],
+  'current': aggFuncs['last'],
+}
+
+
+def getAggFunc(func, rawFunc=None):
+  if func in aggFuncs:
+    return aggFuncs[func]
+  if func in aggFuncAliases:
+    return aggFuncAliases[func]
+  raise InputParameterError('Unsupported aggregation function: %s' % (rawFunc or func))

--- a/webapp/graphite/functions/params.py
+++ b/webapp/graphite/functions/params.py
@@ -89,7 +89,7 @@ class ParamTypeAggFunc(ParamType):
       return True
 
     if value in self.getDeprecatedAggFuncs():
-      log.warning('Deprecated name for aggregation function "{value}"'.format(value=value))
+      log.warning('Deprecated aggregation function "{value}" used'.format(value=value))
       return True
 
     return False

--- a/webapp/graphite/functions/params.py
+++ b/webapp/graphite/functions/params.py
@@ -1,6 +1,7 @@
 import six
 
 from graphite.errors import InputParameterError
+from graphite.logger import log
 from graphite.render.attime import parseTimeOffset
 
 
@@ -135,11 +136,12 @@ def validateParams(func, params, args, kwargs):
       # requirement is satisfied from "args"
       value = args[i]
 
-    # parameter is restricted to a defined set of values, but value is not in it
+    # parameter is restricted to a defined set of possible values, but given value is not in it.
+    # possibly it's a deprecated but still accepted value.
     if params[i].options and value not in params[i].options:
-      raise InputParameterError(
-        'Invalid option specified for function "{func}" parameter "{param}"'.format(
-          param=params[i].name, func=func))
+      log.warning(
+        'given option "{option}" in function "{func}" is not in list of valid options, it may be deprecated but still accepted'
+        .format(option=value, func=func))
 
     if not params[i].validateValue(value):
       raise InputParameterError(

--- a/webapp/graphite/functions/params.py
+++ b/webapp/graphite/functions/params.py
@@ -140,8 +140,8 @@ def validateParams(func, params, args, kwargs):
     # possibly it's a deprecated but still accepted value.
     if params[i].options and value not in params[i].options:
       log.warning(
-        'given option "{option}" in function "{func}" is not in list of valid options, it may be deprecated but still accepted'
-        .format(option=value, func=func))
+        'Deprecated or invalid value "{value}" specified for parameter "{param}" of function "{func}"'
+        .format(value=value, param=params[i].name, func=func))
 
     if not params[i].validateValue(value):
       raise InputParameterError(

--- a/webapp/graphite/functions/params.py
+++ b/webapp/graphite/functions/params.py
@@ -54,7 +54,7 @@ def validateSeriesList(value):
 
 ParamType.register('boolean', validateBoolean)
 ParamType.register('date')
-ParamType.register('float')
+ParamType.register('float', validateFloat)
 ParamType.register('integer', validateInteger)
 ParamType.register('interval', validateInterval)
 ParamType.register('intOrInterval')

--- a/webapp/graphite/functions/safe.py
+++ b/webapp/graphite/functions/safe.py
@@ -1,0 +1,126 @@
+# make / work consistently between python 2.x and 3.x
+# https://www.python.org/dev/peps/pep-0238/
+from __future__ import division
+from functools import reduce
+import math
+
+
+def safeSum(values):
+  safeValues = [v for v in values if v is not None]
+  if safeValues:
+    return sum(safeValues)
+
+
+def safeDiff(values):
+  safeValues = [v for v in values if v is not None]
+  if safeValues:
+    values = list(map(lambda x: x*-1, safeValues[1:]))
+    values.insert(0, safeValues[0])
+    return sum(values)
+
+
+def safeLen(values):
+  return len([v for v in values if v is not None])
+
+
+def safeDiv(a, b):
+  if a is None: return None
+  if b in (0,None): return None
+  return a / b
+
+
+def safeExp(a):
+    try:
+        return math.exp(a)
+    except TypeError:
+        return None
+
+
+def safePow(a, b):
+  if a is None: return None
+  if b is None: return None
+  try:
+    result = math.pow(a, b)
+  except (ValueError, OverflowError):
+    return None
+  return result
+
+
+def safeMul(*factors):
+  if None in factors:
+    return None
+
+  factors = [float(x) for x in factors]
+  product = reduce(lambda x,y: x*y, factors)
+  return product
+
+
+def safeSubtract(a,b):
+    if a is None or b is None: return None
+    return float(a) - float(b)
+
+
+def safeAvg(values):
+  safeValues = [v for v in values if v is not None]
+  if safeValues:
+    return sum(safeValues) / len(safeValues)
+
+
+def safeAvgZero(values):
+  if values:
+    return sum([0 if v is None else v for v in values]) / len(values)
+
+
+def safeMedian(values):
+  safeValues = [v for v in values if v is not None]
+  if safeValues:
+    sortedVals = sorted(safeValues)
+    mid = len(sortedVals) // 2
+    if len(sortedVals) % 2 == 0:
+      return float(sortedVals[mid-1] + sortedVals[mid]) / 2
+    else:
+      return sortedVals[mid]
+
+
+def safeStdDev(a):
+  sm = safeSum(a)
+  ln = safeLen(a)
+  avg = safeDiv(sm,ln)
+  if avg is None: return None
+  sum = 0
+  safeValues = [v for v in a if v is not None]
+  for val in safeValues:
+     sum = sum + (val - avg) * (val - avg)
+  return math.sqrt(sum/ln)
+
+
+def safeLast(values):
+  for v in reversed(values):
+    if v is not None: return v
+
+
+def safeMin(values, default=None):
+  safeValues = [v for v in values if v is not None]
+  if safeValues:
+    return min(safeValues)
+  else:
+    return default
+
+
+def safeMax(values, default=None):
+  safeValues = [v for v in values if v is not None]
+  if safeValues:
+    return max(safeValues)
+  else:
+    return default
+
+
+def safeMap(function, values):
+  safeValues = [v for v in values if v is not None]
+  if safeValues:
+    return [function(x) for x in safeValues]
+
+
+def safeAbs(value):
+  if value is None: return None
+  return abs(value)

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -36,7 +36,7 @@ from os import environ
 from django.conf import settings
 from graphite.errors import NormalizeEmptyResultError, InputParameterError
 from graphite.events import models
-from graphite.functions import SeriesFunction, ParamTypes, Param, ParamTypeAggFunc
+from graphite.functions import SeriesFunction, ParamTypes, Param, ParamTypeAggFunc, getAggFunc, safe
 from graphite.logger import log
 from graphite.render.attime import getUnitString, parseTimeOffset, parseATTime, SECONDS_STRING, MINUTES_STRING, HOURS_STRING, DAYS_STRING, WEEKS_STRING, MONTHS_STRING, YEARS_STRING
 from graphite.render.evaluator import evaluateTarget
@@ -58,127 +58,6 @@ HOUR = 3600
 MINUTE = 60
 
 #Utility functions
-
-
-def safeSum(values):
-  safeValues = [v for v in values if v is not None]
-  if safeValues:
-    return sum(safeValues)
-
-
-def safeDiff(values):
-  safeValues = [v for v in values if v is not None]
-  if safeValues:
-    values = list(map(lambda x: x*-1, safeValues[1:]))
-    values.insert(0, safeValues[0])
-    return sum(values)
-
-
-def safeLen(values):
-  return len([v for v in values if v is not None])
-
-
-def safeDiv(a, b):
-  if a is None: return None
-  if b in (0,None): return None
-  return a / b
-
-
-def safeExp(a):
-    try:
-        return math.exp(a)
-    except TypeError:
-        return None
-
-
-def safePow(a, b):
-  if a is None: return None
-  if b is None: return None
-  try:
-    result = math.pow(a, b)
-  except (ValueError, OverflowError):
-    return None
-  return result
-
-
-def safeMul(*factors):
-  if None in factors:
-    return None
-
-  factors = [float(x) for x in factors]
-  product = reduce(lambda x,y: x*y, factors)
-  return product
-
-
-def safeSubtract(a,b):
-    if a is None or b is None: return None
-    return float(a) - float(b)
-
-
-def safeAvg(values):
-  safeValues = [v for v in values if v is not None]
-  if safeValues:
-    return sum(safeValues) / len(safeValues)
-
-
-def safeAvgZero(values):
-  if values:
-    return sum([0 if v is None else v for v in values]) / len(values)
-
-
-def safeMedian(values):
-  safeValues = [v for v in values if v is not None]
-  if safeValues:
-    sortedVals = sorted(safeValues)
-    mid = len(sortedVals) // 2
-    if len(sortedVals) % 2 == 0:
-      return float(sortedVals[mid-1] + sortedVals[mid]) / 2
-    else:
-      return sortedVals[mid]
-
-
-def safeStdDev(a):
-  sm = safeSum(a)
-  ln = safeLen(a)
-  avg = safeDiv(sm,ln)
-  if avg is None: return None
-  sum = 0
-  safeValues = [v for v in a if v is not None]
-  for val in safeValues:
-     sum = sum + (val - avg) * (val - avg)
-  return math.sqrt(sum/ln)
-
-
-def safeLast(values):
-  for v in reversed(values):
-    if v is not None: return v
-
-
-def safeMin(values, default=None):
-  safeValues = [v for v in values if v is not None]
-  if safeValues:
-    return min(safeValues)
-  else:
-    return default
-
-
-def safeMax(values, default=None):
-  safeValues = [v for v in values if v is not None]
-  if safeValues:
-    return max(safeValues)
-  else:
-    return default
-
-
-def safeMap(function, values):
-  safeValues = [v for v in values if v is not None]
-  if safeValues:
-    return [function(x) for x in safeValues]
-
-
-def safeAbs(value):
-  if value is None: return None
-  return abs(value)
 
 
 # In Py2, None < (any integer) . Use -inf for same sorting on Python 3
@@ -263,38 +142,6 @@ def formatPathExpressions(seriesList):
 
 
 # Series Functions
-
-aggFuncs = {
-  'average': safeAvg,
-  'avg_zero': safeAvgZero,
-  'median': safeMedian,
-  'sum': safeSum,
-  'min': safeMin,
-  'max': safeMax,
-  'diff': safeDiff,
-  'stddev': safeStdDev,
-  'count': safeLen,
-  'range': lambda row: safeSubtract(safeMax(row), safeMin(row)),
-  'multiply': lambda row: safeMul(*row),
-  'last': safeLast,
-}
-
-aggFuncAliases = {
-  'rangeOf': aggFuncs['range'],
-  'avg': aggFuncs['average'],
-  'total': aggFuncs['sum'],
-  'current': aggFuncs['last'],
-}
-
-ParamTypeAggFunc.setValidAggFuncs(list(aggFuncs.keys()), list(aggFuncAliases.keys()))
-
-
-def getAggFunc(func, rawFunc=None):
-  if func in aggFuncs:
-    return aggFuncs[func]
-  if func in aggFuncAliases:
-    return aggFuncAliases[func]
-  raise InputParameterError('Unsupported aggregation function: %s' % (rawFunc or func))
 
 
 def aggregate(requestContext, seriesList, func, xFilesFactor=None):
@@ -921,7 +768,7 @@ def asPercent(requestContext, seriesList, total=None, *nodes):
         else:
           name = 'sumSeries(%s)' % formatPathExpressions(metaSeries[key])
           (seriesList,start,end,step) = normalize([metaSeries[key]])
-          totalValues = [ safeSum(row) for row in izip_longest(*metaSeries[key]) ]
+          totalValues = [ safe.safeSum(row) for row in izip_longest(*metaSeries[key]) ]
           totalSeries[key] = TimeSeries(name,start,end,step,totalValues,xFilesFactor=xFilesFactor)
     # total seriesList was specified, sum the values for each group of totals
     elif isinstance(total, list):
@@ -940,7 +787,7 @@ def asPercent(requestContext, seriesList, total=None, *nodes):
         else:
           name = 'sumSeries(%s)' % formatPathExpressions(totalSeries[key])
           (seriesList,start,end,step) = normalize([totalSeries[key]])
-          totalValues = [ safeSum(row) for row in izip_longest(*totalSeries[key]) ]
+          totalValues = [ safe.safeSum(row) for row in izip_longest(*totalSeries[key]) ]
           totalSeries[key] = TimeSeries(name,start,end,step,totalValues,xFilesFactor=xFilesFactor)
     # trying to use nodes with a total value, which isn't supported because it has no effect
     else:
@@ -967,7 +814,7 @@ def asPercent(requestContext, seriesList, total=None, *nodes):
           series2 = totalSeries[key]
           name = "asPercent(%s,%s)" % (series1.name, series2.name)
           (seriesList,start,end,step) = normalize([(series1, series2)])
-          resultValues = [ safeMul(safeDiv(v1, v2), 100.0) for v1,v2 in izip_longest(series1,series2) ]
+          resultValues = [ safe.safeMul(safe.safeDiv(v1, v2), 100.0) for v1,v2 in izip_longest(series1,series2) ]
 
         resultSeries = TimeSeries(name,start,end,step,resultValues,xFilesFactor=xFilesFactor)
         resultList.append(resultSeries)
@@ -975,7 +822,7 @@ def asPercent(requestContext, seriesList, total=None, *nodes):
     return resultList
 
   if total is None:
-    totalValues = [ safeSum(row) for row in izip_longest(*seriesList) ]
+    totalValues = [ safe.safeSum(row) for row in izip_longest(*seriesList) ]
     totalText = "sumSeries(%s)" % formatPathExpressions(seriesList)
   elif type(total) is list:
     if len(total) != 1 and len(total) != len(seriesList):
@@ -994,12 +841,12 @@ def asPercent(requestContext, seriesList, total=None, *nodes):
     for series1, series2 in matchSeries(seriesList, total):
       name = "asPercent(%s,%s)" % (series1.name,series2.name)
       (seriesList,start,end,step) = normalize([(series1, series2)])
-      resultValues = [ safeMul(safeDiv(v1, v2), 100.0) for v1,v2 in izip_longest(series1,series2) ]
+      resultValues = [ safe.safeMul(safe.safeDiv(v1, v2), 100.0) for v1,v2 in izip_longest(series1,series2) ]
       resultSeries = TimeSeries(name,start,end,step,resultValues,xFilesFactor=xFilesFactor)
       resultList.append(resultSeries)
   else:
     for series in seriesList:
-      resultValues = [ safeMul(safeDiv(val, totalVal), 100.0) for val,totalVal in izip_longest(series,totalValues) ]
+      resultValues = [ safe.safeMul(safe.safeDiv(val, totalVal), 100.0) for val,totalVal in izip_longest(series,totalValues) ]
 
       name = "asPercent(%s,%s)" % (series.name, totalText or series.pathExpression)
       resultSeries = TimeSeries(name,series.start,series.end,series.step,resultValues,xFilesFactor=xFilesFactor)
@@ -1042,7 +889,7 @@ def divideSeriesLists(requestContext, dividendSeriesList, divisorSeriesList):
     end = max([s.end for s in bothSeries])
     end -= (end - start) % step
 
-    values = ( safeDiv(v1,v2) for v1,v2 in izip_longest(*bothSeries) )
+    values = ( safe.safeDiv(v1,v2) for v1,v2 in izip_longest(*bothSeries) )
 
     quotientSeries = TimeSeries(name, start, end, step, values, xFilesFactor=requestContext.get('xFilesFactor'))
     results.append(quotientSeries)
@@ -1097,7 +944,7 @@ def divideSeries(requestContext, dividendSeriesList, divisorSeries):
     end = max([s.end for s in bothSeries])
     end -= (end - start) % step
 
-    values = ( safeDiv(v1,v2) for v1,v2 in izip_longest(*bothSeries) )
+    values = ( safe.safeDiv(v1,v2) for v1,v2 in izip_longest(*bothSeries) )
 
     quotientSeries = TimeSeries(name, start, end, step, values, xFilesFactor=requestContext.get('xFilesFactor'))
     results.append(quotientSeries)
@@ -1178,7 +1025,7 @@ def weightedAverage(requestContext, seriesListAvg, seriesListWeight, *nodes):
     seriesWeight = sortedSeries[key]['weight']
     seriesAvg = sortedSeries[key]['avg']
 
-    productValues = [ safeMul(val1, val2) for val1,val2 in izip_longest(seriesAvg,seriesWeight) ]
+    productValues = [ safe.safeMul(val1, val2) for val1,val2 in izip_longest(seriesAvg,seriesWeight) ]
     name='product(%s,%s)' % (seriesWeight.name, seriesAvg.name)
     productSeries = TimeSeries(name,seriesAvg.start,seriesAvg.end,seriesAvg.step,productValues,xFilesFactor=requestContext.get('xFilesFactor'))
     productList.append(productSeries)
@@ -1189,7 +1036,7 @@ def weightedAverage(requestContext, seriesListAvg, seriesListWeight, *nodes):
   sumProducts=sumSeries(requestContext, productList)[0]
   sumWeights=sumSeries(requestContext, seriesListWeight)[0]
 
-  resultValues = [ safeDiv(val1, val2) for val1,val2 in izip_longest(sumProducts,sumWeights) ]
+  resultValues = [ safe.safeDiv(val1, val2) for val1,val2 in izip_longest(sumProducts,sumWeights) ]
   name = "weightedAverage(%s, %s, %s)" % (','.join(sorted(set(s.pathExpression for s in seriesListAvg))) ,','.join(sorted(set(s.pathExpression for s in seriesListWeight))), ','.join(map(str,nodes)))
   resultSeries = TimeSeries(name,sumProducts.start,sumProducts.end,sumProducts.step,resultValues,xFilesFactor=requestContext.get('xFilesFactor'))
   return [resultSeries]
@@ -1347,7 +1194,7 @@ def exponentialMovingAverage(requestContext, seriesList, windowSize):
     series.tags['exponentialMovingAverage'] = windowSize
     newSeries = series.copy(name=newName, start=series.start + previewSeconds, values=[])
 
-    ema = safeAvg(series[:windowPoints]) or 0
+    ema = safe.safeAvg(series[:windowPoints]) or 0
     newSeries.append(round(ema, 6))
 
     for i in range(windowPoints, len(series)):
@@ -1417,7 +1264,7 @@ def scale(requestContext, seriesList, factor):
     series.name = "scale(%s,%g)" % (series.name,float(factor))
     series.pathExpression = series.name
     for i,value in enumerate(series):
-      series[i] = safeMul(value,factor)
+      series[i] = safe.safeMul(value,factor)
   return seriesList
 
 
@@ -1478,7 +1325,7 @@ def exp(requestContext, seriesList):
         series.name = "exp(%s)" % (series.name)
         series.pathExpression = series.name
         for i, value in enumerate(series):
-            series[i] = safeExp(value)
+            series[i] = safe.safeExp(value)
 
     return seriesList
 
@@ -1542,7 +1389,7 @@ def sigmoid(requestContext, seriesList):
         for i, value in enumerate(series):
             try:
                 log.info(value)
-                series[i] = 1 / (1 + safeExp(-value))
+                series[i] = 1 / (1 + safe.safeExp(-value))
             except (TypeError, ValueError, ZeroDivisionError):
                 series[i] = None
 
@@ -1605,7 +1452,7 @@ def pow(requestContext, seriesList, factor):
     series.name = "pow(%s,%g)" % (series.name, float(factor))
     series.pathExpression = series.name
     for i,value in enumerate(series):
-      series[i] = safePow(value, factor)
+      series[i] = safe.safePow(value, factor)
   return seriesList
 
 
@@ -1645,7 +1492,7 @@ def powSeries(requestContext, *seriesLists):
         tmpVal = element
         first = False
       else:
-        tmpVal = safePow(tmpVal, element)
+        tmpVal = safe.safePow(tmpVal, element)
     values.append(tmpVal)
   series = TimeSeries(name,start,end,step,values,xFilesFactor=requestContext.get('xFilesFactor'))
   return [series]
@@ -1673,7 +1520,7 @@ def squareRoot(requestContext, seriesList):
     series.name = "squareRoot(%s)" % (series.name)
     series.pathExpression = series.name
     for i,value in enumerate(series):
-      series[i] = safePow(value, 0.5)
+      series[i] = safe.safePow(value, 0.5)
   return seriesList
 
 
@@ -1699,7 +1546,7 @@ def invert(requestContext, seriesList):
     series.name = "invert(%s)" % (series.name)
     series.pathExpression = series.name
     for i,value in enumerate(series):
-        series[i] = safePow(value, -1)
+        series[i] = safe.safePow(value, -1)
   return seriesList
 
 
@@ -1726,7 +1573,7 @@ def absolute(requestContext, seriesList):
     series.name = "absolute(%s)" % (series.name)
     series.pathExpression = series.name
     for i,value in enumerate(series):
-      series[i] = safeAbs(value)
+      series[i] = safe.safeAbs(value)
   return seriesList
 
 
@@ -1796,7 +1643,7 @@ def offsetToZero(requestContext, seriesList):
 
   """
   for series in seriesList:
-    minimum = safeMin(series)
+    minimum = safe.safeMin(series)
     series.tags['offsetToZero'] = minimum
     series.name = "offsetToZero(%s)" % (series.name)
     series.pathExpression = series.name
@@ -2514,7 +2361,7 @@ def aliasQuery(requestContext, seriesList, search, replace, newName):
     newSeriesList = evaluateTarget(newContext, newQuery)
     if newSeriesList is None or len(newSeriesList) == 0:
       raise InputParameterError('No series found with query: ' + newQuery)
-    current = safeLast(newSeriesList[0])
+    current = safe.safeLast(newSeriesList[0])
     if current is None:
       raise InputParameterError('Cannot get last value of series: ' + newSeriesList[0])
     series.name = newName % current
@@ -2595,13 +2442,13 @@ def cactiStyle(requestContext, seriesList, system=None, units=None):
       else:
           fmt = lambda x:"%.2f"%x
   nameLen = max([0] + [len(getattr(series,"name")) for series in seriesList])
-  lastLen = max([0] + [len(fmt(int(safeLast(series) or 3))) for series in seriesList]) + 3
-  maxLen = max([0] + [len(fmt(int(safeMax(series) or 3))) for series in seriesList]) + 3
-  minLen = max([0] + [len(fmt(int(safeMin(series) or 3))) for series in seriesList]) + 3
+  lastLen = max([0] + [len(fmt(int(safe.safeLast(series) or 3))) for series in seriesList]) + 3
+  maxLen = max([0] + [len(fmt(int(safe.safeMax(series) or 3))) for series in seriesList]) + 3
+  minLen = max([0] + [len(fmt(int(safe.safeMin(series) or 3))) for series in seriesList]) + 3
   for series in seriesList:
-      last = safeLast(series)
-      maximum = safeMax(series)
-      minimum = safeMin(series)
+      last = safe.safeLast(series)
+      maximum = safe.safeMax(series)
+      minimum = safe.safeMin(series)
       if last is None:
         last = NAN
       else:
@@ -2714,10 +2561,10 @@ def legendValue(requestContext, seriesList, *valueTypes):
     system = valueTypes[-1]
     valueTypes = valueTypes[:-1]
   for valueType in valueTypes:
-    if valueType in aggFuncs:
-      valueFunc = aggFuncs[valueType]
-    else:
-      valueFunc = aggFuncAliases.get(valueType, lambda s: '(?)')
+    try:
+      valueFunc = getAggFunc(valueType)
+    except InputParameterError:
+      valueFunc = lambda s: '(?)'
     if system is None:
       for series in seriesList:
         series.name += " (%s: %s)" % (valueType, valueFunc(series))
@@ -2736,7 +2583,7 @@ def legendValue(requestContext, seriesList, *valueTypes):
 legendValue.group = 'Alias'
 legendValue.params = [
   Param('seriesList', ParamTypes.seriesList, required=True),
-  Param('valuesTypes', ParamTypes.string, multiple=True, options=ParamTypeAggFunc.getValidAggFuncs() + ['si', 'binary']),
+  Param('valuesTypes', ParamTypes.string, multiple=True, options=ParamTypeAggFunc.getAllValidAggFuncs() + ['si', 'binary']),
 ]
 
 
@@ -3345,7 +3192,7 @@ def averageOutsidePercentile(requestContext, seriesList, n):
   """
   Removes series lying inside an average percentile interval
   """
-  averages = [safeAvg(s) for s in seriesList]
+  averages = [safe.safeAvg(s) for s in seriesList]
 
   if n < 50:
     n = 100 - n;
@@ -3353,7 +3200,7 @@ def averageOutsidePercentile(requestContext, seriesList, n):
   lowPercentile = _getPercentile(averages, 100 - n)
   highPercentile = _getPercentile(averages, n)
 
-  return [s for s in seriesList if not lowPercentile < safeAvg(s) < highPercentile]
+  return [s for s in seriesList if not lowPercentile < safe.safeAvg(s) < highPercentile]
 
 
 averageOutsidePercentile.group = 'Filter Series'
@@ -3592,7 +3439,7 @@ def sortByMaxima(requestContext, seriesList):
     &target=sortByMaxima(server*.instance*.memory.free)
 
   """
-  seriesList.sort(key=keyFunc(safeMax), reverse=True)
+  seriesList.sort(key=keyFunc(safe.safeMax), reverse=True)
   return seriesList
 
 
@@ -3616,8 +3463,8 @@ def sortByMinima(requestContext, seriesList):
     &target=sortByMinima(server*.instance*.memory.free)
 
   """
-  newSeries = [series for series in seriesList if safeMax(series, default=0) > 0]
-  newSeries.sort(key=keyFunc(safeMin))
+  newSeries = [series for series in seriesList if safe.safeMax(series, default=0) > 0]
+  newSeries.sort(key=keyFunc(safe.safeMin))
   return newSeries
 
 
@@ -3713,10 +3560,10 @@ def mostDeviant(requestContext, seriesList, n):
 
   deviants = []
   for series in seriesList:
-    mean = safeAvg(series)
+    mean = safe.safeAvg(series)
     if mean is None: continue
     square_sum = sum([ (value - mean) ** 2 for value in series if value is not None ])
-    sigma = safeDiv(square_sum, safeLen(series))
+    sigma = safe.safeDiv(square_sum, safe.safeLen(series))
     if sigma is None: continue
     deviants.append( (sigma, series) )
   deviants.sort(key=keyFunc(lambda i: i[0]), reverse=True) #sort by sigma
@@ -4111,7 +3958,7 @@ def linearRegressionAnalysis(series):
   """
   Returns factor and offset of linear regression function by least squares method.
   """
-  n = safeLen(series)
+  n = safe.safeLen(series)
   sumI = sum([i for i,v in enumerate(series) if v is not None])
   sumV = sum([v for i,v in enumerate(series) if v is not None])
   sumII = sum([i*i for i,v in enumerate(series) if v is not None])
@@ -5728,8 +5575,8 @@ def minMax(requestContext, seriesList):
   for series in seriesList:
     series.name = "minMax(%s)" % (series.name)
     series.pathExpression = series.name
-    min_val = safeMin(series, default=0.0)
-    max_val = safeMax(series, default=0.0)
+    min_val = safe.safeMin(series, default=0.0)
+    max_val = safe.safeMax(series, default=0.0)
     for i, val in enumerate(series):
       if series[i] is not None:
         try:
@@ -5747,7 +5594,7 @@ minMax.params = [
 
 def pieAverage(requestContext, series):
   """Return the average"""
-  return safeDiv(safeSum(series), safeLen(series))
+  return safe.safeDiv(safe.safeSum(series), safe.safeLen(series))
 
 
 pieAverage.group = 'Pie'
@@ -5758,7 +5605,7 @@ pieAverage.params = [
 
 def pieMaximum(requestContext, series):
   """Return the maximum"""
-  return safeMax(series)
+  return safe.safeMax(series)
 
 
 pieMaximum.group = 'Pie'
@@ -5769,7 +5616,7 @@ pieMaximum.params = [
 
 def pieMinimum(requestContext, series):
   """Return the minimum"""
-  return safeMin(series)
+  return safe.safeMin(series)
 
 
 pieMinimum.group = 'Pie'

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -19,7 +19,7 @@ except ImportError:  # Django < 1.10
   from django.core.urlresolvers import reverse
 
 from graphite.errors import NormalizeEmptyResultError
-from graphite.functions import _SeriesFunctions, loadFunctions
+from graphite.functions import _SeriesFunctions, loadFunctions, safe
 from graphite.render.datalib import TimeSeries
 from graphite.render import functions
 from graphite.render.evaluator import evaluateTarget
@@ -49,19 +49,19 @@ class FunctionsTest(TestCase):
 
     def test_safeSum_None(self):
         with self.assertRaises(TypeError):
-            functions.safeSum(None)
+            safe.safeSum(None)
 
     def test_safeSum_empty_list(self):
-        self.assertEqual(functions.safeSum([]), None)
+        self.assertEqual(safe.safeSum([]), None)
 
     def test_safeSum_all_numbers(self):
-        self.assertEqual(functions.safeSum([1,2,3,4]), 10)
+        self.assertEqual(safe.safeSum([1,2,3,4]), 10)
 
     def test_safeSum_all_None(self):
-        self.assertEqual(functions.safeSum([None,None,None,None]), None)
+        self.assertEqual(safe.safeSum([None,None,None,None]), None)
 
     def test_safeSum_mixed(self):
-        self.assertEqual(functions.safeSum([10,None,5,None]), 15)
+        self.assertEqual(safe.safeSum([10,None,5,None]), 15)
 
     #
     # Test safeDiff()
@@ -69,19 +69,19 @@ class FunctionsTest(TestCase):
 
     def test_safeDiff_None(self):
         with self.assertRaises(TypeError):
-            functions.safeDiff(None)
+            safe.safeDiff(None)
 
     def test_safeDiff_empty_list(self):
-        self.assertEqual(functions.safeDiff([]), None)
+        self.assertEqual(safe.safeDiff([]), None)
 
     def test_safeDiff_all_numbers(self):
-        self.assertEqual(functions.safeDiff([1,2,3,4]), -8)
+        self.assertEqual(safe.safeDiff([1,2,3,4]), -8)
 
     def test_safeDiff_all_None(self):
-        self.assertEqual(functions.safeDiff([None,None,None,None]), None)
+        self.assertEqual(safe.safeDiff([None,None,None,None]), None)
 
     def test_safeDiff_mixed(self):
-        self.assertEqual(functions.safeDiff([10,None,5,None]), 5)
+        self.assertEqual(safe.safeDiff([10,None,5,None]), 5)
 
     #
     # Test safeLen()
@@ -89,95 +89,95 @@ class FunctionsTest(TestCase):
 
     def test_safeLen_None(self):
         with self.assertRaises(TypeError):
-            functions.safeLen(None)
+            safe.safeLen(None)
 
     def test_safeLen_empty_list(self):
-        self.assertEqual(functions.safeLen([]), 0)
+        self.assertEqual(safe.safeLen([]), 0)
 
     def test_safeLen_all_numbers(self):
-        self.assertEqual(functions.safeLen([1,2,3,4]), 4)
+        self.assertEqual(safe.safeLen([1,2,3,4]), 4)
 
     def test_safeLen_all_None(self):
-        self.assertEqual(functions.safeLen([None,None,None,None]), 0)
+        self.assertEqual(safe.safeLen([None,None,None,None]), 0)
 
     def test_safeLen_mixed(self):
-        self.assertEqual(functions.safeLen([10,None,5,None]), 2)
+        self.assertEqual(safe.safeLen([10,None,5,None]), 2)
 
     #
     # Test safeDiv()
     #
 
     def test_safeDiv_None_None(self):
-        self.assertEqual(functions.safeDiv(None, None), None)
+        self.assertEqual(safe.safeDiv(None, None), None)
 
     def test_safeDiv_5_None(self):
-        self.assertEqual(functions.safeDiv(5, None), None)
+        self.assertEqual(safe.safeDiv(5, None), None)
 
     def test_safeDiv_5_0(self):
-        self.assertEqual(functions.safeDiv(5, 0), None)
+        self.assertEqual(safe.safeDiv(5, 0), None)
 
     def test_safeDiv_0_10(self):
-        self.assertEqual(functions.safeDiv(0,10), 0)
+        self.assertEqual(safe.safeDiv(0,10), 0)
 
     def test_safeDiv_10_5(self):
-        self.assertEqual(functions.safeDiv(10,5), 2)
+        self.assertEqual(safe.safeDiv(10,5), 2)
 
     #
     # Test safePow()
     #
 
     def test_safePow_None_None(self):
-        self.assertEqual(functions.safePow(None, None), None)
+        self.assertEqual(safe.safePow(None, None), None)
 
     def test_safePow_5_None(self):
-        self.assertEqual(functions.safePow(5, None), None)
+        self.assertEqual(safe.safePow(5, None), None)
 
     def test_safePow_5_0(self):
-        self.assertEqual(functions.safePow(5, 0), 1.0)
+        self.assertEqual(safe.safePow(5, 0), 1.0)
 
     def test_safePow_0_10(self):
-        self.assertEqual(functions.safePow(0,10), 0)
+        self.assertEqual(safe.safePow(0,10), 0)
 
     def test_safePow_10_5(self):
-        self.assertEqual(functions.safePow(10,5), 100000.0)
+        self.assertEqual(safe.safePow(10,5), 100000.0)
 
     #
     # Test safeMul()
     #
 
     def test_safeMul_None_None(self):
-        self.assertEqual(functions.safeMul(None, None), None)
+        self.assertEqual(safe.safeMul(None, None), None)
 
     def test_safeMul_5_None(self):
-        self.assertEqual(functions.safeMul(5, None), None)
+        self.assertEqual(safe.safeMul(5, None), None)
 
     def test_safeMul_5_0(self):
-        self.assertEqual(functions.safeMul(5, 0), 0.0)
+        self.assertEqual(safe.safeMul(5, 0), 0.0)
 
     def test_safeMul_0_10(self):
-        self.assertEqual(functions.safeMul(0,10), 0)
+        self.assertEqual(safe.safeMul(0,10), 0)
 
     def test_safeMul_10_5(self):
-        self.assertEqual(functions.safeMul(10,5), 50.0)
+        self.assertEqual(safe.safeMul(10,5), 50.0)
 
     #
     # Test safeSubtract()
     #
 
     def test_safeSubtract_None_None(self):
-        self.assertEqual(functions.safeSubtract(None, None), None)
+        self.assertEqual(safe.safeSubtract(None, None), None)
 
     def test_safeSubtract_5_None(self):
-        self.assertEqual(functions.safeSubtract(5, None), None)
+        self.assertEqual(safe.safeSubtract(5, None), None)
 
     def test_safeSubtract_5_0(self):
-        self.assertEqual(functions.safeSubtract(5, 0), 5.0)
+        self.assertEqual(safe.safeSubtract(5, 0), 5.0)
 
     def test_safeSubtract_0_10(self):
-        self.assertEqual(functions.safeSubtract(0,10), -10)
+        self.assertEqual(safe.safeSubtract(0,10), -10)
 
     def test_safeSubtract_10_5(self):
-        self.assertEqual(functions.safeSubtract(10,5), 5)
+        self.assertEqual(safe.safeSubtract(10,5), 5)
 
     #
     # Test safeAvg()
@@ -185,19 +185,19 @@ class FunctionsTest(TestCase):
 
     def test_safeAvg_None(self):
         with self.assertRaises(TypeError):
-            functions.safeAvg(None)
+            safe.safeAvg(None)
 
     def test_safeAvg_empty_list(self):
-        self.assertEqual(functions.safeAvg([]), None)
+        self.assertEqual(safe.safeAvg([]), None)
 
     def test_safeAvg_all_numbers(self):
-        self.assertEqual(functions.safeAvg([1,2,3,4]), 2.5)
+        self.assertEqual(safe.safeAvg([1,2,3,4]), 2.5)
 
     def test_safeAvg_all_None(self):
-        self.assertEqual(functions.safeAvg([None,None,None,None]), None)
+        self.assertEqual(safe.safeAvg([None,None,None,None]), None)
 
     def test_safeAvg_mixed(self):
-        self.assertEqual(functions.safeAvg([10,None,5,None]), 7.5)
+        self.assertEqual(safe.safeAvg([10,None,5,None]), 7.5)
 
     #
     # Test safeMedian()
@@ -205,22 +205,22 @@ class FunctionsTest(TestCase):
 
     def test_safeMedian_None(self):
         with self.assertRaises(TypeError):
-            functions.safeMedian(None)
+            safe.safeMedian(None)
 
     def test_safeMedian_empty_list(self):
-        self.assertEqual(functions.safeMedian([]), None)
+        self.assertEqual(safe.safeMedian([]), None)
 
     def test_safeMedian_all_numbers_odd_len(self):
-        self.assertEqual(functions.safeMedian([1,2,3,4,5]), 3)
+        self.assertEqual(safe.safeMedian([1,2,3,4,5]), 3)
 
     def test_safeMedian_all_numbers_even_len(self):
-        self.assertAlmostEqual(functions.safeMedian([1,2,3,4]), 2.5)
+        self.assertAlmostEqual(safe.safeMedian([1,2,3,4]), 2.5)
 
     def test_safeMedian_all_None(self):
-        self.assertEqual(functions.safeMedian([None,None,None,None]), None)
+        self.assertEqual(safe.safeMedian([None,None,None,None]), None)
 
     def test_safeMedian_mixed(self):
-        self.assertAlmostEqual(functions.safeMedian([10,None,5,None]), 7.5)
+        self.assertAlmostEqual(safe.safeMedian([10,None,5,None]), 7.5)
 
     #
     # Test safeStdDev()
@@ -228,19 +228,19 @@ class FunctionsTest(TestCase):
 
     def test_safeStdDev_None(self):
         with self.assertRaises(TypeError):
-            functions.safeStdDev(None)
+            safe.safeStdDev(None)
 
     def test_safeStdDev_empty_list(self):
-        self.assertEqual(functions.safeStdDev([]), None)
+        self.assertEqual(safe.safeStdDev([]), None)
 
     def test_safeStdDev_all_numbers(self):
-        self.assertEqual(functions.safeStdDev([1,2,3,4]), 1.118033988749895)
+        self.assertEqual(safe.safeStdDev([1,2,3,4]), 1.118033988749895)
 
     def test_safeStdDev_all_None(self):
-        self.assertEqual(functions.safeStdDev([None,None,None,None]), None)
+        self.assertEqual(safe.safeStdDev([None,None,None,None]), None)
 
     def test_safeStdDev_mixed(self):
-        self.assertEqual(functions.safeStdDev([10,None,5,None]), 2.5)
+        self.assertEqual(safe.safeStdDev([10,None,5,None]), 2.5)
 
     #
     # Test safeLast()
@@ -248,19 +248,19 @@ class FunctionsTest(TestCase):
 
     def test_safeLast_None(self):
         with self.assertRaises(TypeError):
-            functions.safeLast(None)
+            safe.safeLast(None)
 
     def test_safeLast_empty_list(self):
-        self.assertEqual(functions.safeLast([]), None)
+        self.assertEqual(safe.safeLast([]), None)
 
     def test_safeLast_all_numbers(self):
-        self.assertEqual(functions.safeLast([1,2,3,4]), 4)
+        self.assertEqual(safe.safeLast([1,2,3,4]), 4)
 
     def test_safeLast_all_None(self):
-        self.assertEqual(functions.safeLast([None,None,None,None]), None)
+        self.assertEqual(safe.safeLast([None,None,None,None]), None)
 
     def test_safeLast_mixed(self):
-        self.assertEqual(functions.safeLast([10,None,5,None]), 5)
+        self.assertEqual(safe.safeLast([10,None,5,None]), 5)
 
     #
     # Test safeMin()
@@ -268,19 +268,19 @@ class FunctionsTest(TestCase):
 
     def test_safeMin_None(self):
         with self.assertRaises(TypeError):
-            functions.safeMin(None)
+            safe.safeMin(None)
 
     def test_safeMin_empty_list(self):
-        self.assertEqual(functions.safeMin([]), None)
+        self.assertEqual(safe.safeMin([]), None)
 
     def test_safeMin_all_numbers(self):
-        self.assertEqual(functions.safeMin([1,2,3,4]), 1)
+        self.assertEqual(safe.safeMin([1,2,3,4]), 1)
 
     def test_safeMin_all_None(self):
-        self.assertEqual(functions.safeMin([None,None,None,None]), None)
+        self.assertEqual(safe.safeMin([None,None,None,None]), None)
 
     def test_safeMin_mixed(self):
-        self.assertEqual(functions.safeMin([10,None,5,None]), 5)
+        self.assertEqual(safe.safeMin([10,None,5,None]), 5)
 
     #
     # Test safeMax()
@@ -288,39 +288,39 @@ class FunctionsTest(TestCase):
 
     def test_safeMax_None(self):
         with self.assertRaises(TypeError):
-            functions.safeMax(None)
+            safe.safeMax(None)
 
     def test_safeMax_empty_list(self):
-        self.assertEqual(functions.safeMax([]), None)
+        self.assertEqual(safe.safeMax([]), None)
 
     def test_safeMax_all_numbers(self):
-        self.assertEqual(functions.safeMax([1,2,3,4]), 4)
+        self.assertEqual(safe.safeMax([1,2,3,4]), 4)
 
     def test_safeMax_all_None(self):
-        self.assertEqual(functions.safeMax([None,None,None,None]), None)
+        self.assertEqual(safe.safeMax([None,None,None,None]), None)
 
     def test_safeMax_mixed(self):
-        self.assertEqual(functions.safeMax([10,None,5,None]), 10)
+        self.assertEqual(safe.safeMax([10,None,5,None]), 10)
 
     #
     # Test safeAbs()
     #
 
     def test_safeAbs_None(self):
-        self.assertEqual(functions.safeAbs(None), None)
+        self.assertEqual(safe.safeAbs(None), None)
 
     def test_safeAbs_empty_list(self):
         with self.assertRaises(TypeError):
-          functions.safeAbs([])
+          safe.safeAbs([])
 
     def test_safeAbs_pos_number(self):
-        self.assertEqual(functions.safeAbs(1), 1)
+        self.assertEqual(safe.safeAbs(1), 1)
 
     def test_safeAbs_neg_numbers(self):
-        self.assertEqual(functions.safeAbs(-1), 1)
+        self.assertEqual(safe.safeAbs(-1), 1)
 
     def test_safeAbs_zero(self):
-        self.assertEqual(functions.safeAbs(0), 0)
+        self.assertEqual(safe.safeAbs(0), 0)
 
     #
     # Test safeMap()
@@ -328,19 +328,19 @@ class FunctionsTest(TestCase):
 
     def test_safeMap_None(self):
         with self.assertRaises(TypeError):
-            functions.safeMap(abs, None)
+            safe.safeMap(abs, None)
 
     def test_safeMap_empty_list(self):
-        self.assertEqual(functions.safeMap(abs, []), None)
+        self.assertEqual(safe.safeMap(abs, []), None)
 
     def test_safeMap_all_numbers(self):
-        self.assertEqual(functions.safeMap(abs, [1,2,3,4]), [1,2,3,4])
+        self.assertEqual(safe.safeMap(abs, [1,2,3,4]), [1,2,3,4])
 
     def test_safeMap_all_None(self):
-        self.assertEqual(functions.safeMap(abs, [None,None,None,None]), None)
+        self.assertEqual(safe.safeMap(abs, [None,None,None,None]), None)
 
     def test_safeMap_mixed(self):
-        self.assertEqual(functions.safeMap(abs, [10,None,5,None]), [10,5])
+        self.assertEqual(safe.safeMap(abs, [10,None,5,None]), [10,5])
 
     #
     # Test gcd()
@@ -2116,12 +2116,12 @@ class FunctionsTest(TestCase):
         for i, c in enumerate(config):
             seriesList.append(TimeSeries('Test(%d)' % i, 0, 0, 0, c))
 
-        self.assertEqual(1110, functions.safeSum(seriesList[0]))
+        self.assertEqual(1110, safe.safeSum(seriesList[0]))
 
         result = functions.sortByTotal({}, seriesList)
 
-        self.assertEqual(1111, functions.safeSum(result[0]))
-        self.assertEqual(1110, functions.safeSum(result[1]))
+        self.assertEqual(1111, safe.safeSum(result[0]))
+        self.assertEqual(1110, safe.safeSum(result[1]))
 
     def test_sortByMaxima(self):
         seriesList = self._gen_series_list_with_data(
@@ -2879,7 +2879,7 @@ class FunctionsTest(TestCase):
             # Custom safeLast() function
             def noneSafeLast(x):
                 return None
-            with patch('graphite.render.functions.safeLast', noneSafeLast):
+            with patch('graphite.functions.safe.safeLast', noneSafeLast):
 
                 # Perform query - this one will fail to return a current value for the matched metric
                 with self.assertRaises(Exception):

--- a/webapp/tests/test_params.py
+++ b/webapp/tests/test_params.py
@@ -180,15 +180,13 @@ class TestParam(unittest.TestCase):
             {},
         ))
 
-        self.assertRaises(
-            InputParameterError,
-            validateParams,
+        self.assertTrue(validateParams(
             'TestParam',
             [
                 Param('one', ParamTypes.string, required=True),
                 Param('two', ParamTypes.string, required=True),
                 Param('three', ParamTypes.string, required=True, options=['3', 'three']),
             ],
-            ['one', 'two', 'foud'],
+            ['one', 'two', 'four'],
             {},
-        )
+        ))

--- a/webapp/tests/test_params.py
+++ b/webapp/tests/test_params.py
@@ -180,7 +180,9 @@ class TestParam(unittest.TestCase):
             {},
         ))
 
-        self.assertTrue(validateParams(
+        self.assertRaises(
+            InputParameterError,
+            validateParams,
             'TestParam',
             [
                 Param('one', ParamTypes.string, required=True),
@@ -189,4 +191,4 @@ class TestParam(unittest.TestCase):
             ],
             ['one', 'two', 'four'],
             {},
-        ))
+        )


### PR DESCRIPTION
this relaxes the input validation because we have seen issues where queries using deprecated aggregation functions have been rejected (f.e. `sumSeries`). We want these deprecated functions to still be accepted, while logging a warning that a deprecated function has been used.

#2508 