### PR TITLE
introduce paramtype for agg or series func

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -4840,7 +4840,7 @@ groupByNode.group = 'Combine'
 groupByNode.params = [
   Param('seriesList', ParamTypes.seriesList, required=True),
   Param('nodeNum', ParamTypes.nodeOrTag, required=True),
-  Param('callback', ParamTypes.aggFunc, default='average'),
+  Param('callback', ParamTypes.aggOrSeriesFunc, default='average'),
 ]
 
 
@@ -4895,7 +4895,7 @@ def groupByNodes(requestContext, seriesList, callback, *nodes):
 groupByNodes.group = 'Combine'
 groupByNodes.params = [
   Param('seriesList', ParamTypes.seriesList, required=True),
-  Param('callback', ParamTypes.aggFunc, required=True),
+  Param('callback', ParamTypes.aggOrSeriesFunc, required=True),
   Param('nodes', ParamTypes.nodeOrTag, required=True, multiple=True),
 ]
 
@@ -5483,7 +5483,7 @@ def groupByTags(requestContext, seriesList, callback, *tags):
 groupByTags.group = 'Combine'
 groupByTags.params = [
   Param('seriesList', ParamTypes.seriesList, required=True),
-  Param('callback', ParamTypes.aggFunc, required=True),
+  Param('callback', ParamTypes.aggOrSeriesFunc, required=True),
   Param('tags', ParamTypes.tag, required=True, multiple=True),
 ]
 
@@ -5796,3 +5796,6 @@ SeriesFunctions = {
   'timeFunction': timeFunction,
   'xFilesFactor': setXFilesFactor,
 }
+
+
+ParamTypes.aggOrSeriesFunc.setSeriesFuncs(SeriesFunctions)


### PR DESCRIPTION
This re-allows the use of series functions as aggregation functions when input validation is enabled.
It tries to detect whether a series func can be used as an aggregation func based on its parameters. that way a lot of series funcs which would never work as aggregations funcs can already be ruled out by the input validation layer, preventing an exception.

Example:
Using the series func `weightedAverage` with `groupByNodes()` blows up because `weightedAverage` requires more parameters than only a list of series:
```
$ curl 'http://localhost:8000/render?target=groupByNodes(some.id.of.a.metric.*,"weightedAverage",4)'
...
  File &quot;/home/replay/go/src/github.com/graphite-project/graphite-web/webapp/graphite/render/functions.py&quot;, line 4888, in groupByNodes
    metaSeries[key] = SeriesFunctions[callback](requestContext, metaSeries[key])[0]
TypeError: weightedAverage() takes at least 3 arguments (2 given)
```
But with this PR, when input validation is enabled, we can detect that and return an error
```
$ curl 'http://localhost:8000/render?target=groupByNodes(some.id.of.a.metric.*,"weightedAverage",4)'
Bad Request: Invalid option "weightedAverage" specified for function "groupByNodes" parameter "callback"
```
The valid aggregation funcs are also shown in the function exploration API:
```
$ curl -s 'http://localhost:8000/functions/groupByNodes' | jq
{
  "function": "groupByNodes(seriesList, callback, *nodes)",
  "group": "Combine",
  "name": "groupByNodes",
  "module": "graphite.render.functions",
  "params": [
    {
      "required": true,
      "type": "seriesList",
      "name": "seriesList"
    },
    {
      "required": true,
      "type": "aggOrSeriesFunc",                                                                                                                                                                                                                                                                             "name": "callback",                                                                                                                                                                                                                                                                                    "options": [                                                                                                                                                                                                                                                                                             "absolute",                                                                                                                                                                                                                                                                                            "aggregateLine",
        "aliasByMetric",
        "areaBetween",
        "asPercent",
        "average",
        "averageSeries",
        "averageSeriesWithWildcards",
        "avg",
        "avg_zero",
        "cactiStyle",
        "changed",
        "count",
        "countSeries",
...
```
Unfortunately this is not going to be perfect, because the functions don't define their return type and there also appears to be no other practical way to detect the type of the return values. If we'd want to make this bullet proof we'd have to define a return type for each of the known functions. 
So I'm currently kind of unsure whether I should:
A) Just not return the series functions as valid options in the functions exploration API, so they don't show up as valid suggestions in Grafana
B) Modify every single series function definition and add something like a return type based on which we can detect whether this functions makes sense as an aggregation functions

I'm currently leaning towards A

Related #2508 