### PR TITLE
Mark series functions to use as aggregators

### DIFF
--- a/webapp/graphite/functions/params.py
+++ b/webapp/graphite/functions/params.py
@@ -112,20 +112,10 @@ class ParamTypeAggOrSeriesFunc(ParamTypeAggFunc):
     super(ParamTypeAggOrSeriesFunc, self).__init__(name=name, validator=validator)
 
   def setSeriesFuncs(self, funcs):
-    # check for each of the series functions whether their param types
-    # define that they could be used to aggregate a list of series, those
-    # which can get appended to seriesFuncsForMergingSeries
+    # check for each of the series functions whether they have an 'aggregator'
+    # property being set to 'True'. If so we consider them valid aggregators.
     for name, func in funcs.items():
-      if len(getattr(func, 'params', [])) == 0:
-        continue
-
-      if func.params[0].type not in [
-        ParamTypes.seriesList,
-        ParamTypes.seriesLists,
-      ]:
-        continue
-
-      if any(param.required for param in func.params[1:]):
+      if getattr(func, 'aggregator', False) is not True:
         continue
 
       self.options.append(name)

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -232,6 +232,7 @@ sumSeries.group = 'Combine'
 sumSeries.params = [
   Param('seriesLists', ParamTypes.seriesList, required=True, multiple=True),
 ]
+sumSeries.aggregator = True
 
 
 def sumSeriesWithWildcards(requestContext, seriesList, *position): #XXX
@@ -260,6 +261,7 @@ sumSeriesWithWildcards.params = [
   Param('seriesList', ParamTypes.seriesList, required=True),
   Param('position', ParamTypes.node, multiple=True),
 ]
+sumSeriesWithWildcards.aggregator = True
 
 
 def averageSeriesWithWildcards(requestContext, seriesList, *position): #XXX
@@ -288,6 +290,7 @@ averageSeriesWithWildcards.params = [
   Param('seriesList', ParamTypes.seriesList, required=True),
   Param('position', ParamTypes.node, multiple=True),
 ]
+averageSeriesWithWildcards.aggregator = True
 
 
 def multiplySeriesWithWildcards(requestContext, seriesList, *position): #XXX
@@ -316,6 +319,7 @@ multiplySeriesWithWildcards.params = [
   Param('seriesList', ParamTypes.seriesList, required=True),
   Param('position', ParamTypes.node, multiple=True),
 ]
+multiplySeriesWithWildcards.aggregator = True
 
 
 def aggregateWithWildcards(requestContext, seriesList, func, *positions):
@@ -395,6 +399,7 @@ diffSeries.group = 'Combine'
 diffSeries.params = [
   Param('seriesLists', ParamTypes.seriesList, required=True, multiple=True),
 ]
+diffSeries.aggregator = True
 
 
 def averageSeries(requestContext, *seriesLists):
@@ -419,6 +424,7 @@ averageSeries.group = 'Combine'
 averageSeries.params = [
   Param('seriesLists', ParamTypes.seriesList, required=True, multiple=True),
 ]
+averageSeries.aggregator = True
 
 
 def stddevSeries(requestContext, *seriesLists):
@@ -442,6 +448,7 @@ stddevSeries.group = 'Combine'
 stddevSeries.params = [
   Param('seriesLists', ParamTypes.seriesList, required=True, multiple=True),
 ]
+stddevSeries.aggregator = True
 
 
 def minSeries(requestContext, *seriesLists):
@@ -464,6 +471,7 @@ minSeries.group = 'Combine'
 minSeries.params = [
   Param('seriesLists', ParamTypes.seriesList, required=True, multiple=True),
 ]
+minSeries.aggregator = True
 
 
 def maxSeries(requestContext, *seriesLists):
@@ -486,6 +494,7 @@ maxSeries.group = 'Combine'
 maxSeries.params = [
   Param('seriesLists', ParamTypes.seriesList, required=True, multiple=True),
 ]
+maxSeries.aggregator = True
 
 
 def rangeOfSeries(requestContext, *seriesLists):
@@ -508,6 +517,7 @@ rangeOfSeries.group = 'Combine'
 rangeOfSeries.params = [
   Param('seriesLists', ParamTypes.seriesList, required=True, multiple=True),
 ]
+rangeOfSeries.aggregator = True
 
 
 def percentileOfSeries(requestContext, seriesList, n, interpolate=False):
@@ -983,6 +993,7 @@ multiplySeries.group = 'Combine'
 multiplySeries.params = [
   Param('seriesLists', ParamTypes.seriesList, required=True, multiple=True),
 ]
+multiplySeries.aggregator = True
 
 
 def weightedAverage(requestContext, seriesListAvg, seriesListWeight, *nodes):
@@ -1502,6 +1513,7 @@ powSeries.group = 'Transform'
 powSeries.params = [
   Param('seriesList', ParamTypes.seriesList, required=True, multiple=True),
 ]
+powSeries.aggregator = True
 
 
 def squareRoot(requestContext, seriesList):
@@ -4611,6 +4623,7 @@ countSeries.group = 'Combine'
 countSeries.params = [
   Param('seriesLists', ParamTypes.seriesList, multiple=True),
 ]
+countSeries.aggregator = True
 
 
 def group(requestContext, *seriesLists):

--- a/webapp/tests/test_params.py
+++ b/webapp/tests/test_params.py
@@ -192,3 +192,26 @@ class TestParam(unittest.TestCase):
             ['one', 'two', 'four'],
             {},
         )
+
+    def test_use_series_function_as_aggregator(self):
+        # powSeries is a series function which is marked as a valid aggregator
+        self.assertTrue(validateParams(
+            'TestParam',
+            [
+                Param('func', ParamTypes.aggOrSeriesFunc, required=True),
+            ],
+            ['powSeries'],
+            {},
+        ))
+
+        # squareRoot is a series function which is not marked as a valid aggregator
+        self.assertRaises(
+            InputParameterError,
+            validateParams,
+            'TestParam',
+            [
+                Param('func', ParamTypes.aggOrSeriesFunc, required=True),
+            ],
+            ['squareRoot'],
+            {},
+        )


### PR DESCRIPTION
This explicitly marks every series processing function which may also be used as an aggregator callback by the `groupBy*` functions as such. Every series processing function which has not been marked is considered as not a valid aggregator by the input validation.