### PR TITLE
Fix validator when default value is used

### DIFF
--- a/webapp/graphite/functions/params.py
+++ b/webapp/graphite/functions/params.py
@@ -180,9 +180,6 @@ class Param(object):
     return jsonVal
 
   def validateValue(self, value):
-    if value is None and self.default is not None:
-      value = self.default
-
     # None is ok for optional params
     if not self.required and value is None:
       return True
@@ -217,6 +214,11 @@ def validateParams(func, params, args, kwargs):
     else:
       # requirement is satisfied from "args"
       value = args[i]
+
+    if value is None and params[i].default is not None:
+      # if value isn't specified and there's a default, then the default will be used
+      # we don't need to validate the default value because we trust that it is valid
+      continue
 
     # parameter is restricted to a defined set of values, but value is not in it
     if params[i].options and value not in params[i].options:

--- a/webapp/tests/test_params.py
+++ b/webapp/tests/test_params.py
@@ -239,3 +239,15 @@ class TestParam(unittest.TestCase):
             [1.2],
             {},
         )
+
+    def test_default_value(self):
+        # if no value is specified, but there is a default value, we don't
+        # want the validator to raise an exception because 'None' is invalid
+        self.assertTrue(validateParams(
+            'TestParam',
+            [
+                Param('one', ParamTypes.aggFunc, default='sum'),
+            ],
+            [],
+            {},
+        ))


### PR DESCRIPTION
Found this issue because a user was querying `target=summarize(<metrics>,"15min")`, without specifying the `func` parameter. By default the `func` parameter is `sum`, but the validator threw an exception because `None` is not a valid value for `func`.

The first commit adds a test to illustrate the problem, the second fixes it and makes the test passes.