### PR TITLE
flake8: re-enable F841 (local variable assigned but not used)

### DIFF
--- a/contrib/memcache_whisper.py
+++ b/contrib/memcache_whisper.py
@@ -225,7 +225,7 @@ xFilesFactor specifies the fraction of data points in a propagation interval tha
 
 def __propagate(fh,timestamp,xff,higher,lower):
   lowerIntervalStart = timestamp - (timestamp % lower['secondsPerPoint'])
-  lowerIntervalEnd = lowerIntervalStart + lower['secondsPerPoint']
+  # lowerIntervalEnd = lowerIntervalStart + lower['secondsPerPoint']
   fh.seek(higher['offset'])
   packedPoint = fh.read(pointSize)
   (higherBaseInterval,higherBaseValue) = struct.unpack(pointFormat,packedPoint)
@@ -315,7 +315,7 @@ timestamp is either an int or float
   if baseInterval == 0: #This file's first update
     fh.seek(archive['offset'])
     fh.write(myPackedPoint)
-    baseInterval,baseValue = myInterval,value
+    baseInterval,baseValue = myInterval,value  # noqa: F841
   else: #Not our first update
     timeDistance = myInterval - baseInterval
     pointDistance = timeDistance / archive['secondsPerPoint']

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,5 +70,3 @@ ignore =
     E701,
     # E731 do not assign a lambda expression, use a def
     E731,
-    # F841 local variable 'stuff' is assigned to but never used
-    F841,

