### PR TITLE
[1.1.x] handle exceptions if params cannot be type converted (#2547) | fix minor bug in query param evaluation (#2547) | fails to instantiate find query must be due to bad user input (#2547) | add tests for invalid parameter types (#2547) |

### DIFF
--- a/contrib/memcache_whisper.py
+++ b/contrib/memcache_whisper.py
@@ -194,13 +194,13 @@ xFilesFactor specifies the fraction of data points in a propagation interval tha
     if i == len(archiveList) - 1: break
     next = archiveList[i+1]
     assert archive[0] < next[0],\
-    "You cannot configure two archives with the same precision %s,%s" % (archive,next)
+        "You cannot configure two archives with the same precision %s,%s" % (archive,next)
     assert (next[0] % archive[0]) == 0,\
-    "Higher precision archives' precision must evenly divide all lower precision archives' precision %s,%s" % (archive[0],next[0])
+        "Higher precision archives' precision must evenly divide all lower precision archives' precision %s,%s" % (archive[0],next[0])
     retention = archive[0] * archive[1]
     nextRetention = next[0] * next[1]
     assert nextRetention > retention,\
-    "Lower precision archives must cover larger time intervals than higher precision archives %s,%s" % (archive,next)
+        "Lower precision archives must cover larger time intervals than higher precision archives %s,%s" % (archive,next)
   #Looks good, now we create the file and write the header
   assert not exists(path), "File %s already exists!" % path
   fh = open(path,'wb')

--- a/contrib/memcache_whisper.py
+++ b/contrib/memcache_whisper.py
@@ -225,7 +225,7 @@ xFilesFactor specifies the fraction of data points in a propagation interval tha
 
 def __propagate(fh,timestamp,xff,higher,lower):
   lowerIntervalStart = timestamp - (timestamp % lower['secondsPerPoint'])
-  lowerIntervalEnd = lowerIntervalStart + lower['secondsPerPoint']
+  # lowerIntervalEnd = lowerIntervalStart + lower['secondsPerPoint']
   fh.seek(higher['offset'])
   packedPoint = fh.read(pointSize)
   (higherBaseInterval,higherBaseValue) = struct.unpack(pointFormat,packedPoint)
@@ -315,7 +315,7 @@ timestamp is either an int or float
   if baseInterval == 0: #This file's first update
     fh.seek(archive['offset'])
     fh.write(myPackedPoint)
-    baseInterval,baseValue = myInterval,value
+    baseInterval,baseValue = myInterval,value  # noqa: F841
   else: #Not our first update
     timeDistance = myInterval - baseInterval
     pointDistance = timeDistance / archive['secondsPerPoint']

--- a/contrib/memcache_whisper.py
+++ b/contrib/memcache_whisper.py
@@ -30,12 +30,21 @@ NOTE: This is a modified version of whisper.py
 For details on the modification, read https://bugs.launchpad.net/graphite/+bug/245835
 """
 
-import os, struct, time
+import os
+import struct
+import sys
+import time
 try:
   import fcntl
   CAN_LOCK = True
 except ImportError:
   CAN_LOCK = False
+
+if sys.version_info[0] == 3:
+    xrange = range
+    # This `file` hack avoids linter warnings under Python-3,
+    # but this code likely only works with Python-2.
+    file = None
 
 LOCK = False
 CACHE_HEADERS = False
@@ -58,11 +67,14 @@ archiveInfoSize = struct.calcsize(archiveInfoFormat)
 
 debug = startBlock = endBlock = lambda *a,**k: None
 
+
 def exists(path):
   return os.path.exists(path)
 
+
 def drop(path):
   os.remove(path)
+
 
 def enableMemcache(servers = ['127.0.0.1:11211'], min_compress_len = 0):
   from StringIO import StringIO
@@ -84,15 +96,17 @@ def enableMemcache(servers = ['127.0.0.1:11211'], min_compress_len = 0):
       if self.mode == "r+b" or self.mode == "wb":
         MC.set(self.name, self.getvalue(), min_compress_len = min_compress_len)
       StringIO.close(self)
-      
+
   def exists(path):
-    return MC.get(path) != None
+    return MC.get(path) is not None
 
   def drop(path):
     MC.delete(path)
 
+
 def enableDebug():
   global open, debug, startBlock, endBlock
+
   class open(file):
     def __init__(self,*args,**kwargs):
       file.__init__(self,*args,**kwargs)

--- a/contrib/test_aggregator_rules.py
+++ b/contrib/test_aggregator_rules.py
@@ -8,12 +8,12 @@ ROOT_DIR = dirname(dirname(abspath(__file__)))
 LIB_DIR = join(ROOT_DIR, 'graphite', 'lib')
 sys.path.insert(0, LIB_DIR)
 
-from carbon.aggregator.rules import RuleManager
+from carbon.aggregator.rules import RuleManager  # noqa: E402
 
 ### Basic usage
 if len(sys.argv) != 3:
   print("Usage: %s 'aggregator rule' 'line item'" % (__file__))
-  print("\nSample invocation: %s %s %s" % \
+  print("\nSample invocation: %s %s %s" %
     (__file__, "'<prefix>.<env>.<key>.sum.all (10) = sum <prefix>.<env>.<<key>>.sum.<node>'", 'stats.prod.js.ktime_sum.sum.host2' ))
   sys.exit(42)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,10 +26,6 @@ ignore =
     E114,
     # E121 continuation line under-indented for hanging indent
     E121,
-    # E122 continuation line missing indentation or outdented
-    E122,
-    # E124 closing bracket does not match visual indentation
-    E124,
     # E126 continuation line over-indented for hanging indent
     E126,
     # E128 continuation line under-indented for visual indent

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,8 +68,6 @@ ignore =
     W504,
     # E701 multiple statements on one line (colon)
     E701,
-    # E713 test for membership should be 'not in'
-    E713,
     # E731 do not assign a lambda expression, use a def
     E731,
     # F841 local variable 'stuff' is assigned to but never used

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ provides = graphite
 obsoletes = graphite <= 0.9.9
 
 [flake8]
-exclude = .tox,contrib
+exclude = .tox
 ignore =
     # E111 indentation is not a multiple of four
     E111,

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,5 +66,3 @@ ignore =
     E701,
     # E731 do not assign a lambda expression, use a def
     E731,
-    # F841 local variable 'stuff' is assigned to but never used
-    F841,

--- a/webapp/graphite/errors.py
+++ b/webapp/graphite/errors.py
@@ -1,3 +1,6 @@
+from django.http import HttpResponseBadRequest
+
+
 class NormalizeEmptyResultError(Exception):
   # throw error for normalize() when empty
   pass
@@ -5,3 +8,14 @@ class NormalizeEmptyResultError(Exception):
 
 class InputParameterError(ValueError):
   pass
+
+
+# decorator which turns InputParameterExceptions into Django's HttpResponseBadRequest
+def handleInputParameterError(f):
+    def new_f(*args, **kwargs):
+      try:
+        return f(*args, **kwargs)
+      except InputParameterError as e:
+        return HttpResponseBadRequest('Bad Request: {err}'.format(err=e))
+
+    return new_f

--- a/webapp/graphite/functions/params.py
+++ b/webapp/graphite/functions/params.py
@@ -185,20 +185,22 @@ class Param(object):
     if value is None and self.default is not None:
       return True
 
+    # None is ok for optional params
+    if not self.required and value is None:
+      return True
+
     # parameter is restricted to a defined set of values, but value is not in it
     if self.options and value not in self.options:
       raise InputParameterError(
         'Invalid option specified for function "{func}" parameter "{param}": {value}'.format(
           func=func, param=self.name, value=repr(value)))
 
-    # None is ok for optional params
-    if not self.required and value is None:
-      return True
-
     if not self.type.isValid(value):
       raise InputParameterError(
         'Invalid "{type}" value specified for function "{func}" parameter "{param}": {value}'.format(
           type=self.type.name, func=func, param=self.name, value=repr(value)))
+
+    return True
 
 
 def validateParams(func, params, args, kwargs):

--- a/webapp/graphite/functions/params.py
+++ b/webapp/graphite/functions/params.py
@@ -179,12 +179,26 @@ class Param(object):
       jsonVal['suggestions'] = self.suggestions
     return jsonVal
 
-  def validateValue(self, value):
+  def validateValue(self, value, func):
+    # if value isn't specified and there's a default then the default will be used,
+    # we don't need to validate the default value because we trust that it is valid
+    if value is None and self.default is not None:
+      return True
+
+    # parameter is restricted to a defined set of values, but value is not in it
+    if self.options and value not in self.options:
+      raise InputParameterError(
+        'Invalid option specified for function "{func}" parameter "{param}": {value}'.format(
+          func=func, param=self.name, value=repr(value)))
+
     # None is ok for optional params
     if not self.required and value is None:
       return True
 
-    return self.type.isValid(value)
+    if not self.type.isValid(value):
+      raise InputParameterError(
+        'Invalid "{type}" value specified for function "{func}" parameter "{param}": {value}'.format(
+          type=self.type.name, func=func, param=self.name, value=repr(value)))
 
 
 def validateParams(func, params, args, kwargs):
@@ -215,22 +229,7 @@ def validateParams(func, params, args, kwargs):
       # requirement is satisfied from "args"
       value = args[i]
 
-    if value is None and params[i].default is not None:
-      # if value isn't specified and there's a default, then the default will be used
-      # we don't need to validate the default value because we trust that it is valid
-      continue
-
-    # parameter is restricted to a defined set of values, but value is not in it
-    if params[i].options and value not in params[i].options:
-      raise InputParameterError(
-        'Invalid option specified for function "{func}" parameter "{param}": {value}'.format(
-          func=func, param=params[i].name, value=repr(value)))
-
-    if not params[i].validateValue(value):
-      raise InputParameterError(
-        'Invalid "{type}" value specified for function "{func}" parameter "{param}": {value}'.format(
-          type=params[i].type.name, func=func, param=params[i].name, value=repr(value)))
-
+    params[i].validateValue(value, func)
     valid_args.append(params[i].name)
 
   return True

--- a/webapp/graphite/functions/params.py
+++ b/webapp/graphite/functions/params.py
@@ -180,9 +180,6 @@ class Param(object):
     return jsonVal
 
   def validateValue(self, value):
-    if value is None and self.default is not None:
-      value = self.default
-
     # None is ok for optional params
     if not self.required and value is None:
       return True
@@ -217,6 +214,11 @@ def validateParams(func, params, args, kwargs):
     else:
       # requirement is satisfied from "args"
       value = args[i]
+
+    if value is None and params[i].default is not None:
+      # if value isn't specified and there's a default, then the default will be used
+      # we don't need to validate the default value because we trust that it is valid
+      continue
 
     # parameter is restricted to a defined set of values, but value is not in it
     if params[i].options and value not in params[i].options:

--- a/webapp/graphite/logger.py
+++ b/webapp/graphite/logger.py
@@ -15,19 +15,8 @@ limitations under the License."""
 import os
 import logging
 from logging.handlers import TimedRotatingFileHandler as Rotater
-try:
-    from logging import NullHandler
-except ImportError as ie:  # py2.6
-    from logging import Handler
+from logging import NullHandler, FileHandler, StreamHandler
 
-    class NullHandler(Handler):
-
-        def emit(self, record):
-            pass
-try:
-    from logging import FileHandler, StreamHandler
-except ImportError as ie:  # py2.6
-    from logging.handlers import FileHandler, StreamHandler
 from django.conf import settings
 
 

--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -57,7 +57,7 @@ def queryParamAsInt(queryParams, name, default):
   try:
     return int(queryParams[name])
   except Exception as e:
-    raise InputParameterError('Invalid int value {value} for {name}: {err}'.format(
+    raise InputParameterError('Invalid int value {value} for param {name}: {err}'.format(
       value=repr(queryParams[name]),
       name=name,
       err=str(e)))

--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -109,7 +109,7 @@ def find_view(request):
   else:
     fromTime = -1
 
-  if 'until' in queryParams and str(queryParams['from']) != '-1':
+  if 'until' in queryParams and str(queryParams['until']) != '-1':
     try:
       value = queryParams['until']
       untilTime = int(epoch(parseATTime(value, tzinfo, now)))

--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -82,11 +82,16 @@ class TimeSeries(list):
     'first': lambda usable: usable[0],
     'last': lambda usable: usable[-1],
   }
+  __consolidation_function_aliases = {
+    'avg': 'average',
+  }
 
   def __consolidatingGenerator(self, gen):
-    try:
+    if self.consolidationFunc in self.__consolidation_functions:
       cf = self.__consolidation_functions[self.consolidationFunc]
-    except KeyError:
+    elif self.consolidationFunc in self.__consolidation_function_aliases:
+      cf = self.__consolidation_functions[self.__consolidation_function_aliases[self.consolidationFunc]]
+    else:
       raise Exception("Invalid consolidation function: '%s'" % self.consolidationFunc)
 
     buf = []

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1855,7 +1855,7 @@ def consolidateBy(requestContext, seriesList, consolidationFunc):
   """
   Takes one metric or a wildcard seriesList and a consolidation function name.
 
-  Valid function names are 'sum', 'average', 'min', 'max', 'first' & 'last'.
+  Valid function names are 'sum', 'average'/'avg', 'min', 'max', 'first' & 'last'.
 
   When a graph is drawn where width of the graph size in pixels is smaller than
   the number of datapoints to be graphed, Graphite consolidates the values to
@@ -1882,7 +1882,7 @@ def consolidateBy(requestContext, seriesList, consolidationFunc):
 consolidateBy.group = 'Special'
 consolidateBy.params = [
   Param('seriesList', ParamTypes.seriesList, required=True),
-  Param('consolidationFunc', ParamTypes.string, required=True, options=['sum', 'average', 'avg_zero', 'min', 'max', 'first', 'last']),
+  Param('consolidationFunc', ParamTypes.string, required=True, options=['sum', 'average', 'avg', 'avg_zero', 'min', 'max', 'first', 'last']),
 ]
 
 

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -3787,12 +3787,13 @@ def holtWintersAnalysis(series, seasonality='1d'):
   deviationSeries = TimeSeries(deviationName, series.start, series.end
           , series.step, deviations, tags=deviationTags, xFilesFactor=series.xFilesFactor)
 
-  results = { 'predictions': forecastSeries
-        , 'deviations': deviationSeries
-        , 'intercepts': intercepts
-        , 'slopes': slopes
-        , 'seasonals': seasonals
-        }
+  results = {
+      'predictions': forecastSeries,
+      'deviations' : deviationSeries,
+      'intercepts' : intercepts,
+      'slopes'     : slopes,
+      'seasonals'  : seasonals,
+  }
   return results
 
 

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -90,7 +90,7 @@ try:
         percent_l_supported = True
     else:
         percent_l_supported = False
-except ValueError as e:
+except ValueError:
     percent_l_supported = False
 
 DATE_FORMAT = settings.DATE_FORMAT

--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -1816,7 +1816,7 @@ class PieGraph(Graph):
     self.valueLabelsMin = float( params.get('valueLabelsMin',5) )
     self.valueLabels = params.get('valueLabels','percent')
     assert self.valueLabels in self.validValueLabels, \
-    "valueLabels=%s must be one of %s" % (self.valueLabels,self.validValueLabels)
+        "valueLabels=%s must be one of %s" % (self.valueLabels,self.validValueLabels)
     if self.valueLabels != 'none':
       self.drawLabels()
 

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -22,7 +22,7 @@ from random import shuffle
 from six.moves.urllib.parse import urlencode, urlsplit, urlunsplit, parse_qs
 
 from graphite.compat import HttpResponse
-from graphite.errors import InputParameterError
+from graphite.errors import InputParameterError, handleInputParameterError
 from graphite.user_util import getProfileByUsername
 from graphite.util import json, unpickle, pickle, msgpack, BytesIO
 from graphite.storage import extractForwardHeaders
@@ -34,7 +34,7 @@ from graphite.render.hashing import hashRequest, hashData
 from graphite.render.glyph import GraphTypes
 from graphite.tags.models import Series, Tag, TagValue, SeriesTag  # noqa # pylint: disable=unused-import
 
-from django.http import HttpResponseServerError, HttpResponseRedirect, HttpResponseBadRequest
+from django.http import HttpResponseServerError, HttpResponseRedirect
 from django.template import Context, loader
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
@@ -46,20 +46,17 @@ from six.moves import zip
 loadFunctions()
 
 
-def handleInputParameterError(f):
-    def new_f(*args, **kwargs):
-      try:
-        return f(*args, **kwargs)
-      except InputParameterError as e:
-        return HttpResponseBadRequest('Bad Request: {err}'.format(err=e))
-
-    return new_f
-
-
 @handleInputParameterError
 def renderView(request):
   start = time()
-  (graphOptions, requestOptions) = parseOptions(request)
+
+  try:
+    # we consider exceptions thrown by the option
+    # parsing to be due to user input error
+    (graphOptions, requestOptions) = parseOptions(request)
+  except Exception as e:
+    raise InputParameterError(str(e))
+
   useCache = 'noCache' not in requestOptions
   cacheTimeout = requestOptions['cacheTimeout']
   # TODO: Make that a namedtuple or a class.

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -182,9 +182,6 @@ class Store(object):
           )
           jobs.append(job)
 
-        done = 0
-        errors = 0
-
         # Start fetches
         start = time.time()
         results = self.wait_jobs(jobs, settings.FETCH_TIMEOUT,

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -21,6 +21,7 @@ except ImportError:  # python < 2.7 compatibility
     from django.utils.importlib import import_module
 
 from graphite.logger import log
+from graphite.errors import InputParameterError
 from graphite.node import LeafNode
 from graphite.intervals import Interval, IntervalSet
 from graphite.finders.utils import FindQuery, BaseFinder
@@ -250,12 +251,17 @@ class Store(object):
         return sorted(list(set(results)))
 
     def find(self, pattern, startTime=None, endTime=None, local=False, headers=None, leaves_only=False):
-        query = FindQuery(
-            pattern, startTime, endTime,
-            local=local,
-            headers=headers,
-            leaves_only=leaves_only
-        )
+        try:
+            query = FindQuery(
+                pattern, startTime, endTime,
+                local=local,
+                headers=headers,
+                leaves_only=leaves_only
+            )
+        except Exception as e:
+            raise InputParameterError(
+                'Failed to instantiate find query: {err}'
+                .format(err=str(e)))
 
         warn_threshold = settings.METRICS_FIND_WARNING_THRESHOLD
         fail_threshold = settings.METRICS_FIND_FAILURE_THRESHOLD

--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -168,11 +168,11 @@ if not PY3:
 
     @classmethod
     def find_class(cls, module, name):
-      if not module in cls.PICKLE_SAFE:
+      if module not in cls.PICKLE_SAFE:
         raise pickle.UnpicklingError('Attempting to unpickle unsafe module %s' % module)
       __import__(module)
       mod = sys.modules[module]
-      if not name in cls.PICKLE_SAFE[module]:
+      if name not in cls.PICKLE_SAFE[module]:
         raise pickle.UnpicklingError('Attempting to unpickle unsafe class %s' % name)
       return getattr(mod, name)
 
@@ -201,11 +201,11 @@ else:
     }
 
     def find_class(self, module, name):
-      if not module in self.PICKLE_SAFE:
+      if module not in self.PICKLE_SAFE:
         raise pickle.UnpicklingError('Attempting to unpickle unsafe module %s' % module)
       __import__(module)
       mod = sys.modules[module]
-      if not name in self.PICKLE_SAFE[module]:
+      if name not in self.PICKLE_SAFE[module]:
         raise pickle.UnpicklingError('Attempting to unpickle unsafe class %s' % name)
       return getattr(mod, name)
 

--- a/webapp/tests/test_attime.py
+++ b/webapp/tests/test_attime.py
@@ -399,11 +399,11 @@ class getUnitStringTest(TestCase):
 
     def test_m_raises_Exception(self):
         with self.assertRaises(Exception):
-            result = getUnitString("m")
+            _ = getUnitString("m")
 
     def test_integer_raises_Exception(self):
         with self.assertRaises(Exception):
-            result = getUnitString(1)
+            _ = getUnitString(1)
 
 
 @mock.patch('graphite.render.attime.datetime', mockDateTime(2016, 2, 29, 00, 0, 0))

--- a/webapp/tests/test_dashboard.py
+++ b/webapp/tests/test_dashboard.py
@@ -45,14 +45,14 @@ class DashboardTest(TestCase):
         check.side_effect = OSError(errno.EPERM, 'Operation not permitted')
         url = reverse('dashboard')
         with self.assertRaises(Exception):
-            response = self.client.get(url)
+            _ = self.client.get(url)
 
     @mock.patch('graphite.dashboard.views.DashboardConfig.check')
     def test_dashboard_template_conf_read_failure(self, check):
         check.side_effect = OSError(errno.EPERM, 'Operation not permitted')
         url = reverse('dashboard_template', args=['bogustemplate', 'testkey'])
         with self.assertRaises(Exception):
-            response = self.client.get(url)
+            _ = self.client.get(url)
 
     @override_settings(DASHBOARD_CONF=os.path.join(TEST_CONF_DIR, 'dashboard.conf.missing_ui'))
     def test_dashboard_conf_missing_ui(self):

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -2612,7 +2612,7 @@ class FunctionsTest(TestCase):
         )
         message = r"verticalLine\(\): timestamp 3600 exists before start of range"
         with self.assertRaisesRegexp(ValueError, message):
-            result = functions.verticalLine(requestContext, "01:0019700101", "foo")
+            _ = functions.verticalLine(requestContext, "01:0019700101", "foo")
 
     def test_vertical_line_after_end(self):
         requestContext = self._build_requestContext(
@@ -2622,7 +2622,7 @@ class FunctionsTest(TestCase):
         )
         message = r"verticalLine\(\): timestamp 31539600 exists after end of range"
         with self.assertRaisesRegexp(ValueError, message):
-            result = functions.verticalLine(requestContext, "01:0019710101", "foo")
+            _ = functions.verticalLine(requestContext, "01:0019710101", "foo")
 
     def test_line_width(self):
         seriesList = self._generate_series_list()
@@ -2890,9 +2890,6 @@ class FunctionsTest(TestCase):
         seriesList = self._generate_series_list()
 
         def verify_node_name(cases, expected, *nodes):
-            if isinstance(nodes, int):
-                node_number = [nodes]
-
             # Use deepcopy so the original seriesList is unmodified
             results = functions.aliasByNode({}, copy.deepcopy(cases), *nodes)
 
@@ -3025,11 +3022,7 @@ class FunctionsTest(TestCase):
         seriesList, inputList = self._generate_mr_series()
 
         def verify_groupByNodes(expectedResult, func, *nodes):
-            if isinstance(nodes, int):
-                node_number = [nodes]
-
             results = functions.groupByNodes({}, copy.deepcopy(seriesList), func, *nodes)
-
             self.assertEqual(results, expectedResult)
 
         expectedResult = [
@@ -3577,7 +3570,7 @@ class FunctionsTest(TestCase):
 
     def test_constantLine(self):
         requestContext = {'startTime': datetime(2014,3,12,2,0,0,2,pytz.timezone(settings.TIME_ZONE)), 'endTime':datetime(2014,3,12,3,0,0,2,pytz.timezone(settings.TIME_ZONE))}
-        results = functions.constantLine(requestContext, [1])
+        _ = functions.constantLine(requestContext, [1])
 
     def test_aggregateLine_default(self):
         seriesList = self._gen_series_list_with_data(
@@ -3712,7 +3705,7 @@ class FunctionsTest(TestCase):
         )
 
         with self.assertRaisesRegexp(ValueError, '^Unsupported aggregation function: bad$'):
-          result = functions.aggregateLine(
+          functions.aggregateLine(
             self._build_requestContext(
                 startTime=datetime(1970,1,1,1,0,0,0,pytz.timezone(settings.TIME_ZONE)),
                 endTime=datetime(1970,1,1,1,0,0,0,pytz.timezone(settings.TIME_ZONE))

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -510,18 +510,19 @@ class FunctionsTest(TestCase):
         )
 
         expectedResult = [
-        [
-            TimeSeries('collectd.test-db1.load.value',0,1,1,[1,10,11]),
-            TimeSeries('collectd.test-db2.load.value',0,1,1,[2,20,21]),
-            TimeSeries('collectd.test-db3.load.value',0,1,1,[3,30,31]),
-            TimeSeries('collectd.test-db4.load.value',0,1,1,[4,40,41]),
-        ],
-        [
-            TimeSeries('collectd.test-db1.load.value',0,1,1,[1,5,9]),
-            TimeSeries('collectd.test-db2.load.value',0,1,1,[2,6,10]),
-            TimeSeries('collectd.test-db3.load.value',0,1,1,[3,7,11]),
-            TimeSeries('collectd.test-db4.load.value',0,1,1,[4,8,12]),
-        ]]
+            [
+                TimeSeries('collectd.test-db1.load.value',0,1,1,[1,10,11]),
+                TimeSeries('collectd.test-db2.load.value',0,1,1,[2,20,21]),
+                TimeSeries('collectd.test-db3.load.value',0,1,1,[3,30,31]),
+                TimeSeries('collectd.test-db4.load.value',0,1,1,[4,40,41]),
+            ],
+            [
+                TimeSeries('collectd.test-db1.load.value',0,1,1,[1,5,9]),
+                TimeSeries('collectd.test-db2.load.value',0,1,1,[2,6,10]),
+                TimeSeries('collectd.test-db3.load.value',0,1,1,[3,7,11]),
+                TimeSeries('collectd.test-db4.load.value',0,1,1,[4,8,12]),
+            ],
+        ]
         results = functions.matchSeries(copy.deepcopy(seriesList1), copy.deepcopy(seriesList2))
         for i, (series1, series2) in enumerate(results):
             self.assertEqual(series1, expectedResult[0][i])
@@ -2554,8 +2555,7 @@ class FunctionsTest(TestCase):
         limit = len(seriesList) - 1
         results = functions.limit({}, seriesList, limit)
         self.assertEqual(len(results), limit,
-            "More than {0} results returned".format(limit),
-        )
+                         "More than {0} results returned".format(limit))
 
     def _verify_series_options(self, seriesList, name, value):
         """
@@ -2666,14 +2666,14 @@ class FunctionsTest(TestCase):
                 continue
             # If the None values weren't transformed, there is a problem
             self.assertNotIn(None, results[counter],
-                "tranformNull should remove all None values",
-            )
+                             "tranformNull should remove all None values")
             # Anywhere a None was in the original series, verify it
             # was transformed to the given value it should be.
             for i, value in enumerate(series):
                 if value is None:
                     result_val = results[counter][i]
-                    self.assertEqual(transform, result_val,
+                    self.assertEqual(
+                        transform, result_val,
                         "Transformed value should be {0}, not {1}".format(transform, result_val),
                     )
 
@@ -2697,7 +2697,8 @@ class FunctionsTest(TestCase):
             for i, value in enumerate(series):
                 if value is None and referenceSeries[i] is not None:
                     result_val = results[counter][i]
-                    self.assertEqual(transform, result_val,
+                    self.assertEqual(
+                        transform, result_val,
                         "Transformed value should be {0}, not {1}".format(transform, result_val),
                     )
 
@@ -2713,14 +2714,14 @@ class FunctionsTest(TestCase):
                 continue
             # If the None values weren't transformed, there is a problem
             self.assertNotIn(None, results[counter],
-                "tranformNull should remove all None values",
-            )
+                             "tranformNull should remove all None values")
             # Anywhere a None was in the original series, verify it
             # was transformed to the given value if a value existed
             for i, value in enumerate(series):
                 if value is None:
                     result_val = results[counter][i]
-                    self.assertEqual(transform, result_val,
+                    self.assertEqual(
+                        transform, result_val,
                         "Transformed value should be {0}, not {1}".format(transform, result_val),
                     )
 
@@ -2827,8 +2828,7 @@ class FunctionsTest(TestCase):
         results = functions.aliasSub({}, seriesList, r"^\w+", substitution)
         for series in results:
             self.assertTrue(series.name.startswith(substitution),
-                    "aliasSub should replace the name with {0}".format(substitution),
-            )
+                            "aliasSub should replace the name with {0}".format(substitution))
 
     def test_alias_query(self):
 
@@ -3116,11 +3116,9 @@ class FunctionsTest(TestCase):
 
         for i, series in enumerate(results):
             self.assertTrue(hasattr(series, "color"),
-                "The transformed seriesList is missing the 'color' attribute",
-            )
+                            "The transformed seriesList is missing the 'color' attribute")
             self.assertFalse(hasattr(seriesList[i], "color"),
-                "The original seriesList shouldn't have a 'color' attribute",
-            )
+                             "The original seriesList shouldn't have a 'color' attribute")
             self.assertEqual(series.color, color)
 
     def test_substr(self):
