### PR TITLE
ensure that all tag values are strings

### DIFF
--- a/webapp/graphite/render/datalib.py
+++ b/webapp/graphite/render/datalib.py
@@ -26,6 +26,17 @@ from graphite.storage import STORE
 from graphite.util import timebounds, logtime
 
 
+try:
+  from collections import UserDict
+except ImportError:
+  from UserDict import IterableUserDict as UserDict
+
+
+class Tags(UserDict):
+  def __setitem__(self, key, value):
+    self.data[key] = str(value)
+
+
 class TimeSeries(list):
   def __init__(self, name, start, end, step, values, consolidate='average', tags=None, xFilesFactor=None, pathExpression=None):
     list.__init__(self, values)
@@ -157,6 +168,19 @@ class TimeSeries(list):
   def datapoints(self):
     timestamps = range(int(self.start), int(self.end) + 1, int(self.step * self.valuesPerPoint))
     return list(zip(self, timestamps))
+
+  @property
+  def tags(self):
+    return self.__tags
+
+  @tags.setter
+  def tags(self, tags):
+    if isinstance(tags, Tags):
+      self.__tags = tags
+    elif isinstance(tags, dict):
+      self.__tags = Tags(tags)
+    else:
+      raise Exception('Invalid tags specified')
 
 
 # Data retrieval API

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -237,7 +237,7 @@ def renderViewJson(requestOptions, data):
         if not datapoints:
           continue
 
-      series_data.append(dict(target=series.name, tags=series.tags, datapoints=datapoints))
+      series_data.append(dict(target=series.name, tags=dict(series.tags), datapoints=datapoints))
 
   output = json.dumps(series_data, indent=(2 if requestOptions.get('pretty') else None)).replace('None,', 'null,').replace('NaN,', 'null,').replace('Infinity,', '1e9999,')
 


### PR DESCRIPTION
fixes #2571 by ensuring that all tag values are set as strings.  This fixes a number of places that numeric values could have caused issues.