--- a/webapp/graphite/logger.py
+++ b/webapp/graphite/logger.py
@@ -15,19 +15,8 @@ limitations under the License."""
 import os
 import logging
 from logging.handlers import TimedRotatingFileHandler as Rotater
-try:
-    from logging import NullHandler
-except ImportError as ie:  # py2.6
-    from logging import Handler
+from logging import NullHandler, FileHandler, StreamHandler
 
-    class NullHandler(Handler):
-
-        def emit(self, record):
-            pass
-try:
-    from logging import FileHandler, StreamHandler
-except ImportError as ie:  # py2.6
-    from logging.handlers import FileHandler, StreamHandler
 from django.conf import settings
 
 

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -90,7 +90,7 @@ try:
         percent_l_supported = True
     else:
         percent_l_supported = False
-except ValueError as e:
+except ValueError:
     percent_l_supported = False
 
 DATE_FORMAT = settings.DATE_FORMAT

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -182,9 +182,6 @@ class Store(object):
           )
           jobs.append(job)
 
-        done = 0
-        errors = 0
-
         # Start fetches
         start = time.time()
         results = self.wait_jobs(jobs, settings.FETCH_TIMEOUT,

--- a/webapp/tests/test_attime.py
+++ b/webapp/tests/test_attime.py
@@ -399,11 +399,11 @@ class getUnitStringTest(TestCase):
 
     def test_m_raises_Exception(self):
         with self.assertRaises(Exception):
-            result = getUnitString("m")
+            _ = getUnitString("m")
 
     def test_integer_raises_Exception(self):
         with self.assertRaises(Exception):
-            result = getUnitString(1)
+            _ = getUnitString(1)
 
 
 @mock.patch('graphite.render.attime.datetime', mockDateTime(2016, 2, 29, 00, 0, 0))

--- a/webapp/tests/test_dashboard.py
+++ b/webapp/tests/test_dashboard.py
@@ -45,14 +45,14 @@ class DashboardTest(TestCase):
         check.side_effect = OSError(errno.EPERM, 'Operation not permitted')
         url = reverse('dashboard')
         with self.assertRaises(Exception):
-            response = self.client.get(url)
+            _ = self.client.get(url)
 
     @mock.patch('graphite.dashboard.views.DashboardConfig.check')
     def test_dashboard_template_conf_read_failure(self, check):
         check.side_effect = OSError(errno.EPERM, 'Operation not permitted')
         url = reverse('dashboard_template', args=['bogustemplate', 'testkey'])
         with self.assertRaises(Exception):
-            response = self.client.get(url)
+            _ = self.client.get(url)
 
     @override_settings(DASHBOARD_CONF=os.path.join(TEST_CONF_DIR, 'dashboard.conf.missing_ui'))
     def test_dashboard_conf_missing_ui(self):

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -2612,7 +2612,7 @@ class FunctionsTest(TestCase):
         )
         message = r"verticalLine\(\): timestamp 3600 exists before start of range"
         with self.assertRaisesRegexp(ValueError, message):
-            result = functions.verticalLine(requestContext, "01:0019700101", "foo")
+            _ = functions.verticalLine(requestContext, "01:0019700101", "foo")
 
     def test_vertical_line_after_end(self):
         requestContext = self._build_requestContext(
@@ -2622,7 +2622,7 @@ class FunctionsTest(TestCase):
         )
         message = r"verticalLine\(\): timestamp 31539600 exists after end of range"
         with self.assertRaisesRegexp(ValueError, message):
-            result = functions.verticalLine(requestContext, "01:0019710101", "foo")
+            _ = functions.verticalLine(requestContext, "01:0019710101", "foo")
 
     def test_line_width(self):
         seriesList = self._generate_series_list()
@@ -2890,9 +2890,6 @@ class FunctionsTest(TestCase):
         seriesList = self._generate_series_list()
 
         def verify_node_name(cases, expected, *nodes):
-            if isinstance(nodes, int):
-                node_number = [nodes]
-
             # Use deepcopy so the original seriesList is unmodified
             results = functions.aliasByNode({}, copy.deepcopy(cases), *nodes)
 
@@ -3025,11 +3022,7 @@ class FunctionsTest(TestCase):
         seriesList, inputList = self._generate_mr_series()
 
         def verify_groupByNodes(expectedResult, func, *nodes):
-            if isinstance(nodes, int):
-                node_number = [nodes]
-
             results = functions.groupByNodes({}, copy.deepcopy(seriesList), func, *nodes)
-
             self.assertEqual(results, expectedResult)
 
         expectedResult = [
@@ -3579,7 +3572,7 @@ class FunctionsTest(TestCase):
 
     def test_constantLine(self):
         requestContext = {'startTime': datetime(2014,3,12,2,0,0,2,pytz.timezone(settings.TIME_ZONE)), 'endTime':datetime(2014,3,12,3,0,0,2,pytz.timezone(settings.TIME_ZONE))}
-        results = functions.constantLine(requestContext, [1])
+        _ = functions.constantLine(requestContext, [1])
 
     def test_aggregateLine_default(self):
         seriesList = self._gen_series_list_with_data(
@@ -3714,14 +3707,14 @@ class FunctionsTest(TestCase):
         )
 
         with self.assertRaisesRegexp(ValueError, '^Unsupported aggregation function: bad$'):
-          result = functions.aggregateLine(
+          functions.aggregateLine(
             self._build_requestContext(
                 startTime=datetime(1970,1,1,1,0,0,0,pytz.timezone(settings.TIME_ZONE)),
                 endTime=datetime(1970,1,1,1,0,0,0,pytz.timezone(settings.TIME_ZONE))
             ),
             seriesList,
             'bad'
-        )
+          )
 
     def test_threshold_default(self):
         expectedResult = [

--- a/webapp/tests/test_metrics.py
+++ b/webapp/tests/test_metrics.py
@@ -95,8 +95,7 @@ class MetricsTester(TestCase):
 
     def test_find_view(self):
         ts = int(time.time())
-        #create a minus 60 variable to test with, otherwise the build could fail the longer the test runs
-        ts_minus_sixty_seconds = ts - 60
+        # ts_minus_sixty_seconds = ts - 60  # usage always commented-out below?
 
         self.create_whisper_hosts(ts)
         self.addCleanup(self.wipe_whisper_hosts)

--- a/webapp/tests/test_render_datalib.py
+++ b/webapp/tests/test_render_datalib.py
@@ -253,7 +253,7 @@ class TimeSeriesTest(TestCase):
       series.consolidate(2)
       self.assertEqual(series.valuesPerPoint, 2)
       with self.assertRaisesRegexp(Exception, "Invalid consolidation function: 'bogus'"):
-        result = list(series)
+        _ = list(series)
 
 
 class DatalibFunctionTest(TestCase):
@@ -303,7 +303,7 @@ class DatalibFunctionTest(TestCase):
       pathExpr = 'collectd.test-db.load.value'
       startTime=datetime(1970, 1, 1, 0, 10, 0, 0, pytz.timezone(settings.TIME_ZONE))
       endTime=datetime(1970, 1, 1, 0, 20, 0, 0, pytz.timezone(settings.TIME_ZONE))
-      timeInfo = [startTime, endTime, 60]
+      # timeInfo = [startTime, endTime, 60]
       result_queue = [
                       [pathExpr, None],
                      ]
@@ -320,7 +320,7 @@ class DatalibFunctionTest(TestCase):
       pathExpr = 'collectd.test-db.load.value'
       startTime=datetime(1970, 1, 1, 0, 10, 0, 0, pytz.timezone(settings.TIME_ZONE))
       endTime=datetime(1970, 1, 1, 0, 20, 0, 0, pytz.timezone(settings.TIME_ZONE))
-      timeInfo = [startTime, endTime, 60]
+      # timeInfo = [startTime, endTime, 60]
       result_queue = [
                       [pathExpr, ['invalid input']],
                      ]

--- a/webapp/tests/test_util.py
+++ b/webapp/tests/test_util.py
@@ -94,7 +94,7 @@ class UtilTest(TestCase):
 
     def test_load_module(self):
         with self.assertRaises(IOError):
-            module = util.load_module('test', member=None)
+            _ = util.load_module('test', member=None)
 
     @patch('graphite.util.log')
     def test_logtime(self, log):

--- a/webapp/tests/test_whitelist.py
+++ b/webapp/tests/test_whitelist.py
@@ -36,7 +36,7 @@ class WhitelistTester(TestCase):
     def test_whitelist_show_no_whitelist(self):
         url = reverse('whitelist_show')
         with self.assertRaises(IOError):
-          response = self.client.get(url)
+          _ = self.client.get(url)
 
     def test_whitelist_show(self):
         url = reverse('whitelist_show')


### PR DESCRIPTION
if you have a preference do these fixups a different way, please feel free to comment :)

In some cases I commented out a line, because it was part of the pattern of every test in the series, but unused in one or two tests, or in one case because there were a bunch of other commented out lines further down which referenced it. I could alternatively "delete them all".