@@ -3721,7 +3719,7 @@ class FunctionsTest(TestCase):
             ),
             seriesList,
             'bad'
-        )
+          )
 
     def test_threshold_default(self):
         expectedResult = [
@@ -5687,36 +5685,37 @@ class FunctionsTest(TestCase):
             data=[list(range(0, 240)), list(range(0, -240, -1)), [None] * 240, list(range(0, 480, 2))]
         )
 
-        expectedResults = {'sum' : [
-            TimeSeries('summarize(servers.s1.disk.bytes_used, "1minute", "sum")', 0, 300, 60, [1770, 5370, 8970, 12570, None]),
-            TimeSeries('summarize(servers.s1.disk.bytes_free, "1minute", "sum")', 0, 300, 60, [-1770, -5370, -8970, -12570, None]),
-            TimeSeries('summarize(servers.s2.disk.bytes_used, "1minute", "sum")', 0, 300, 60, [None, None, None, None, None]),
-            TimeSeries('summarize(servers.s2.disk.bytes_free, "1minute", "sum")', 0, 300, 60, [3540, 10740, 17940, 25140, None])
-        ],
-        'avg' : [
-            TimeSeries('summarize(servers.s1.disk.bytes_used, "1minute", "avg")', 0, 300, 60, [29.5, 89.5, 149.5, 209.5, None]),
-            TimeSeries('summarize(servers.s1.disk.bytes_free, "1minute", "avg")', 0, 300, 60, [-29.5, -89.5, -149.5, -209.5, None]),
-            TimeSeries('summarize(servers.s2.disk.bytes_used, "1minute", "avg")', 0, 300, 60, [None, None, None, None, None]),
-            TimeSeries('summarize(servers.s2.disk.bytes_free, "1minute", "avg")', 0, 300, 60, [59.0, 179.0, 299.0, 419.0, None])
-        ],
-        'last' : [
-            TimeSeries('summarize(servers.s1.disk.bytes_used, "1minute", "last")', 0, 300, 60, [59, 119, 179, 239, None]),
-            TimeSeries('summarize(servers.s1.disk.bytes_free, "1minute", "last")', 0, 300, 60, [-59, -119, -179, -239, None]),
-            TimeSeries('summarize(servers.s2.disk.bytes_used, "1minute", "last")', 0, 300, 60, [None, None, None, None, None]),
-            TimeSeries('summarize(servers.s2.disk.bytes_free, "1minute", "last")', 0, 300, 60, [118, 238, 358, 478, None])
-        ],
-        'max' : [
-            TimeSeries('summarize(servers.s1.disk.bytes_used, "1minute", "max")', 0, 300, 60, [59, 119, 179, 239, None]),
-            TimeSeries('summarize(servers.s1.disk.bytes_free, "1minute", "max")', 0, 300, 60, [0, -60, -120, -180, None]),
-            TimeSeries('summarize(servers.s2.disk.bytes_used, "1minute", "max")', 0, 300, 60, [None, None, None, None, None]),
-            TimeSeries('summarize(servers.s2.disk.bytes_free, "1minute", "max")', 0, 300, 60, [118, 238, 358, 478, None])
-        ],
-        'min' : [
-            TimeSeries('summarize(servers.s1.disk.bytes_used, "1minute", "min")', 0, 300, 60, [0, 60, 120, 180, None]),
-            TimeSeries('summarize(servers.s1.disk.bytes_free, "1minute", "min")', 0, 300, 60, [-59, -119, -179, -239, None]),
-            TimeSeries('summarize(servers.s2.disk.bytes_used, "1minute", "min")', 0, 300, 60, [None, None, None, None, None]),
-            TimeSeries('summarize(servers.s2.disk.bytes_free, "1minute", "min")', 0, 300, 60, [0, 120, 240, 360, None])
-        ],
+        expectedResults = {
+            'sum' : [
+                TimeSeries('summarize(servers.s1.disk.bytes_used, "1minute", "sum")', 0, 300, 60, [1770, 5370, 8970, 12570, None]),
+                TimeSeries('summarize(servers.s1.disk.bytes_free, "1minute", "sum")', 0, 300, 60, [-1770, -5370, -8970, -12570, None]),
+                TimeSeries('summarize(servers.s2.disk.bytes_used, "1minute", "sum")', 0, 300, 60, [None, None, None, None, None]),
+                TimeSeries('summarize(servers.s2.disk.bytes_free, "1minute", "sum")', 0, 300, 60, [3540, 10740, 17940, 25140, None])
+            ],
+            'avg' : [
+                TimeSeries('summarize(servers.s1.disk.bytes_used, "1minute", "avg")', 0, 300, 60, [29.5, 89.5, 149.5, 209.5, None]),
+                TimeSeries('summarize(servers.s1.disk.bytes_free, "1minute", "avg")', 0, 300, 60, [-29.5, -89.5, -149.5, -209.5, None]),
+                TimeSeries('summarize(servers.s2.disk.bytes_used, "1minute", "avg")', 0, 300, 60, [None, None, None, None, None]),
+                TimeSeries('summarize(servers.s2.disk.bytes_free, "1minute", "avg")', 0, 300, 60, [59.0, 179.0, 299.0, 419.0, None])
+            ],
+            'last' : [
+                TimeSeries('summarize(servers.s1.disk.bytes_used, "1minute", "last")', 0, 300, 60, [59, 119, 179, 239, None]),
+                TimeSeries('summarize(servers.s1.disk.bytes_free, "1minute", "last")', 0, 300, 60, [-59, -119, -179, -239, None]),
+                TimeSeries('summarize(servers.s2.disk.bytes_used, "1minute", "last")', 0, 300, 60, [None, None, None, None, None]),
+                TimeSeries('summarize(servers.s2.disk.bytes_free, "1minute", "last")', 0, 300, 60, [118, 238, 358, 478, None])
+            ],
+            'max' : [
+                TimeSeries('summarize(servers.s1.disk.bytes_used, "1minute", "max")', 0, 300, 60, [59, 119, 179, 239, None]),
+                TimeSeries('summarize(servers.s1.disk.bytes_free, "1minute", "max")', 0, 300, 60, [0, -60, -120, -180, None]),
+                TimeSeries('summarize(servers.s2.disk.bytes_used, "1minute", "max")', 0, 300, 60, [None, None, None, None, None]),
+                TimeSeries('summarize(servers.s2.disk.bytes_free, "1minute", "max")', 0, 300, 60, [118, 238, 358, 478, None])
+            ],
+            'min' : [
+                TimeSeries('summarize(servers.s1.disk.bytes_used, "1minute", "min")', 0, 300, 60, [0, 60, 120, 180, None]),
+                TimeSeries('summarize(servers.s1.disk.bytes_free, "1minute", "min")', 0, 300, 60, [-59, -119, -179, -239, None]),
+                TimeSeries('summarize(servers.s2.disk.bytes_used, "1minute", "min")', 0, 300, 60, [None, None, None, None, None]),
+                TimeSeries('summarize(servers.s2.disk.bytes_free, "1minute", "min")', 0, 300, 60, [0, 120, 240, 360, None])
+            ],
         }
 
         for func in expectedResults:
@@ -5740,36 +5739,37 @@ class FunctionsTest(TestCase):
             data=[list(range(0, 240)), list(range(0, -240, -1)), [None] * 240, list(range(0, 480, 2))]
         )
 
