### PR TITLE
Optional replacement value for replaceAboveValue

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -3271,17 +3271,17 @@ removeAbovePercentile.params = [
 ]
 
 
-def removeAboveValue(requestContext, seriesList, n):
+def removeAboveValue(requestContext, seriesList, n, replacement=None):
   """
   Removes data above the given threshold from the series or list of series provided.
-  Values above this threshold are assigned a value of None.
+  Values above this threshold are assigned the replacement value (defaults to None).
   """
   for s in seriesList:
-    s.name = 'removeAboveValue(%s, %g)' % (s.name, n)
+    s.name = 'removeAboveValue(%s, %g, %g)' % (s.name, n, replacement)
     s.pathExpression = s.name
     for (index, val) in enumerate(s):
       if val is not None and val > n:
-        s[index] = None
+        s[index] = replacement
 
   return seriesList
 
@@ -3290,6 +3290,7 @@ removeAboveValue.group = 'Filter Data'
 removeAboveValue.params = [
   Param('seriesList', ParamTypes.seriesList, required=True),
   Param('n', ParamTypes.float, required=True),
+  Param('replacement', ParamTypes.float, required=False),
 ]
 
 

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -36,6 +36,10 @@ def return_less(series, value):
     return [i for i in series if i is not None and i < value]
 
 
+def return_equal(series, value):
+    return [i for i in series if i is not None and i == value]
+
+
 class FunctionsTest(TestCase):
 
     def setUp(self):
@@ -2530,6 +2534,16 @@ class FunctionsTest(TestCase):
             self.assertEqual(return_greater(result, value), [])
             expected_name = "removeAboveValue(collectd.test-db{0}.load.value, 0.1)".format(i + 1)
             self.assertEqual(expected_name, result.name)
+
+    def test_remove_above_value_replace(self):
+        seriesList = self._generate_series_list()
+        value = 5
+        results = functions.removeAboveValue({}, seriesList, value, value)
+        for i, result in enumerate(results):
+            self.assertEqual(return_greater(result, value), [])
+            expected_name = "removeAboveValue(collectd.test-db{0}.load.value, 5, 5)".format(i + 1)
+            self.assertEqual(expected_name, result.name)
+            self.assertEqual(len(return_equal(result, value)), len(return_greater(seriesList[i], value-1)))
 
     def test_remove_below_value(self):
         seriesList = self._generate_series_list()


### PR DESCRIPTION
I'm converting some raw sensor data into a percentage, and want to truncate values above 100 to 100%. This PR lets me do this using a new optional argument to `replaceAboveValue`:

>sensor.soil_capacitance | offset(-244) | scale(0.3813) | removeAboveValue(100, 100)

If this looks reasonable, I could be convinced to add it to the other `replace{Below,Above}{Value,Percentile}` functions too.