### PR TITLE
handle exceptions if params cannot be type converted

### DIFF
--- a/webapp/graphite/errors.py
+++ b/webapp/graphite/errors.py
@@ -1,3 +1,6 @@
+from django.http import HttpResponseBadRequest
+
+
 class NormalizeEmptyResultError(Exception):
   # throw error for normalize() when empty
   pass
@@ -5,3 +8,14 @@ class NormalizeEmptyResultError(Exception):
 
 class InputParameterError(ValueError):
   pass
+
+
+# decorator which turns InputParameterExceptions into Django's HttpResponseBadRequest
+def handleInputParameterError(f):
+    def new_f(*args, **kwargs):
+      try:
+        return f(*args, **kwargs)
+      except InputParameterError as e:
+        return HttpResponseBadRequest('Bad Request: {err}'.format(err=e))
+
+    return new_f

--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -57,7 +57,7 @@ def queryParamAsInt(queryParams, name, default):
   try:
     return int(queryParams[name])
   except Exception as e:
-    raise InputParameterError('Invalid int value {value} for {name}: {err}'.format(
+    raise InputParameterError('Invalid int value {value} for param {name}: {err}'.format(
       value=repr(queryParams[name]),
       name=name,
       err=str(e)))

--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -109,7 +109,7 @@ def find_view(request):
   else:
     fromTime = -1
 
-  if 'until' in queryParams and str(queryParams['from']) != '-1':
+  if 'until' in queryParams and str(queryParams['until']) != '-1':
     try:
       value = queryParams['until']
       untilTime = int(epoch(parseATTime(value, tzinfo, now)))

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -22,7 +22,7 @@ from random import shuffle
 from six.moves.urllib.parse import urlencode, urlsplit, urlunsplit, parse_qs
 
 from graphite.compat import HttpResponse
-from graphite.errors import InputParameterError
+from graphite.errors import InputParameterError, handleInputParameterError
 from graphite.user_util import getProfileByUsername
 from graphite.util import json, unpickle, pickle, msgpack, BytesIO
 from graphite.storage import extractForwardHeaders
@@ -34,7 +34,7 @@ from graphite.render.hashing import hashRequest, hashData
 from graphite.render.glyph import GraphTypes
 from graphite.tags.models import Series, Tag, TagValue, SeriesTag  # noqa # pylint: disable=unused-import
 
-from django.http import HttpResponseServerError, HttpResponseRedirect, HttpResponseBadRequest
+from django.http import HttpResponseServerError, HttpResponseRedirect
 from django.template import Context, loader
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
@@ -46,20 +46,17 @@ from six.moves import zip
 loadFunctions()
 
 
-def handleInputParameterError(f):
-    def new_f(*args, **kwargs):
-      try:
-        return f(*args, **kwargs)
-      except InputParameterError as e:
-        return HttpResponseBadRequest('Bad Request: {err}'.format(err=e))
-
-    return new_f
-
-
 @handleInputParameterError
 def renderView(request):
   start = time()
-  (graphOptions, requestOptions) = parseOptions(request)
+
+  try:
+    # we consider exceptions thrown by the option
+    # parsing to be due to user input error
+    (graphOptions, requestOptions) = parseOptions(request)
+  except Exception as e:
+    raise InputParameterError(str(e))
+
   useCache = 'noCache' not in requestOptions
   cacheTimeout = requestOptions['cacheTimeout']
   # TODO: Make that a namedtuple or a class.

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -21,6 +21,7 @@ except ImportError:  # python < 2.7 compatibility
     from django.utils.importlib import import_module
 
 from graphite.logger import log
+from graphite.errors import InputParameterError
 from graphite.node import LeafNode
 from graphite.intervals import Interval, IntervalSet
 from graphite.finders.utils import FindQuery, BaseFinder
@@ -250,12 +251,17 @@ class Store(object):
         return sorted(list(set(results)))
 
     def find(self, pattern, startTime=None, endTime=None, local=False, headers=None, leaves_only=False):
-        query = FindQuery(
-            pattern, startTime, endTime,
-            local=local,
-            headers=headers,
-            leaves_only=leaves_only
-        )
+        try:
+            query = FindQuery(
+                pattern, startTime, endTime,
+                local=local,
+                headers=headers,
+                leaves_only=leaves_only
+            )
+        except Exception as e:
+            raise InputParameterError(
+                'Failed to instantiate find query: {err}'
+                .format(err=str(e)))
 
         warn_threshold = settings.METRICS_FIND_WARNING_THRESHOLD
         fail_threshold = settings.METRICS_FIND_FAILURE_THRESHOLD

--- a/webapp/tests/test_metrics.py
+++ b/webapp/tests/test_metrics.py
@@ -132,7 +132,7 @@ class MetricsTester(TestCase):
         })
         self.assertEqual(response.status_code, 400)
         # the output in Python 2/3 slightly varies because repr() shows unicode strings differently, that's why the "u?"
-        self.assertRegex(response.content, b"^Bad Request: Invalid int value u?'123a' for param wildcards: invalid literal for int\(\) with base 10: u?'123a'$")
+        self.assertRegex(response.content, b"^Bad Request: Invalid int value u?'123a' for param wildcards: invalid literal for int\\(\\) with base 10: u?'123a'$")
 
         #
         # Invalid 'from' timestamp

--- a/webapp/tests/test_metrics.py
+++ b/webapp/tests/test_metrics.py
@@ -108,7 +108,7 @@ class MetricsTester(TestCase):
         #
         response = self.client.post(url, {})
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.content, b"Missing required parameter 'query'")
+        self.assertEqual(response.content, b"Bad Request: Missing required parameter 'query'")
 
         #
         # format=invalid_format


### PR DESCRIPTION
Handling various cases of bad input in the `/metrics/find` and `/render` routes and replying with `4xx` instead of `5xx`.

Before merging, there's one thing i'm uncertain about... should the second part of this `if` condition actually be checking `queryParams['until']` or is this really supposed to check `queryParams['from']`? (looks like a bug to me) https://github.com/graphite-project/graphite-web/blob/master/webapp/graphite/metrics/views.py#L80
For now I've left the logic as it currently is, but if that's a bug I can push another commit into this PR to fix it, since I'm already changing a lot of lines in that area.