-        expectedResults = {'sum' : [
-            TimeSeries('summarize(servers.s1.disk.bytes_used, "1minute", "sum", true)', 0, 240, 60, [1770, 5370, 8970, 12570]),
-            TimeSeries('summarize(servers.s1.disk.bytes_free, "1minute", "sum", true)', 0, 240, 60, [-1770, -5370, -8970, -12570]),
-            TimeSeries('summarize(servers.s2.disk.bytes_used, "1minute", "sum", true)', 0, 240, 60, [None, None, None, None]),
-            TimeSeries('summarize(servers.s2.disk.bytes_free, "1minute", "sum", true)', 0, 240, 60, [3540, 10740, 17940, 25140])
-        ],
-        'avg' : [
-            TimeSeries('summarize(servers.s1.disk.bytes_used, "1minute", "avg", true)', 0, 240, 60, [29.5, 89.5, 149.5, 209.5]),
-            TimeSeries('summarize(servers.s1.disk.bytes_free, "1minute", "avg", true)', 0, 240, 60, [-29.5, -89.5, -149.5, -209.5]),
-            TimeSeries('summarize(servers.s2.disk.bytes_used, "1minute", "avg", true)', 0, 240, 60, [None, None, None, None]),
-            TimeSeries('summarize(servers.s2.disk.bytes_free, "1minute", "avg", true)', 0, 240, 60, [59.0, 179.0, 299.0, 419.0])
-        ],
-        'last' : [
-            TimeSeries('summarize(servers.s1.disk.bytes_used, "1minute", "last", true)', 0, 240, 60, [59, 119, 179, 239]),
-            TimeSeries('summarize(servers.s1.disk.bytes_free, "1minute", "last", true)', 0, 240, 60, [-59, -119, -179, -239]),
-            TimeSeries('summarize(servers.s2.disk.bytes_used, "1minute", "last", true)', 0, 240, 60, [None, None, None, None]),
-            TimeSeries('summarize(servers.s2.disk.bytes_free, "1minute", "last", true)', 0, 240, 60, [118, 238, 358, 478])
-        ],
-        'max' : [
-            TimeSeries('summarize(servers.s1.disk.bytes_used, "1minute", "max", true)', 0, 240, 60, [59, 119, 179, 239]),
-            TimeSeries('summarize(servers.s1.disk.bytes_free, "1minute", "max", true)', 0, 240, 60, [0, -60, -120, -180]),
-            TimeSeries('summarize(servers.s2.disk.bytes_used, "1minute", "max", true)', 0, 240, 60, [None, None, None, None]),
-            TimeSeries('summarize(servers.s2.disk.bytes_free, "1minute", "max", true)', 0, 240, 60, [118, 238, 358, 478])
-        ],
-        'min' : [
-            TimeSeries('summarize(servers.s1.disk.bytes_used, "1minute", "min", true)', 0, 240, 60, [0, 60, 120, 180]),
-            TimeSeries('summarize(servers.s1.disk.bytes_free, "1minute", "min", true)', 0, 240, 60, [-59, -119, -179, -239]),
-            TimeSeries('summarize(servers.s2.disk.bytes_used, "1minute", "min", true)', 0, 240, 60, [None, None, None, None]),
-            TimeSeries('summarize(servers.s2.disk.bytes_free, "1minute", "min", true)', 0, 240, 60, [0, 120, 240, 360])
-        ],
+        expectedResults = {
+            'sum' : [
+                TimeSeries('summarize(servers.s1.disk.bytes_used, "1minute", "sum", true)', 0, 240, 60, [1770, 5370, 8970, 12570]),
+                TimeSeries('summarize(servers.s1.disk.bytes_free, "1minute", "sum", true)', 0, 240, 60, [-1770, -5370, -8970, -12570]),
+                TimeSeries('summarize(servers.s2.disk.bytes_used, "1minute", "sum", true)', 0, 240, 60, [None, None, None, None]),
+                TimeSeries('summarize(servers.s2.disk.bytes_free, "1minute", "sum", true)', 0, 240, 60, [3540, 10740, 17940, 25140])
+            ],
+            'avg' : [
+                TimeSeries('summarize(servers.s1.disk.bytes_used, "1minute", "avg", true)', 0, 240, 60, [29.5, 89.5, 149.5, 209.5]),
+                TimeSeries('summarize(servers.s1.disk.bytes_free, "1minute", "avg", true)', 0, 240, 60, [-29.5, -89.5, -149.5, -209.5]),
+                TimeSeries('summarize(servers.s2.disk.bytes_used, "1minute", "avg", true)', 0, 240, 60, [None, None, None, None]),
+                TimeSeries('summarize(servers.s2.disk.bytes_free, "1minute", "avg", true)', 0, 240, 60, [59.0, 179.0, 299.0, 419.0])
+            ],
+            'last' : [
+                TimeSeries('summarize(servers.s1.disk.bytes_used, "1minute", "last", true)', 0, 240, 60, [59, 119, 179, 239]),
+                TimeSeries('summarize(servers.s1.disk.bytes_free, "1minute", "last", true)', 0, 240, 60, [-59, -119, -179, -239]),
+                TimeSeries('summarize(servers.s2.disk.bytes_used, "1minute", "last", true)', 0, 240, 60, [None, None, None, None]),
+                TimeSeries('summarize(servers.s2.disk.bytes_free, "1minute", "last", true)', 0, 240, 60, [118, 238, 358, 478])
+            ],
+            'max' : [
+                TimeSeries('summarize(servers.s1.disk.bytes_used, "1minute", "max", true)', 0, 240, 60, [59, 119, 179, 239]),
+                TimeSeries('summarize(servers.s1.disk.bytes_free, "1minute", "max", true)', 0, 240, 60, [0, -60, -120, -180]),
+                TimeSeries('summarize(servers.s2.disk.bytes_used, "1minute", "max", true)', 0, 240, 60, [None, None, None, None]),
+                TimeSeries('summarize(servers.s2.disk.bytes_free, "1minute", "max", true)', 0, 240, 60, [118, 238, 358, 478])
+            ],
+            'min' : [
+                TimeSeries('summarize(servers.s1.disk.bytes_used, "1minute", "min", true)', 0, 240, 60, [0, 60, 120, 180]),
+                TimeSeries('summarize(servers.s1.disk.bytes_free, "1minute", "min", true)', 0, 240, 60, [-59, -119, -179, -239]),
+                TimeSeries('summarize(servers.s2.disk.bytes_used, "1minute", "min", true)', 0, 240, 60, [None, None, None, None]),
+                TimeSeries('summarize(servers.s2.disk.bytes_free, "1minute", "min", true)', 0, 240, 60, [0, 120, 240, 360])
+            ],
         }
 
         for func in expectedResults:

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -2662,7 +2662,7 @@ class FunctionsTest(TestCase):
         results = functions.transformNull({}, copy.deepcopy(seriesList), transform)
 
         for counter, series in enumerate(seriesList):
-            if not None in series:
+            if None not in series:
                 continue
             # If the None values weren't transformed, there is a problem
             self.assertNotIn(None, results[counter],
@@ -2688,7 +2688,7 @@ class FunctionsTest(TestCase):
         results = functions.transformNull({}, copy.deepcopy(seriesList), transform, [referenceSeries])
 
         for counter, series in enumerate(seriesList):
-            if not None in series:
+            if None not in series:
                 continue
 
             # Anywhere a None was in the original series, verify it
@@ -2709,7 +2709,7 @@ class FunctionsTest(TestCase):
         results = functions.transformNull({}, copy.deepcopy(seriesList), transform, [referenceSeries])
 
         for counter, series in enumerate(seriesList):
-            if not None in series:
+            if None not in series:
                 continue
             # If the None values weren't transformed, there is a problem
             self.assertNotIn(None, results[counter],

--- a/webapp/tests/test_metrics.py
+++ b/webapp/tests/test_metrics.py
@@ -95,8 +95,7 @@ class MetricsTester(TestCase):
 
     def test_find_view(self):
         ts = int(time.time())
-        #create a minus 60 variable to test with, otherwise the build could fail the longer the test runs
-        ts_minus_sixty_seconds = ts - 60
+        # ts_minus_sixty_seconds = ts - 60  # usage always commented-out below?
 
         self.create_whisper_hosts(ts)
         self.addCleanup(self.wipe_whisper_hosts)

--- a/webapp/tests/test_metrics.py
+++ b/webapp/tests/test_metrics.py
@@ -132,7 +132,7 @@ class MetricsTester(TestCase):
         })
         self.assertEqual(response.status_code, 400)
         # the output in Python 2/3 slightly varies because repr() shows unicode strings differently, that's why the "u?"
-        self.assertRegex(response.content, b"^Bad Request: Invalid int value u?'123a' for param wildcards: invalid literal for int\(\) with base 10: u?'123a'$")
+        self.assertRegex(response.content, b"^Bad Request: Invalid int value u?'123a' for param wildcards: invalid literal for int\\(\\) with base 10: u?'123a'$")
 
         #
         # Invalid 'from' timestamp

--- a/webapp/tests/test_metrics.py
+++ b/webapp/tests/test_metrics.py
@@ -108,7 +108,7 @@ class MetricsTester(TestCase):
         #
         response = self.client.post(url, {})
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.content, b"Missing required parameter 'query'")
+        self.assertEqual(response.content, b"Bad Request: Missing required parameter 'query'")
 
         #
         # format=invalid_format

