### PR TITLE
fixes #2541

### DIFF
--- a/webapp/graphite/functions/params.py
+++ b/webapp/graphite/functions/params.py
@@ -72,6 +72,9 @@ ParamType.register('seriesLists', validateSeriesList)
 ParamType.register('string')
 ParamType.register('tag')
 
+# special type that accepts everything
+ParamType.register('any')
+
 
 class ParamTypeAggFunc(ParamType):
 

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -868,7 +868,7 @@ def asPercent(requestContext, seriesList, total=None, *nodes):
 asPercent.group = 'Combine'
 asPercent.params = [
   Param('seriesList', ParamTypes.seriesList, required=True),
-  Param('total', ParamTypes.seriesList),
+  Param('total', ParamTypes.any),
   Param('nodes', ParamTypes.nodeOrTag, multiple=True),
 ]
 

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -6176,7 +6176,7 @@ class FunctionsTest(TestCase):
                 },
                 {
                     'name': 'total',
-                    'type': 'seriesList'
+                    'type': 'any'
                 },
                 {
                     'multiple': True,


### PR DESCRIPTION
In the case of the function `asPercent()` we can't use the input validation to validate the value of the parameter `total` because depending the values given in other parameters it may or may not have different types. So instead we just accept any type for `total` and then ensure that the function `asPercent()` raises the correct exception `InputParameterError` if an invalid parameter has been given to prevent exceptions leading to 5xx due to bad input (it already does that without changes).

Fixes #2541 