### PR TITLE
log grafana dashboard/panel id headers

### DIFF
--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -132,19 +132,14 @@ def invalidParamLogMsg(requestContext, exception, func, args, kwargs):
   source = ''
 
   if 'sourceIdHeaders' in requestContext:
-    if 'HTTP_X_GRAFANA_ORG_ID' in requestContext['sourceIdHeaders']:
-      source += 'org-id: {id}'.format(
-        id=requestContext['sourceIdHeaders']['HTTP_X_GRAFANA_ORG_ID'])
-    if 'HTTP_X_DASHBOARD_ID' in requestContext['sourceIdHeaders']:
+    headers = list(requestContext['sourceIdHeaders'].keys())
+    headers.sort()
+    for name in headers:
       if source:
         source += ', '
-      source += 'dashboard-id: {id}'.format(
-        id=requestContext['sourceIdHeaders']['HTTP_X_DASHBOARD_ID'])
-    if 'HTTP_X_PANEL_ID' in requestContext['sourceIdHeaders']:
-      if source:
-        source += ', '
-      source += 'panel-id: {id}'.format(
-        id=requestContext['sourceIdHeaders']['HTTP_X_PANEL_ID'])
+      source += '{name}: {value}'.format(
+        name=name,
+        value=requestContext['sourceIdHeaders'][name])
 
   logMsg = 'Received invalid parameters ({msg}): {func} ({args})'.format(
       msg=exception,

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -104,18 +104,7 @@ def evaluateTokens(requestContext, tokens, replacements=None, pipedArg=None):
 
     def handleInvalidParameters(e):
       if not getattr(handleInvalidParameters, 'alreadyLogged', False):
-        log.warning(
-          'Received invalid parameters ({msg}): {func} ({args})'.format(
-            msg=str(e),
-            func=tokens.call.funcname,
-            args=', '.join(
-              argList
-              for argList in [
-                ', '.join(repr(arg) for arg in args),
-                ', '.join('{k}={v}'.format(k=str(k), v=repr(v)) for k, v in kwargs.items()),
-              ] if argList
-            )
-          ))
+        log.warning(invalidParamLogMsg(requestContext, str(e), tokens.call.funcname, args, kwargs))
 
         # only log invalid parameters once
         setattr(handleInvalidParameters, 'alreadyLogged', True)
@@ -137,6 +126,42 @@ def evaluateTokens(requestContext, tokens, replacements=None, pipedArg=None):
       handleInvalidParameters(e)
 
   return evaluateScalarTokens(tokens)
+
+
+def invalidParamLogMsg(requestContext, exception, func, args, kwargs):
+  source = ''
+
+  if 'sourceIdHeaders' in requestContext:
+    if 'HTTP_X_GRAFANA_ORG_ID' in requestContext['sourceIdHeaders']:
+      source += 'org-id: {id}'.format(
+        id=requestContext['sourceIdHeaders']['HTTP_X_GRAFANA_ORG_ID'])
+    if 'HTTP_X_DASHBOARD_ID' in requestContext['sourceIdHeaders']:
+      if source:
+        source += ', '
+      source += 'dashboard-id: {id}'.format(
+        id=requestContext['sourceIdHeaders']['HTTP_X_DASHBOARD_ID'])
+    if 'HTTP_X_PANEL_ID' in requestContext['sourceIdHeaders']:
+      if source:
+        source += ', '
+      source += 'panel-id: {id}'.format(
+        id=requestContext['sourceIdHeaders']['HTTP_X_PANEL_ID'])
+
+  logMsg = 'Received invalid parameters ({msg}): {func} ({args})'.format(
+      msg=exception,
+      func=func,
+      args=', '.join(
+        argList
+        for argList in [
+          ', '.join(repr(arg) for arg in args),
+          ', '.join('{k}={v}'.format(k=str(k), v=repr(v)) for k, v in kwargs.items()),
+        ] if argList
+      ))
+
+  if not source:
+    return logMsg
+
+  logMsg += '; source: ({source})'.format(source=source)
+  return logMsg
 
 
 def evaluateScalarTokens(tokens):

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -25,7 +25,7 @@ from graphite.compat import HttpResponse
 from graphite.errors import InputParameterError, handleInputParameterError
 from graphite.user_util import getProfileByUsername
 from graphite.util import json, unpickle, pickle, msgpack, BytesIO
-from graphite.storage import extractForwardHeaders
+from graphite.storage import extractForwardHeaders, extractSourceIdHeaders
 from graphite.logger import log
 from graphite.render.evaluator import evaluateTarget
 from graphite.render.attime import parseATTime
@@ -68,6 +68,7 @@ def renderView(request):
     'template' : requestOptions['template'],
     'tzinfo' : requestOptions['tzinfo'],
     'forwardHeaders': requestOptions['forwardHeaders'],
+    'sourceIdHeaders': requestOptions['sourceIdHeaders'],
     'data' : [],
     'prefetched' : {},
     'xFilesFactor' : requestOptions['xFilesFactor'],
@@ -352,6 +353,7 @@ def parseOptions(request):
   cacheTimeout = int( queryParams.get('cacheTimeout', settings.DEFAULT_CACHE_DURATION) )
   requestOptions['targets'] = []
   requestOptions['forwardHeaders'] = extractForwardHeaders(request)
+  requestOptions['sourceIdHeaders'] = extractSourceIdHeaders(request)
 
   # Extract the targets out of the queryParams
   mytargets = []

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -467,21 +467,18 @@ def parseOptions(request):
 # user-defined headers from settings.INPUT_VALIDATION_SOURCE_ID_HEADERS also get extracted and mixed
 # with the standard Grafana headers.
 def extractSourceIdHeaders(request):
+    source_headers = {
+        'X-Grafana-Org-ID': 'grafana-org-id',
+        'X-Dashboard-ID': 'dashboard-id',
+        'X-Panel-ID': 'panel-id',
+    }
+    source_headers.update(settings.INPUT_VALIDATION_SOURCE_ID_HEADERS)
+
     headers = {}
-
-    if 'HTTP_X_GRAFANA_ORG_ID' in request.META:
-        headers['grafana-org-id'] = request.META['HTTP_X_GRAFANA_ORG_ID']
-
-    if 'HTTP_X_DASHBOARD_ID' in request.META:
-        headers['dashboard-id'] = request.META['HTTP_X_DASHBOARD_ID']
-
-    if 'HTTP_X_PANEL_ID' in request.META:
-        headers['panel-id'] = request.META['HTTP_X_PANEL_ID']
-
-    for name in settings.INPUT_VALIDATION_SOURCE_ID_HEADERS:
-        value = request.META.get('HTTP_%s' % name.upper().replace('-', '_'))
-        if value is not None:
-            headers[settings.INPUT_VALIDATION_SOURCE_ID_HEADERS[name]] = value
+    for hdr_name, log_name in source_headers.items():
+        value = request.META.get('HTTP_' + hdr_name.upper().replace('-', '_'))
+        if value:
+            headers[log_name] = value
 
     return headers
 

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -25,7 +25,7 @@ from graphite.compat import HttpResponse
 from graphite.errors import InputParameterError, handleInputParameterError
 from graphite.user_util import getProfileByUsername
 from graphite.util import json, unpickle, pickle, msgpack, BytesIO
-from graphite.storage import extractForwardHeaders, extractSourceIdHeaders
+from graphite.storage import extractForwardHeaders
 from graphite.logger import log
 from graphite.render.evaluator import evaluateTarget
 from graphite.render.attime import parseATTime
@@ -461,6 +461,17 @@ def parseOptions(request):
   requestOptions['xFilesFactor'] = float( queryParams.get('xFilesFactor', settings.DEFAULT_XFILES_FACTOR) )
 
   return (graphOptions, requestOptions)
+
+
+# headers which get set by Grafana when issuing queries, identifying where the query came from
+def extractSourceIdHeaders(request):
+    source_id_headers = ['HTTP_X_GRAFANA_ORG_ID', 'HTTP_X_DASHBOARD_ID', 'HTTP_X_PANEL_ID']
+    headers = {}
+    for header in source_id_headers:
+        value = request.META.get(header)
+        if value is not None:
+            headers[header] = value
+    return headers
 
 
 connectionPools = {}

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -463,14 +463,26 @@ def parseOptions(request):
   return (graphOptions, requestOptions)
 
 
-# headers which get set by Grafana when issuing queries, identifying where the query came from
+# extract headers which get set by Grafana when issuing queries, to help identifying where a query came from.
+# user-defined headers from settings.INPUT_VALIDATION_SOURCE_ID_HEADERS also get extracted and mixed
+# with the standard Grafana headers.
 def extractSourceIdHeaders(request):
-    source_id_headers = ['HTTP_X_GRAFANA_ORG_ID', 'HTTP_X_DASHBOARD_ID', 'HTTP_X_PANEL_ID']
     headers = {}
-    for header in source_id_headers:
-        value = request.META.get(header)
+
+    if 'HTTP_X_GRAFANA_ORG_ID' in request.META:
+        headers['grafana-org-id'] = request.META['HTTP_X_GRAFANA_ORG_ID']
+
+    if 'HTTP_X_DASHBOARD_ID' in request.META:
+        headers['dashboard-id'] = request.META['HTTP_X_DASHBOARD_ID']
+
+    if 'HTTP_X_PANEL_ID' in request.META:
+        headers['panel-id'] = request.META['HTTP_X_PANEL_ID']
+
+    for name in settings.INPUT_VALIDATION_SOURCE_ID_HEADERS:
+        value = request.META.get('HTTP_%s' % name.upper().replace('-', '_'))
         if value is not None:
-            headers[header] = value
+            headers[settings.INPUT_VALIDATION_SOURCE_ID_HEADERS[name]] = value
+
     return headers
 
 

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -189,6 +189,13 @@ SECRET_KEY = 'UNSAFE_DEFAULT'
 #   provided arguments and return an error message to the user
 ENFORCE_INPUT_VALIDATION = False
 
+# headers which shall be added to log statements informing about invalid queries,
+# this is useful to identify where a query came from.
+# The dict is keyed by the header name and the associated value is a short description
+# of the header which will be used in the log statement, for example:
+# {'X-FORWARD-FOR': 'forwarded-for'}
+INPUT_VALIDATION_SOURCE_ID_HEADERS = {}
+
 # Django 1.5 requires this to be set. Here we default to prior behavior and allow all
 ALLOWED_HOSTS = [ '*' ]
 

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -517,6 +517,17 @@ def extractForwardHeaders(request):
     return headers
 
 
+# headers which get set by Grafana when issuing queries, identifying where the query came from
+def extractSourceIdHeaders(request):
+    source_id_headers = ['HTTP_X_GRAFANA_ORG_ID', 'HTTP_X_DASHBOARD_ID', 'HTTP_X_PANEL_ID']
+    headers = {}
+    for header in source_id_headers:
+        value = request.META.get(header)
+        if value is not None:
+            headers[header] = value
+    return headers
+
+
 def write_index(index=None):
   if not index:
     index = settings.INDEX_FILE

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -517,17 +517,6 @@ def extractForwardHeaders(request):
     return headers
 
 
-# headers which get set by Grafana when issuing queries, identifying where the query came from
-def extractSourceIdHeaders(request):
-    source_id_headers = ['HTTP_X_GRAFANA_ORG_ID', 'HTTP_X_DASHBOARD_ID', 'HTTP_X_PANEL_ID']
-    headers = {}
-    for header in source_id_headers:
-        value = request.META.get(header)
-        if value is not None:
-            headers[header] = value
-    return headers
-
-
 def write_index(index=None):
   if not index:
     index = settings.INDEX_FILE

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -965,23 +965,23 @@ class RenderTest(TestCase):
         args = [1]
         kwargs = {}
         requestContext['sourceIdHeaders'] = {
-            'HTTP_X_GRAFANA_ORG_ID': 123,
+            'grafana-org-id': 123,
         }
         msg = invalidParamLogMsg(requestContext, exception, func, args, kwargs)
         self.assertEqual(
             msg,
-            'Received invalid parameters (exception details): test_func (1); source: (org-id: 123)'
+            'Received invalid parameters (exception details): test_func (1); source: (grafana-org-id: 123)'
         )
 
         requestContext['sourceIdHeaders'] = {
-            'HTTP_X_GRAFANA_ORG_ID': 123,
-            'HTTP_X_DASHBOARD_ID': 9,
-            'HTTP_X_PANEL_ID': 38,
+            'grafana-org-id': 123,
+            'dashboard-id': 9,
+            'panel-id': 38,
         }
         msg = invalidParamLogMsg(requestContext, exception, func, args, kwargs)
         self.assertEqual(
             msg,
-            'Received invalid parameters (exception details): test_func (1); source: (org-id: 123, dashboard-id: 9, panel-id: 38)'
+            'Received invalid parameters (exception details): test_func (1); source: (dashboard-id: 9, grafana-org-id: 123, panel-id: 38)'
         )
 
 


### PR DESCRIPTION
This PR adds a bit more context to the log messages which are talking about invalid query parameters, if possible. 

When Grafana issues queries from dashboards it adds the org/dashboard/panel id into the headers, with this PR we're extracting those headers if they're present and add them to the log statement. This makes it much easier to go from an error which talks about a bad query to the dashboard & panel where the query came from, because otherwise making that association can be quite hard. 

I hope that's not too Grafana specific to merge it into Graphite, what do you think @deniszh ? I believe that a large number of Graphite users are probably using Grafana for querying, so it would benefit them all. And for those who don't use Grafana nothing changes.

This is an example log statement, after i issued the query `scale(a.b.c,"0.123")` from Grafana:
```
2020-03-09,18:18:05.035 :: Received invalid parameters (org-id: 1; dashboard-id: 1; panel-id: 2; Invalid "float" value specified for fuction "scale" parameter "factor": u'0.123'): scale ([], u'0.123')
```