### PR TITLE
make consolidation func `avg` alias for average

### DIFF
--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -82,11 +82,16 @@ class TimeSeries(list):
     'first': lambda usable: usable[0],
     'last': lambda usable: usable[-1],
   }
+  __consolidation_function_aliases = {
+    'avg': 'average',
+  }
 
   def __consolidatingGenerator(self, gen):
-    try:
+    if self.consolidationFunc in self.__consolidation_functions:
       cf = self.__consolidation_functions[self.consolidationFunc]
-    except KeyError:
+    elif self.consolidationFunc in self.__consolidation_function_aliases:
+      cf = self.__consolidation_functions[self.__consolidation_function_aliases[self.consolidationFunc]]
+    else:
       raise Exception("Invalid consolidation function: '%s'" % self.consolidationFunc)
 
     buf = []

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1855,7 +1855,7 @@ def consolidateBy(requestContext, seriesList, consolidationFunc):
   """
   Takes one metric or a wildcard seriesList and a consolidation function name.
 
-  Valid function names are 'sum', 'average', 'min', 'max', 'first' & 'last'.
+  Valid function names are 'sum', 'average'/'avg', 'min', 'max', 'first' & 'last'.
 
   When a graph is drawn where width of the graph size in pixels is smaller than
   the number of datapoints to be graphed, Graphite consolidates the values to
@@ -1882,7 +1882,7 @@ def consolidateBy(requestContext, seriesList, consolidationFunc):
 consolidateBy.group = 'Special'
 consolidateBy.params = [
   Param('seriesList', ParamTypes.seriesList, required=True),
-  Param('consolidationFunc', ParamTypes.string, required=True, options=['sum', 'average', 'avg_zero', 'min', 'max', 'first', 'last']),
+  Param('consolidationFunc', ParamTypes.string, required=True, options=['sum', 'average', 'avg', 'avg_zero', 'min', 'max', 'first', 'last']),
 ]
 
 

--- a/webapp/tests/test_render_datalib.py
+++ b/webapp/tests/test_render_datalib.py
@@ -127,7 +127,7 @@ class TimeSeriesTest(TestCase):
       series.xFilesFactor = 1
       self.assertEqual(list(series), list(expected))
 
-    def test_TimeSeries_iterate_valuesPerPoint_2_avg(self):
+    def test_TimeSeries_iterate_valuesPerPoint_2_average(self):
       values = list(range(0,100))
 
       series = TimeSeries("collectd.test-db.load.value", 0, len(values)/2, 1, values)
@@ -225,6 +225,23 @@ class TimeSeriesTest(TestCase):
       series.consolidate(3)
       self.assertEqual(series.valuesPerPoint, 3)
       expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, list(range(2,100,3)) + [99])
+      self.assertEqual(list(series), list(expected))
+
+    # avg is an alias for average
+    def test_TimeSeries_iterate_valuesPerPoint_2_avg_alias(self):
+      values = list(range(0,100))
+
+      series = TimeSeries("collectd.test-db.load.value", 0, len(values)/2, 1, values, consolidate='avg')
+      self.assertEqual(series.valuesPerPoint, 1)
+
+      series.consolidate(2)
+      self.assertEqual(series.valuesPerPoint, 2)
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, [0.5, 2.5, 4.5, 6.5, 8.5, 10.5, 12.5, 14.5, 16.5, 18.5, 20.5, 22.5, 24.5, 26.5, 28.5, 30.5, 32.5, 34.5, 36.5, 38.5, 40.5, 42.5, 44.5, 46.5, 48.5, 50.5, 52.5, 54.5, 56.5, 58.5, 60.5, 62.5, 64.5, 66.5, 68.5, 70.5, 72.5, 74.5, 76.5, 78.5, 80.5, 82.5, 84.5, 86.5, 88.5, 90.5, 92.5, 94.5, 96.5, 98.5])
+      self.assertEqual(list(series), list(expected))
+
+      series.consolidate(3)
+      self.assertEqual(series.valuesPerPoint, 3)
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, map(float, list(range(1, 100, 3)) + [99]))
       self.assertEqual(list(series), list(expected))
 
     def test_TimeSeries_iterate_valuesPerPoint_2_invalid(self):


### PR DESCRIPTION
it's confusing that most of the functions accepted by `consolidateBy` use a short form like `min`/`max`/`avg_zero`, but `average` needs to be spelled out because `avg` is not accepted. 