### PR TITLE
Interpret inf

### DIFF
--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -159,6 +159,9 @@ def evaluateScalarTokens(tokens):
   if tokens.none:
     return None
 
+  if tokens.infinity:
+    return float('inf')
+
   raise InputParameterError("unknown token in target evaluator")
 
 

--- a/webapp/graphite/render/grammar.py
+++ b/webapp/graphite/render/grammar.py
@@ -38,6 +38,10 @@ none = Group(
   CaselessKeyword('none')
 )('none')
 
+infinity = Group(
+  CaselessKeyword('inf')
+)('infinity')
+
 argname = Word(alphas + '_', alphanums + '_')('argname')
 funcname = Word(alphas + '_', alphanums + '_')('funcname')
 
@@ -64,6 +68,7 @@ arg = Group(
   number |
   none |
   aString |
+  infinity |
   expression
 )('args*')
 kwarg = Group(argname + equal + arg)('kwargs*')

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -156,7 +156,7 @@ class RenderTest(TestCase):
 
     def test_render_evaluateScalarTokens(self):
         # test parsing numeric arguments
-        tokens = grammar.parseString('test(1, 1.0, 1e3, True, false, None, none)')
+        tokens = grammar.parseString('test(1, 1.0, 1e3, True, false, None, none, inf, INF)')
         self.assertEqual(evaluateScalarTokens(tokens.expression.call.args[0]), 1)
         self.assertEqual(evaluateScalarTokens(tokens.expression.call.args[1]), 1.0)
         self.assertEqual(evaluateScalarTokens(tokens.expression.call.args[2]), 1e3)
@@ -164,6 +164,8 @@ class RenderTest(TestCase):
         self.assertEqual(evaluateScalarTokens(tokens.expression.call.args[4]), False)
         self.assertIsNone(evaluateScalarTokens(tokens.expression.call.args[5]))
         self.assertIsNone(evaluateScalarTokens(tokens.expression.call.args[6]))
+        self.assertEqual(evaluateScalarTokens(tokens.expression.call.args[7]), float('inf'))
+        self.assertEqual(evaluateScalarTokens(tokens.expression.call.args[8]), float('inf'))
 
         # test invalid tokens
         class ScalarToken(object):

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -171,6 +171,7 @@ class RenderTest(TestCase):
           string = None
           boolean = None
           none = None
+          infinity = None
 
         class ScalarTokenNumber(object):
           integer = None


### PR DESCRIPTION
Currently unquoted `inf` values are not interpreted, so they get passed into the functions as `[]` (empty list of series). This is an issue because some examples (https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.interpolate / https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.keepLastValue) show an unquoted value `inf` as default. 

These defaults work fine if the value isn't specified, but we've seen cases where users then explicitly specified `limit=inf` like the default value in the docs, which was not interpreted correctly. 

This adds the interpretation of the unquoted `inf` values into `float(inf)`