### PR TITLE
Parameter type int or inf

### DIFF
--- a/webapp/graphite/functions/params.py
+++ b/webapp/graphite/functions/params.py
@@ -41,6 +41,10 @@ def validateInteger(value):
   return isinstance(value, six.integer_types)
 
 
+def validateIntOrInf(value):
+  return validateInteger(value) or value == float('inf')
+
+
 def validateInterval(value):
   try:
     parseTimeOffset(value)
@@ -59,6 +63,7 @@ ParamType.register('float', validateFloat)
 ParamType.register('integer', validateInteger)
 ParamType.register('interval', validateInterval)
 ParamType.register('intOrInterval')
+ParamType.register('intOrInf', validateIntOrInf)
 ParamType.register('node', validateInteger)
 ParamType.register('nodeOrTag')
 ParamType.register('series')

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -592,7 +592,7 @@ def keepLastValue(requestContext, seriesList, limit = INF):
 keepLastValue.group = 'Transform'
 keepLastValue.params = [
   Param('seriesList', ParamTypes.seriesList, required=True),
-  Param('limit', ParamTypes.integer, default='INF'),
+  Param('limit', ParamTypes.intOrInf, default=INF),
 ]
 
 
@@ -648,7 +648,7 @@ def interpolate(requestContext, seriesList, limit = INF):
 interpolate.group = 'Transform'
 interpolate.params = [
   Param('seriesList', ParamTypes.seriesList, required=True),
-  Param('limit', ParamTypes.integer, default='INF'),
+  Param('limit', ParamTypes.intOrInf, default=INF),
 ]
 
 

--- a/webapp/tests/test_params.py
+++ b/webapp/tests/test_params.py
@@ -215,3 +215,27 @@ class TestParam(unittest.TestCase):
             ['squareRoot'],
             {},
         )
+
+    def test_param_type_int_or_inf(self):
+        self.assertTrue(validateParams(
+            'TestParam',
+            [Param('param', ParamTypes.intOrInf)],
+            [1],
+            {},
+        ))
+
+        self.assertTrue(validateParams(
+            'TestParam',
+            [Param('param', ParamTypes.intOrInf)],
+            [float('inf')],
+            {},
+        ))
+
+        self.assertRaises(
+            InputParameterError,
+            validateParams,
+            'TestParam',
+            [Param('param', ParamTypes.intOrInf)],
+            [1.2],
+            {},
+        )


### PR DESCRIPTION
Introduces new parameter type `intOrInf`. This is necessary because two functions `keepLastValue()` and `interpolate()` have a parameter `limit` which may be an `int` or `inf` but not a numeric `float` value. Unfortunately, in Python, `inf` is a valid `float` but not a valid `int`. So the new type `intOrInf` enforces specifically that a given value is `int` or the float value `inf`, but not any other `float` value.