### PR TITLE
Allow floats in scaleToSeconds()

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1315,7 +1315,7 @@ def scaleToSeconds(requestContext, seriesList, seconds):
 scaleToSeconds.group = 'Transform'
 scaleToSeconds.params = [
   Param('seriesList', ParamTypes.seriesList, required=True),
-  Param('seconds', ParamTypes.integer, required=True),
+  Param('seconds', ParamTypes.float, required=True),
 ]
 
 


### PR DESCRIPTION
I've seen users using `scaleToSeconds()` with float values as the `seconds` parameter. I think this appears to be a valid use case