### PR TITLE
Django 3.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,31 +10,31 @@ matrix:
         - TOXENV=pypy-django111-pyparsing2
     - python: 3.5
       env:
-        - TOXENV=py35-django21-pyparsing2
-    - python: 3.5
-      env:
         - TOXENV=py35-django22-pyparsing2
     - python: 3.6
       env:
         - TOXENV=py36-django22-pyparsing2
     - python: 3.7
       env:
-        - TOXENV=py37-django22-pyparsing2-msgpack
-    - python: 3.7
-      env:
-        - TOXENV=py37-django22-pyparsing2-pyhash
-    - python: 3.7
-      env:
-        - TOXENV=py37-django22-pyparsing2-mysql TEST_MYSQL_PASSWORD=graphite
-    - python: 3.7
-      env:
-        - TOXENV=py37-django22-pyparsing2-postgresql TEST_POSTGRESQL_PASSWORD=graphite
-    - python: 3.8
-      env:
-        - TOXENV=lint
+        - TOXENV=py37-django22-pyparsing2
     - python: 3.8
       env:
         - TOXENV=py38-django22-pyparsing2
+    - python: 3.8
+      env:
+        - TOXENV=py38-django30-pyparsing2-msgpack
+    - python: 3.8
+      env:
+        - TOXENV=py38-django30-pyparsing2-pyhash
+    - python: 3.8
+      env:
+        - TOXENV=py38-django30-pyparsing2-mysql TEST_MYSQL_PASSWORD=graphite
+    - python: 3.8
+      env:
+        - TOXENV=py38-django30-pyparsing2-postgresql TEST_POSTGRESQL_PASSWORD=graphite
+    - python: 3.8
+      env:
+        - TOXENV=lint
 
 env:
   - TOXENV=py27-django111-pyparsing2-msgpack

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@
 #   deactivate
 #
 
-Django>=1.8,<2.3
+Django>=1.8,<3.1
 python-memcached==1.58
 txAMQP==0.8
 django-tagging==0.4.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_rpm]
-requires = Django => 1.4
+requires = Django => 1.8
            django-tagging
            carbon
            whisper

--- a/setup.py
+++ b/setup.py
@@ -71,9 +71,11 @@ for root, dirs, files in os.walk('webapp/content'):
 conf_files = [ ('conf', glob('conf/*.example')) ]
 examples = [ ('examples', glob('examples/example-*')) ]
 
+
 def read(fname):
     with open(os.path.join(os.path.dirname(__file__), fname)) as f:
         return f.read()
+
 
 try:
     setup(
@@ -115,7 +117,8 @@ try:
         ['templates/*', 'local_settings.py.example']},
       scripts=glob('bin/*'),
       data_files=list(webapp_content.items()) + storage_dirs + conf_files + examples,
