### PR TITLE
better error messages with type indications

### DIFF
--- a/webapp/graphite/functions/params.py
+++ b/webapp/graphite/functions/params.py
@@ -218,13 +218,13 @@ def validateParams(func, params, args, kwargs):
     # parameter is restricted to a defined set of values, but value is not in it
     if params[i].options and value not in params[i].options:
       raise InputParameterError(
-        'Invalid option "{value}" specified for function "{func}" parameter "{param}"'.format(
-          value=value, param=params[i].name, func=func))
+        'Invalid option specified for function "{func}" parameter "{param}": {value}'.format(
+          func=func, param=params[i].name, value=repr(value)))
 
     if not params[i].validateValue(value):
       raise InputParameterError(
-        'Invalid {type} value specified for function "{func}" parameter "{param}": {value}'.format(
-          type=params[i].type.name, func=func, param=params[i].name, value=value))
+        'Invalid "{type}" value specified for function "{func}" parameter "{param}": {value}'.format(
+          type=params[i].type.name, func=func, param=params[i].name, value=repr(value)))
 
     valid_args.append(params[i].name)
 

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -111,8 +111,8 @@ def evaluateTokens(requestContext, tokens, replacements=None, pipedArg=None):
             args=', '.join(
               argList
               for argList in [
-                ', '.join(str(arg) for arg in args),
-                ', '.join('{k}={v}'.format(k=str(k), v=str(v)) for k, v in kwargs.items()),
+                ', '.join(repr(arg) for arg in args),
+                ', '.join('{k}={v}'.format(k=str(k), v=repr(v)) for k, v in kwargs.items()),
               ] if argList
             )
           ))


### PR DESCRIPTION
with this change the error message includes useful hints regarding what
the type of a given invalid value is.

F.e. previously a message talking about an `int(1)` value would have been
the same as a message talking about a `str('1')`, but now they are
differentiable because `repr()` indicates the type

These are the log statements resulting from the query `target=scale(a.b.c,"0.123")` (the second parameter is supposed to be a float).
```
# master
2020-02-20,20:03:36.090 :: Received invalid parameters (Invalid float value specified for function "scale" parameter "factor": 0.123): scale ([Time
Series(name=a.b.c, start=1582229014, end=1582229017, step=1, valuesPerPoint=1, consolidationFunc=average, xFilesFactor=0.0)], 0.123)

# this branch
2020-02-20,20:04:08.945 :: Received invalid parameters (Invalid "float" value specified for function "scale" parameter "factor": u'0.123'): scale (
[TimeSeries(name=a.b.c, start=1582229046, end=1582229049, step=1, valuesPerPoint=1, consolidationFunc=average, xFilesFactor=0.0)], u'0.123')
```