--- a/webapp/tests/test_params.py
+++ b/webapp/tests/test_params.py
@@ -239,3 +239,15 @@ class TestParam(unittest.TestCase):
             [1.2],
             {},
         )
+
+    def test_default_value(self):
+        # if no value is specified, but there is a default value, we don't
+        # want the validator to raise an exception because 'None' is invalid
+        self.assertTrue(validateParams(
+            'TestParam',
+            [
+                Param('one', ParamTypes.aggFunc, default='sum'),
+            ],
+            [],
+            {},
+        ))

--- a/webapp/tests/test_readers_remote.py
+++ b/webapp/tests/test_readers_remote.py
@@ -57,7 +57,8 @@ class RemoteReaderTests(TestCase):
         reader = RemoteReader(finder, {'intervals': [], 'path': 'a.b.c.d'})
 
         data = [
-                {'start': startTime,
+                {
+                 'start': startTime,
                  'step': 60,
                  'end': endTime,
                  'values': [1.0, 0.0, 1.0, 0.0, 1.0],
@@ -100,7 +101,8 @@ class RemoteReaderTests(TestCase):
         reader = RemoteReader(finder, {'intervals': [], 'path': 'a.b.c.d'}, bulk_query=['a.b.c.d'])
 
         data = [
-                {'start': startTime,
+                {
+                 'start': startTime,
                  'step': 60,
                  'end': endTime,
                  'values': [1.0, 0.0, 1.0, 0.0, 1.0],
@@ -205,13 +207,15 @@ class RemoteReaderTests(TestCase):
         reader = RemoteReader(finder, {'intervals': [], 'path': 'a.b.c.d'}, bulk_query=['a.b.c.*'])
 
         data = [
-                {'start': startTime,
+                {
+                 'start': startTime,
                  'step': 60,
                  'end': endTime,
                  'values': [1.0, 0.0, 1.0, 0.0, 1.0],
                  'name': 'a.b.c.c'
                 },
-                {'start': startTime,
+                {
+                 'start': startTime,
                  'step': 60,
                  'end': endTime,
                  'values': [1.0, 0.0, 1.0, 0.0, 1.0],

--- a/webapp/tests/test_render_datalib.py
+++ b/webapp/tests/test_render_datalib.py
@@ -253,7 +253,7 @@ class TimeSeriesTest(TestCase):
       series.consolidate(2)
       self.assertEqual(series.valuesPerPoint, 2)
       with self.assertRaisesRegexp(Exception, "Invalid consolidation function: 'bogus'"):
-        result = list(series)
+        _ = list(series)
 
 
 class DatalibFunctionTest(TestCase):
@@ -303,7 +303,7 @@ class DatalibFunctionTest(TestCase):
       pathExpr = 'collectd.test-db.load.value'
       startTime=datetime(1970, 1, 1, 0, 10, 0, 0, pytz.timezone(settings.TIME_ZONE))
       endTime=datetime(1970, 1, 1, 0, 20, 0, 0, pytz.timezone(settings.TIME_ZONE))
-      timeInfo = [startTime, endTime, 60]
+      # timeInfo = [startTime, endTime, 60]
       result_queue = [
                       [pathExpr, None],
                      ]
@@ -320,7 +320,7 @@ class DatalibFunctionTest(TestCase):
       pathExpr = 'collectd.test-db.load.value'
       startTime=datetime(1970, 1, 1, 0, 10, 0, 0, pytz.timezone(settings.TIME_ZONE))
       endTime=datetime(1970, 1, 1, 0, 20, 0, 0, pytz.timezone(settings.TIME_ZONE))
-      timeInfo = [startTime, endTime, 60]
+      # timeInfo = [startTime, endTime, 60]
       result_queue = [
                       [pathExpr, ['invalid input']],
                      ]

--- a/webapp/tests/test_render_datalib.py
+++ b/webapp/tests/test_render_datalib.py
@@ -127,7 +127,7 @@ class TimeSeriesTest(TestCase):
       series.xFilesFactor = 1
       self.assertEqual(list(series), list(expected))
 
-    def test_TimeSeries_iterate_valuesPerPoint_2_avg(self):
+    def test_TimeSeries_iterate_valuesPerPoint_2_average(self):
       values = list(range(0,100))
 
       series = TimeSeries("collectd.test-db.load.value", 0, len(values)/2, 1, values)
@@ -225,6 +225,23 @@ class TimeSeriesTest(TestCase):
       series.consolidate(3)
       self.assertEqual(series.valuesPerPoint, 3)
       expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, list(range(2,100,3)) + [99])
+      self.assertEqual(list(series), list(expected))
+
+    # avg is an alias for average
+    def test_TimeSeries_iterate_valuesPerPoint_2_avg_alias(self):
+      values = list(range(0,100))
+
+      series = TimeSeries("collectd.test-db.load.value", 0, len(values)/2, 1, values, consolidate='avg')
+      self.assertEqual(series.valuesPerPoint, 1)
+
+      series.consolidate(2)
+      self.assertEqual(series.valuesPerPoint, 2)
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, [0.5, 2.5, 4.5, 6.5, 8.5, 10.5, 12.5, 14.5, 16.5, 18.5, 20.5, 22.5, 24.5, 26.5, 28.5, 30.5, 32.5, 34.5, 36.5, 38.5, 40.5, 42.5, 44.5, 46.5, 48.5, 50.5, 52.5, 54.5, 56.5, 58.5, 60.5, 62.5, 64.5, 66.5, 68.5, 70.5, 72.5, 74.5, 76.5, 78.5, 80.5, 82.5, 84.5, 86.5, 88.5, 90.5, 92.5, 94.5, 96.5, 98.5])
+      self.assertEqual(list(series), list(expected))
+
+      series.consolidate(3)
+      self.assertEqual(series.valuesPerPoint, 3)
+      expected = TimeSeries("collectd.test-db.load.value", 0, 5, 1, map(float, list(range(1, 100, 3)) + [99]))
       self.assertEqual(list(series), list(expected))
 
     def test_TimeSeries_iterate_valuesPerPoint_2_invalid(self):

--- a/webapp/tests/test_util.py
+++ b/webapp/tests/test_util.py
@@ -94,7 +94,7 @@ class UtilTest(TestCase):
 
     def test_load_module(self):
         with self.assertRaises(IOError):
-            module = util.load_module('test', member=None)
+            _ = util.load_module('test', member=None)
 
     @patch('graphite.util.log')
     def test_logtime(self, log):

--- a/webapp/tests/test_whitelist.py
+++ b/webapp/tests/test_whitelist.py
@@ -36,7 +36,7 @@ class WhitelistTester(TestCase):
     def test_whitelist_show_no_whitelist(self):
         url = reverse('whitelist_show')
         with self.assertRaises(IOError):
-          response = self.client.get(url)
+          _ = self.client.get(url)
 
     def test_whitelist_show(self):
         url = reverse('whitelist_show')


### PR DESCRIPTION
Backports the following commits to 1.1.x:
 - handle exceptions if params cannot be type converted (#2547)
 - fix minor bug in query param evaluation (#2547)
 - fails to instantiate find query must be due to bad user input (#2547)
 - add tests for invalid parameter types (#2547)
 - fix formatting (#2547)
 - test validator with default values (#2555)
 - use default value in validator when necessary (#2555)
 - flake8: include contrib/ subdir (#2554)
 - flake8: re-enable rule E713 - use "not in" (#2554)
 - make consolidation func avg alias for average (#2556)
 - move all validation into Param.validateValue (#2557)
 - move check acceptance of optional params up (#2557)
 - flake8: re-enable E122,E124 (indent of continuation and closing bracket) (#2558)
 - flake8: re-enable F841 (local variable assigned but not used) (#2559)