-      install_requires=['Django>=1.8,<2.3', 'django-tagging==0.4.3', 'pytz', 'pyparsing', 'cairocffi', 'urllib3', 'scandir', 'six'],
+      install_requires=['Django>=1.8,<3.1', 'django-tagging==0.4.3', 'pytz',
+                        'pyparsing', 'cairocffi', 'urllib3', 'scandir', 'six'],
       classifiers=[
           'Intended Audience :: Developers',
           'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
   py{27,py}-django111-pyparsing2{,-msgpack,-pyhash},
-  py{35,36,37,38}-django{111,21,22}-pyparsing2{,-msgpack,-pyhash},
+  py35-django{111,22}-pyparsing2{,-msgpack,-pyhash},
+  py{36,37,38}-django{111,22,30}-pyparsing2{,-msgpack,-pyhash},
   lint, docs
 
 [testenv]
@@ -29,9 +30,8 @@ deps =
 	git+git://github.com/graphite-project/ceres.git#egg=ceres
 	pyparsing2: pyparsing
 	django111: Django>=1.11,<1.11.99
-	django20: Django>=2.0,<2.0.99
-	django21: Django>=2.1,<2.1.99
 	django22: Django>=2.2,<2.2.99
+	django30: Django>=3.0,<3.0.99
 	scandir
 	urllib3
 	redis
@@ -50,7 +50,7 @@ deps =
 	pytz
 	git+git://github.com/graphite-project/whisper.git#egg=whisper
 	git+git://github.com/graphite-project/ceres.git#egg=ceres
-	Django<2.3
+	Django<3.1
 	pyparsing
 	Sphinx<1.4
 	sphinx_rtd_theme

--- a/webapp/graphite/account/views.py
+++ b/webapp/graphite/account/views.py
@@ -18,7 +18,7 @@ try:
 except ImportError:  # Django < 1.10
     from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from graphite.user_util import getProfile, isAuthenticated
 
 
@@ -32,14 +32,14 @@ def loginView(request):
   if username and password:
     user = authenticate(username=username,password=password)
     if user is None:
-      return render_to_response("login.html",{'authenticationFailed' : True, 'nextPage' : nextPage})
+      return render(request, "login.html",{'authenticationFailed' : True, 'nextPage' : nextPage})
     elif not user.is_active:
-      return render_to_response("login.html",{'accountDisabled' : True, 'nextPage' : nextPage})
+      return render(request, "login.html",{'accountDisabled' : True, 'nextPage' : nextPage})
     else:
       login(request,user)
       return HttpResponseRedirect(nextPage)
   else:
-    return render_to_response("login.html",{'nextPage' : nextPage})
+    return render(request, "login.html",{'nextPage' : nextPage})
 
 
 def logoutView(request):
@@ -52,7 +52,7 @@ def editProfile(request):
   if not isAuthenticated(request.user):
     return HttpResponseRedirect(reverse('browser'))
   context = { 'profile' : getProfile(request) }
-  return render_to_response("editProfile.html",context)
+  return render(request, "editProfile.html",context)
 
 
 def updateProfile(request):

--- a/webapp/graphite/browser/views.py
+++ b/webapp/graphite/browser/views.py
@@ -15,7 +15,7 @@ limitations under the License."""
 import re
 
 from django.conf import settings
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.utils.safestring import mark_safe
 from django.utils.html import escape
 from graphite.account.models import Profile
@@ -34,7 +34,7 @@ def header(request):
   context['profile'] = getProfile(request)
   context['documentation_url'] = settings.DOCUMENTATION_URL
   context['login_url'] = settings.LOGIN_URL
-  return render_to_response("browserHeader.html", context)
+  return render(request, "browserHeader.html", context)
 
 
 def browser(request):
@@ -47,7 +47,7 @@ def browser(request):
     context['queryString'] = context['queryString'].replace('#','%23')
   if context['target']:
     context['target'] = context['target'].replace('#','%23') #js libs terminate a querystring on #
-  return render_to_response("browser.html", context)
+  return render(request, "browser.html", context)
 
 
 def search(request):

--- a/webapp/graphite/composer/views.py
+++ b/webapp/graphite/composer/views.py
@@ -17,7 +17,7 @@ from graphite.user_util import getProfile
 from graphite.logger import log
 from graphite.account.models import MyGraph
 
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.http import HttpResponse
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
@@ -36,7 +36,7 @@ def composer(request):
     'debug' : settings.DEBUG,
     'jsdebug' : settings.DEBUG,
   }
-  return render_to_response("composer.html",context)
+  return render(request, "composer.html",context)
 
 
 def mygraph(request):

--- a/webapp/graphite/dashboard/views.py
+++ b/webapp/graphite/dashboard/views.py
@@ -4,7 +4,7 @@ import errno
 from os.path import getmtime
 from six.moves.urllib.parse import urlencode
 from six.moves.configparser import ConfigParser
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.http import QueryDict
 from django.conf import settings
 from django.contrib.auth import login, authenticate, logout
@@ -152,7 +152,7 @@ def dashboard(request, name=None):
     else:
       context['initialState'] = dashboard.state
 
-  return render_to_response("dashboard.html", context)
+  return render(request, "dashboard.html", context)
 
 
 def template(request, name, val):
@@ -200,7 +200,7 @@ def template(request, name, val):
     state = json.loads(template.loadState(val))
     state['name'] = '%s/%s' % (name, val)
     context['initialState'] = json.dumps(state)
-  return render_to_response("dashboard.html", context)
+  return render(request, "dashboard.html", context)
 
 
 def getPermissions(user):
@@ -360,7 +360,7 @@ def find_template(request):
 
 def help(request):
   context = {}
-  return render_to_response("dashboardHelp.html", context)
+  return render(request, "dashboardHelp.html", context)
 
 
 def email(request):

--- a/webapp/graphite/events/models.py
+++ b/webapp/graphite/events/models.py
@@ -1,9 +1,15 @@
 import os
 
 from django.db import models
-from tagging.models import Tag
 
-from graphite.events.compat import ModelTaggedItemManager
+# Monkeypatching so that django-tagging can import python_2_unicode_compatible
+import django.utils.encoding
+import six
+django.utils.encoding.python_2_unicode_compatible = six.python_2_unicode_compatible
+django.utils.six = six
+from tagging.models import Tag  # noqa: E402
+
+from graphite.events.compat import ModelTaggedItemManager  # noqa: E402
 
 if os.environ.get('READTHEDOCS'):
     TagField = lambda *args, **kwargs: None

--- a/webapp/graphite/events/views.py
+++ b/webapp/graphite/events/views.py
@@ -9,7 +9,7 @@ except ImportError:  # Django < 1.9
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.serializers.json import DjangoJSONEncoder
 from django.forms.models import model_to_dict
-from django.shortcuts import render_to_response, get_object_or_404
+from django.shortcuts import render, get_object_or_404
 from django.utils.timezone import now
 
 from graphite.util import json, epoch, epoch_to_dt, jsonResponse, HttpError, HttpResponse
@@ -29,7 +29,7 @@ def view_events(request):
         context = {'events': fetch(request),
                    'site': RequestSite(request),
                    'protocol': 'https' if request.is_secure() else 'http'}
-        return render_to_response('events.html', context)
+        return render(request, 'events.html', context)
     else:
         return post_event(request)
 
@@ -50,7 +50,7 @@ def detail(request, event_id):
 
     e = get_object_or_404(Event, pk=event_id)
     context = {'event': e}
-    return render_to_response('event.html', context)
+    return render(request, 'event.html', context)
 
 
 def post_event(request):

--- a/webapp/graphite/templates/browserHeader.html
+++ b/webapp/graphite/templates/browserHeader.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+{% load static %}<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <!-- Copyright 2008 Orbitz WorldWide
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/webapp/graphite/templates/composer.html
+++ b/webapp/graphite/templates/composer.html
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. -->
-{% load static staticfiles %}
+{% load static %}
 
 <html>
   <head>

--- a/webapp/graphite/templates/dashboard.html
+++ b/webapp/graphite/templates/dashboard.html
@@ -1,4 +1,4 @@
-{% load static staticfiles %}
+{% load static %}
 <html>
   <head>
     <title>Graphite Dashboard</title>

--- a/webapp/graphite/templates/event.html
+++ b/webapp/graphite/templates/event.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}<html>
+{% load static %}<html>
   <head>
     <title>{{event.what}}</title>
     <link rel="stylesheet" type="text/css" href="{% static "css/table.css" %}" />

--- a/webapp/graphite/templates/events.html
+++ b/webapp/graphite/templates/events.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}<html>
+{% load static %}<html>
   <head>
     <title>Events</title>
     <link rel="stylesheet" type="text/css" href="{% static "css/table.css" %}" />

--- a/webapp/graphite/version/views.py
+++ b/webapp/graphite/version/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from graphite import settings
 
 
@@ -6,4 +6,4 @@ def index(request):
   context = {
     'version' : settings.WEBAPP_VERSION,
   }
-  return render_to_response('version.html', context)
+  return render(request, 'version.html', context)

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -6,6 +6,7 @@ import math
 import logging
 import shutil
 import sys
+import django
 
 from mock import patch
 
@@ -280,15 +281,18 @@ class RenderTest(TestCase):
         self.assertEqual(resp_text(response), csv_response)
 
         # test noCache flag
+        expected_flags = ['max-age=0', 'must-revalidate', 'no-cache', 'no-store']
+        if django.VERSION[0] >= 3:
+            expected_flags.append('private')
         response = self.client.get(url, {'target': 'test', 'format': 'csv', 'noCache': 1, 'from': ts-50, 'now': ts})
         self.assertEqual(response['content-type'], 'text/csv')
-        self.assertEqual(sorted(response['cache-control'].split(', ')), ['max-age=0', 'must-revalidate', 'no-cache', 'no-store'])
+        self.assertEqual(sorted(response['cache-control'].split(', ')), expected_flags)
         self.assertEqual(resp_text(response), csv_response)
 
         # test cacheTimeout=0 flag
         response = self.client.get(url, {'target': 'test', 'format': 'csv', 'cacheTimeout': 0, 'from': ts-50, 'now': ts})
         self.assertEqual(response['content-type'], 'text/csv')
-        self.assertEqual(sorted(response['cache-control'].split(', ')), ['max-age=0', 'must-revalidate', 'no-cache', 'no-store'])
+        self.assertEqual(sorted(response['cache-control'].split(', ')), expected_flags)
         self.assertEqual(resp_text(response), csv_response)
 
         # test alternative target syntax


### PR DESCRIPTION
Changes render_to_response() to response().

Changes load staticfiles to load static in templates.

Django 3 sets the private header when setting no-cache headers. Adjusted tests to
reflect this.

Monkeypatched django.utils.enocoding.python2_unicode_compatible so that django-tagging
can continue to function. Django-tagging is dead, it should be replaced with django-taggit
or the graphite events functionality should be removed in favor of Graphana annotations.

Updates travis and tox to test currently maintained Django versions.