### PR TITLE
Attempt to convert parameter types in validator

### DIFF
--- a/webapp/graphite/functions/params.py
+++ b/webapp/graphite/functions/params.py
@@ -40,7 +40,9 @@ def validateBoolean(value):
     if type(value) in [int, float]:
         if value == 0:
             return False
-        return True
+        if value == 1:
+            return True
+        raise ValueError('Invalid boolean value: {value}'.format(value=repr(value)))
 
     return bool(value)
 

--- a/webapp/graphite/functions/params.py
+++ b/webapp/graphite/functions/params.py
@@ -7,83 +7,83 @@ from graphite.functions.aggfuncs import aggFuncs, aggFuncAliases
 
 
 class ParamTypes(object):
-  pass
+    pass
 
 
 class ParamType(object):
-  options = []
+    options = []
 
-  def __init__(self, name, validator=None):
-    self.name = name
-    self.validator = validator
+    def __init__(self, name, validator=None):
+        self.name = name
+        self.validator = validator
 
-  @classmethod
-  def register(cls, name, *args):
-    setattr(ParamTypes, name, cls(name, *args))
+    @classmethod
+    def register(cls, name, *args):
+        setattr(ParamTypes, name, cls(name, *args))
 
-  def isValid(self, value):
-    if self.validator is None:
-      # if there's no validator for the type we assume True
-      return value
+    def isValid(self, value):
+        if self.validator is None:
+            # if there's no validator for the type we assume True
+            return value
 
-    return self.validator(value)
+        return self.validator(value)
 
 
 def validateBoolean(value):
-  if isinstance(value, six.string_types):
-    if value.lower() == 'true':
-      return True
-    if value.lower() == 'false':
-      return False
-    raise ValueError('Invalid boolean value: {value}'.format(value=repr(value)))
+    if isinstance(value, six.string_types):
+        if value.lower() == 'true':
+            return True
+        if value.lower() == 'false':
+            return False
+        raise ValueError('Invalid boolean value: {value}'.format(value=repr(value)))
 
-  if type(value) in [int, float]:
-    if value == 0:
-      return False
-    return True
+    if type(value) in [int, float]:
+        if value == 0:
+            return False
+        return True
 
-  return bool(value)
+    return bool(value)
 
 
 def validateFloat(value):
-  return float(value)
+    return float(value)
 
 
 def validateInteger(value):
-  # prevent that float values get converted to int, because an
-  # error is better than silently falsifying the result
-  if type(value) is float:
-    raise ValueError('Not a valid integer value: {value}'.format(value=repr(value)))
+    # prevent that float values get converted to int, because an
+    # error is better than silently falsifying the result
+    if type(value) is float:
+        raise ValueError('Not a valid integer value: {value}'.format(value=repr(value)))
 
-  return int(value)
+    return int(value)
 
 
 def validateIntOrInf(value):
-  try:
-    return validateInteger(value)
-  except Exception:
-    pass
+    try:
+        return validateInteger(value)
+    except Exception:
+        pass
 
-  try:
-    inf = float('inf')
-    if float(value) == inf:
-      return inf
-  except Exception:
-    pass
+    try:
+        inf = float('inf')
+        if float(value) == inf:
+            return inf
+    except Exception:
+        pass
 
-  raise ValueError('Not a valid integer nor float value: {value}'.format(value=repr(value)))
+    raise ValueError('Not a valid integer nor float value: {value}'.format(value=repr(value)))
 
 
 def validateInterval(value):
-  try:
-    parseTimeOffset(value)
-  except Exception as e:
-    raise ValueError('Invalid interval value: {value}: {e}'.format(value=repr(value), e=str(e)))
-  return value
+    try:
+        parseTimeOffset(value)
+    except Exception as e:
+        raise ValueError('Invalid interval value: {value}: {e}'.format(value=repr(value), e=str(e)))
+    return value
 
 
 def validateSeriesList(value):
-  return list(value)
+    return list(value)
 
 
 ParamType.register('boolean', validateBoolean)
@@ -107,188 +107,187 @@ ParamType.register('any')
 
 class ParamTypeAggFunc(ParamType):
 
-  def __init__(self, name, validator=None):
-    if validator is None:
-      validator = self.validateAggFuncs
+    def __init__(self, name, validator=None):
+        if validator is None:
+            validator = self.validateAggFuncs
 
-    super(ParamTypeAggFunc, self).__init__(name=name, validator=validator)
-    self.options = self.getValidAggFuncs()
+        super(ParamTypeAggFunc, self).__init__(name=name, validator=validator)
+        self.options = self.getValidAggFuncs()
 
-  @classmethod
-  def getValidAggFuncs(cls):
-    return list(aggFuncs.keys()) + list(aggFuncAliases.keys())
+    @classmethod
+    def getValidAggFuncs(cls):
+        return list(aggFuncs.keys()) + list(aggFuncAliases.keys())
 
-  @classmethod
-  def getDeprecatedAggFuncs(cls):
-    return [name + 'Series' for name in cls.getValidAggFuncs()]
+    @classmethod
+    def getDeprecatedAggFuncs(cls):
+        return [name + 'Series' for name in cls.getValidAggFuncs()]
 
-  @classmethod
-  def getAllValidAggFuncs(cls):
-    return cls.getValidAggFuncs() + cls.getDeprecatedAggFuncs()
+    @classmethod
+    def getAllValidAggFuncs(cls):
+        return cls.getValidAggFuncs() + cls.getDeprecatedAggFuncs()
 
-  def validateAggFuncs(self, value):
-    if value in self.getValidAggFuncs():
-      return value
+    def validateAggFuncs(self, value):
+        if value in self.getValidAggFuncs():
+            return value
 
-    if value in self.getDeprecatedAggFuncs():
-      log.warning('Deprecated aggregation function: {value}'.format(value=repr(value)))
-      return value
+        if value in self.getDeprecatedAggFuncs():
+            log.warning('Deprecated aggregation function: {value}'.format(value=repr(value)))
+            return value
 
-    raise ValueError('Invalid aggregation function: {value}'.format(value=repr(value)))
+        raise ValueError('Invalid aggregation function: {value}'.format(value=repr(value)))
 
 
 ParamTypeAggFunc.register('aggFunc')
 
 
 class ParamTypeAggOrSeriesFunc(ParamTypeAggFunc):
-  options = []
+    options = []
 
-  def __init__(self, name, validator=None):
-    if validator is None:
-      validator = self.validateAggOrSeriesFuncs
-    super(ParamTypeAggOrSeriesFunc, self).__init__(name=name, validator=validator)
+    def __init__(self, name, validator=None):
+        if validator is None:
+            validator = self.validateAggOrSeriesFuncs
+        super(ParamTypeAggOrSeriesFunc, self).__init__(name=name, validator=validator)
 
-  def setSeriesFuncs(self, funcs):
-    # check for each of the series functions whether they have an 'aggregator'
-    # property being set to 'True'. If so we consider them valid aggregators.
-    for name, func in funcs.items():
-      if getattr(func, 'aggregator', False) is not True:
-        continue
+    def setSeriesFuncs(self, funcs):
+        # check for each of the series functions whether they have an 'aggregator'
+        # property being set to 'True'. If so we consider them valid aggregators.
+        for name, func in funcs.items():
+            if getattr(func, 'aggregator', False) is not True:
+                continue
 
-      self.options.append(name)
+            self.options.append(name)
 
-  def validateAggOrSeriesFuncs(self, value):
-    try:
-      return self.validateAggFuncs(value)
-    except Exception:
-      pass
+    def validateAggOrSeriesFuncs(self, value):
+        try:
+            return self.validateAggFuncs(value)
+        except Exception:
+            pass
 
-    if value in self.options:
-      return value
+        if value in self.options:
+            return value
 
-    return False
+        return False
 
 
 ParamTypeAggOrSeriesFunc.register('aggOrSeriesFunc')
 
 
 class Param(object):
-  __slots__ = ('name', 'type', 'required', 'default', 'multiple', '_options', 'suggestions')
+    __slots__ = ('name', 'type', 'required', 'default', 'multiple', '_options', 'suggestions')
 
-  def __init__(self, name, paramtype, required=False, default=None, multiple=False, options=[],
-               suggestions=None):
-    self.name = name
-    if not isinstance(paramtype, ParamType):
-      raise Exception('Invalid type %s for parameter %s' % (paramtype, name))
-    self.type = paramtype
-    self.required = bool(required)
-    self.default = default
-    self.multiple = bool(multiple)
-    self._options = options
-    self.suggestions = suggestions
+    def __init__(self, name, paramtype, required=False, default=None, multiple=False, options=[], suggestions=None):
+        self.name = name
+        if not isinstance(paramtype, ParamType):
+            raise Exception('Invalid type %s for parameter %s' % (paramtype, name))
+        self.type = paramtype
+        self.required = bool(required)
+        self.default = default
+        self.multiple = bool(multiple)
+        self._options = options
+        self.suggestions = suggestions
 
-  @property
-  def options(self):
-    options = list(set(getattr(self, '_options', []) + getattr(self.type, 'options', [])))
-    options.sort(key=str)
-    return options
+    @property
+    def options(self):
+        options = list(set(getattr(self, '_options', []) + getattr(self.type, 'options', [])))
+        options.sort(key=str)
+        return options
 
-  def toJSON(self):
-    jsonVal = {
-      'name': self.name,
-      'type': self.type.name,
-    }
-    if self.required:
-      jsonVal['required'] = True
-    if self.default is not None:
-      jsonVal['default'] = self.default
-    if self.multiple:
-      jsonVal['multiple'] = True
-    if self.options:
-      jsonVal['options'] = self.options
-    if self.suggestions:
-      jsonVal['suggestions'] = self.suggestions
-    return jsonVal
+    def toJSON(self):
+        jsonVal = {
+            'name': self.name,
+            'type': self.type.name,
+        }
+        if self.required:
+            jsonVal['required'] = True
+        if self.default is not None:
+            jsonVal['default'] = self.default
+        if self.multiple:
+            jsonVal['multiple'] = True
+        if self.options:
+            jsonVal['options'] = self.options
+        if self.suggestions:
+            jsonVal['suggestions'] = self.suggestions
+        return jsonVal
 
-  def validateValue(self, value, func):
-    # if value isn't specified and there's a default then the default will be used,
-    # we don't need to validate the default value because we trust that it is valid
-    if value is None and self.default is not None:
-      return value
+    def validateValue(self, value, func):
+        # if value isn't specified and there's a default then the default will be used,
+        # we don't need to validate the default value because we trust that it is valid
+        if value is None and self.default is not None:
+            return value
 
-    # None is ok for optional params
-    if not self.required and value is None:
-      return value
+        # None is ok for optional params
+        if not self.required and value is None:
+            return value
 
-    # parameter is restricted to a defined set of values, but value is not in it
-    if self.options and value not in self.options:
-      raise InputParameterError(
-        'Invalid option specified for function "{func}" parameter "{param}": {value}'.format(
-          func=func, param=self.name, value=repr(value)))
+        # parameter is restricted to a defined set of values, but value is not in it
+        if self.options and value not in self.options:
+            raise InputParameterError(
+                'Invalid option specified for function "{func}" parameter "{param}": {value}'.format(
+                    func=func, param=self.name, value=repr(value)))
 
-    try:
-      return self.type.isValid(value)
-    except Exception:
-      raise InputParameterError(
-        'Invalid "{type}" value specified for function "{func}" parameter "{param}": {value}'.format(
-          type=self.type.name, func=func, param=self.name, value=repr(value)))
+        try:
+            return self.type.isValid(value)
+        except Exception:
+            raise InputParameterError(
+                'Invalid "{type}" value specified for function "{func}" parameter "{param}": {value}'.format(
+                    type=self.type.name, func=func, param=self.name, value=repr(value)))
 
 
 def validateParams(func, params, args, kwargs):
-  valid_args = []
-  valid_kwargs = {}
+    valid_args = []
+    valid_kwargs = {}
 
-  # total number of args + kwargs might be larger than number of params if
-  # the last param allows to be specified multiple times
-  if len(args) + len(kwargs) > len(params):
-    if not params[-1].multiple:
-      raise InputParameterError(
-        'Too many parameters specified for function "{func}"'.format(func=func))
+    # total number of args + kwargs might be larger than number of params if
+    # the last param allows to be specified multiple times
+    if len(args) + len(kwargs) > len(params):
+        if not params[-1].multiple:
+            raise InputParameterError(
+                'Too many parameters specified for function "{func}"'.format(func=func))
 
-    # if args has more values than params and the last param allows multiple values,
-    # then we're going to validate all paramas from the args value list
-    args_params = params
-    kwargs_params = []
-  else:
-    # take the first len(args) params and use them to validate the args values,
-    # use the remaining params to validate the kwargs values
-    args_params = params[:len(args)]
-    kwargs_params = params[len(args):]
-
-  # validate the args
-  for i in range(len(args)):
-    if i >= len(args_params):
-      # last parameter must be allowing multiple,
-      # so we're using it to validate this arg
-      param = args_params[-1]
+        # if args has more values than params and the last param allows multiple values,
+        # then we're going to validate all paramas from the args value list
+        args_params = params
+        kwargs_params = []
     else:
-      param = args_params[i]
+        # take the first len(args) params and use them to validate the args values,
+        # use the remaining params to validate the kwargs values
+        args_params = params[:len(args)]
+        kwargs_params = params[len(args):]
 
-    valid_args.append(param.validateValue(args[i], func))
+    # validate the args
+    for (i, arg) in enumerate(args):
+        if i >= len(args_params):
+            # last parameter must be allowing multiple,
+            # so we're using it to validate this arg
+            param = args_params[-1]
+        else:
+            param = args_params[i]
 
-  # validate the kwargs
-  for param in kwargs_params:
-    value = kwargs.get(param.name, None)
-    if value is None:
-      if param.required:
+        valid_args.append(param.validateValue(arg, func))
+
+    # validate the kwargs
+    for param in kwargs_params:
+        value = kwargs.get(param.name, None)
+        if value is None:
+            if param.required:
+                raise InputParameterError(
+                    'Missing required parameter "{param}" for function "{func}"'
+                    .format(param=param.name, func=func))
+            continue
+
+        valid_kwargs[param.name] = param.validateValue(value, func)
+
+    if len(kwargs) > len(valid_kwargs):
+        unexpected_keys = []
+        for name in kwargs.keys():
+            if name not in valid_kwargs:
+                unexpected_keys.append(name)
         raise InputParameterError(
-          'Missing required parameter "{param}" for function "{func}"'
-          .format(param=param.name, func=func))
-      continue
+            'Unexpected key word arguments: {keys}'.format(
+                keys=', '.join(
+                    key
+                    for key in kwargs.keys()
+                    if key not in valid_kwargs.keys()
+                )))
 
-    valid_kwargs[param.name] = param.validateValue(value, func)
-
-  if len(kwargs) > len(valid_kwargs):
-    unexpected_keys = []
-    for name in kwargs.keys():
-      if name not in valid_kwargs:
-        unexpected_keys.append(name)
-    raise InputParameterError(
-      'Unexpected key word arguments: {keys}'.format(
-        keys=', '.join(
-          key
-          for key in kwargs.keys()
-          if key not in valid_kwargs.keys()
-        )))
-
-  return (valid_args, valid_kwargs)
+    return (valid_args, valid_kwargs)

--- a/webapp/graphite/functions/params.py
+++ b/webapp/graphite/functions/params.py
@@ -175,7 +175,7 @@ ParamTypeAggOrSeriesFunc.register('aggOrSeriesFunc')
 class Param(object):
     __slots__ = ('name', 'type', 'required', 'default', 'multiple', '_options', 'suggestions')
 
-    def __init__(self, name, paramtype, required=False, default=None, multiple=False, options=[], suggestions=None):
+    def __init__(self, name, paramtype, required=False, default=None, multiple=False, options=None, suggestions=None):
         self.name = name
         if not isinstance(paramtype, ParamType):
             raise Exception('Invalid type %s for parameter %s' % (paramtype, name))
@@ -183,6 +183,8 @@ class Param(object):
         self.required = bool(required)
         self.default = default
         self.multiple = bool(multiple)
+        if options is None:
+            options = []
         self._options = options
         self.suggestions = suggestions
 

--- a/webapp/graphite/functions/params.py
+++ b/webapp/graphite/functions/params.py
@@ -61,14 +61,14 @@ def validateInteger(value):
 def validateIntOrInf(value):
     try:
         return validateInteger(value)
-    except Exception:
+    except (TypeError, ValueError):
         pass
 
     try:
         inf = float('inf')
         if float(value) == inf:
             return inf
-    except Exception:
+    except (TypeError, ValueError, OverflowError):
         pass
 
     raise ValueError('Not a valid integer nor float value: {value}'.format(value=repr(value)))
@@ -77,7 +77,7 @@ def validateIntOrInf(value):
 def validateInterval(value):
     try:
         parseTimeOffset(value)
-    except Exception as e:
+    except (IndexError, KeyError, TypeError, ValueError) as e:
         raise ValueError('Invalid interval value: {value}: {e}'.format(value=repr(value), e=str(e)))
     return value
 
@@ -160,7 +160,7 @@ class ParamTypeAggOrSeriesFunc(ParamTypeAggFunc):
     def validateAggOrSeriesFuncs(self, value):
         try:
             return self.validateAggFuncs(value)
-        except Exception:
+        except ValueError:
             pass
 
         if value in self.options:

--- a/webapp/graphite/render/attime.py
+++ b/webapp/graphite/render/attime.py
@@ -191,4 +191,4 @@ def getUnitString(s):
   if s.startswith('w'): return WEEKS_STRING
   if s.startswith('mon'): return MONTHS_STRING
   if s.startswith('y'): return YEARS_STRING
-  raise Exception("Invalid offset unit '%s'" % s)
+  raise ValueError("Invalid offset unit '%s'" % s)

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -114,7 +114,7 @@ def evaluateTokens(requestContext, tokens, replacements=None, pipedArg=None):
 
     if hasattr(func, 'params'):
       try:
-        validateParams(tokens.call.funcname, func.params, args, kwargs)
+        (args, kwargs) = validateParams(tokens.call.funcname, func.params, args, kwargs)
       except InputParameterError as e:
         handleInvalidParameters(e)
 

--- a/webapp/tests/test_params.py
+++ b/webapp/tests/test_params.py
@@ -314,11 +314,12 @@ class TestParam(unittest.TestCase):
         self.assertEqual(validateParams(
             'TestParam',
             [
-                Param('bool', ParamTypes.boolean),
+                Param('bool1', ParamTypes.boolean),
+                Param('bool2', ParamTypes.boolean),
             ],
-            [],
-            {'bool': 1}),
-            ([], {'bool': True}),
+            [0],
+            {'bool2': 1}),
+            ([False], {'bool2': True}),
         )
 
         self.assertEqual(validateParams(
@@ -407,5 +408,14 @@ class TestParam(unittest.TestCase):
             'TestParam',
             [Param('param', ParamTypes.boolean)],
             ['1'],
+            {},
+        )
+
+        self.assertRaises(
+            InputParameterError,
+            validateParams,
+            'TestParam',
+            [Param('param', ParamTypes.boolean)],
+            [3],
             {},
         )

--- a/webapp/tests/test_params.py
+++ b/webapp/tests/test_params.py
@@ -12,12 +12,13 @@ class TestParam(unittest.TestCase):
     ]
 
     def test_simple_args(self):
-        self.assertTrue(validateParams(
+        self.assertEqual(validateParams(
             'TestParam',
             self.params,
             ['arg1', 'arg2', 'arg3'],
-            {},
-        ))
+            {}),
+            (['arg1', 'arg2', 'arg3'], {}),
+        )
 
         self.assertRaises(
             InputParameterError,
@@ -29,12 +30,13 @@ class TestParam(unittest.TestCase):
         )
 
     def test_simple_kwargs(self):
-        self.assertTrue(validateParams(
+        self.assertEqual(validateParams(
             'TestParam',
             self.params,
             [],
-            {'one': '1', 'two': '2', 'three': '3'},
-        ))
+            {'one': '1', 'two': '2', 'three': '3'}),
+            ([], {'one': '1', 'two': '2', 'three': '3'}),
+        )
 
         self.assertRaises(
             InputParameterError,
@@ -55,27 +57,31 @@ class TestParam(unittest.TestCase):
         )
 
     def test_mixed_cases(self):
-        self.assertTrue(validateParams(
+        self.assertEqual(validateParams(
             'TestParam',
             self.params,
             ['one', 'two'],
-            {'three': '3'},
-        ))
+            {'three': '3'}),
+            (['one', 'two'],
+            {'three': '3'})
+        )
 
-        self.assertTrue(validateParams(
+        self.assertEqual(validateParams(
             'TestParam',
             self.params,
             ['one'],
-            {'three': '3', 'two': '2'},
-        ))
+            {'three': '3', 'two': '2'}),
+            (['one'], {'three': '3', 'two': '2'}),
+        )
 
         # positional args don't check the name
-        self.assertTrue(validateParams(
+        self.assertEqual(validateParams(
             'TestParam',
             self.params,
             ['one', 'two', 'four'],
-            {},
-        ))
+            {}),
+            (['one', 'two', 'four'], {})
+        )
 
         self.assertRaises(
             InputParameterError,
@@ -146,7 +152,7 @@ class TestParam(unittest.TestCase):
             {},
         )
 
-        self.assertTrue(validateParams(
+        self.assertEqual(validateParams(
             'TestParam',
             [
                 Param('one', ParamTypes.string, required=True),
@@ -154,11 +160,27 @@ class TestParam(unittest.TestCase):
                 Param('three', ParamTypes.string, required=True, multiple=True),
             ],
             ['one', 'two', 'three', 'four'],
-            {},
-        ))
+            {}),
+            (['one', 'two', 'three', 'four'], {}),
+        )
+
+        self.assertRaises(
+            InputParameterError,
+            validateParams,
+            'TestParam',
+            [
+                Param('one', ParamTypes.string, required=True),
+                Param('two', ParamTypes.string, required=True),
+                Param('three', ParamTypes.string, required=True, multiple=True),
+            ],
+            ['one', 'two', 'three'],
+            # should fail because parameters which are specified multiple times
+            # cannot be in kwargs, only args
+            {'three': '3'},
+        )
 
     def test_options_property(self):
-        self.assertTrue(validateParams(
+        self.assertEqual(validateParams(
             'TestParam',
             [
                 Param('one', ParamTypes.string, required=True),
@@ -166,10 +188,11 @@ class TestParam(unittest.TestCase):
                 Param('three', ParamTypes.string, required=True, options=['3', 'three']),
             ],
             ['one', 'two', '3'],
-            {},
-        ))
+            {}),
+            (['one', 'two', '3'], {}),
+        )
 
-        self.assertTrue(validateParams(
+        self.assertEqual(validateParams(
             'TestParam',
             [
                 Param('one', ParamTypes.string, required=True),
@@ -177,8 +200,9 @@ class TestParam(unittest.TestCase):
                 Param('three', ParamTypes.string, required=True, options=['3', 'three']),
             ],
             ['one', 'two', 'three'],
-            {},
-        ))
+            {}),
+            (['one', 'two', 'three'], {}),
+        )
 
         self.assertRaises(
             InputParameterError,
@@ -195,14 +219,15 @@ class TestParam(unittest.TestCase):
 
     def test_use_series_function_as_aggregator(self):
         # powSeries is a series function which is marked as a valid aggregator
-        self.assertTrue(validateParams(
+        self.assertEqual(validateParams(
             'TestParam',
             [
                 Param('func', ParamTypes.aggOrSeriesFunc, required=True),
             ],
             ['powSeries'],
-            {},
-        ))
+            {}),
+            (['powSeries'], {}),
+        )
 
         # squareRoot is a series function which is not marked as a valid aggregator
         self.assertRaises(
@@ -217,19 +242,21 @@ class TestParam(unittest.TestCase):
         )
 
     def test_param_type_int_or_inf(self):
-        self.assertTrue(validateParams(
+        self.assertEqual(validateParams(
             'TestParam',
             [Param('param', ParamTypes.intOrInf)],
             [1],
-            {},
-        ))
+            {}),
+            ([1], {}),
+        )
 
-        self.assertTrue(validateParams(
+        self.assertEqual(validateParams(
             'TestParam',
             [Param('param', ParamTypes.intOrInf)],
             [float('inf')],
-            {},
-        ))
+            {}),
+            ([float('inf')], {}),
+        )
 
         self.assertRaises(
             InputParameterError,
@@ -240,14 +267,145 @@ class TestParam(unittest.TestCase):
             {},
         )
 
+    def test_unexpected_kwargs(self):
+        self.assertRaises(
+            InputParameterError,
+            validateParams,
+            'TestParam',
+            [Param('param', ParamTypes.integer)],
+            [],
+            {'param': 1, 'param2': 2},
+        )
+
     def test_default_value(self):
         # if no value is specified, but there is a default value, we don't
         # want the validator to raise an exception because 'None' is invalid
-        self.assertTrue(validateParams(
+        self.assertEqual(validateParams(
             'TestParam',
             [
                 Param('one', ParamTypes.aggFunc, default='sum'),
             ],
             [],
+            {}),
+            ([], {}),
+        )
+
+    def test_various_type_conversions(self):
+        self.assertEqual(validateParams(
+            'TestParam',
+            [
+                Param('bool', ParamTypes.boolean),
+            ],
+            ['true'],
+            {}),
+            ([True], {}),
+        )
+
+        self.assertEqual(validateParams(
+            'TestParam',
+            [
+                Param('bool', ParamTypes.boolean),
+            ],
+            [],
+            {'bool': 'false'}),
+            ([], {'bool': False}),
+        )
+
+        self.assertEqual(validateParams(
+            'TestParam',
+            [
+                Param('bool', ParamTypes.boolean),
+            ],
+            [],
+            {'bool': 1}),
+            ([], {'bool': True}),
+        )
+
+        self.assertEqual(validateParams(
+            'TestParam',
+            [
+                Param('float', ParamTypes.float),
+            ],
+            ['1e3'],
+            {}),
+            ([float(1000)], {}),
+        )
+
+        self.assertEqual(validateParams(
+            'TestParam',
+            [
+                Param('float', ParamTypes.float),
+            ],
+            ['0.123'],
+            {}),
+            ([float(0.123)], {}),
+        )
+
+        self.assertEqual(validateParams(
+            'TestParam',
+            [
+                Param('float', ParamTypes.float),
+            ],
+            [],
+            {'float': 'inf'}),
+            ([], {'float': float('inf')}),
+        )
+
+        self.assertEqual(validateParams(
+            'TestParam',
+            [
+                Param('int', ParamTypes.integer),
+            ],
+            ['123'],
+            {}),
+            ([123], {}),
+        )
+
+        self.assertEqual(validateParams(
+            'TestParam',
+            [
+                Param('int', ParamTypes.integer),
+            ],
+            [],
+            {'int': '-123'}),
+            ([], {'int': -123}),
+        )
+
+        self.assertEqual(validateParams(
+            'TestParam',
+            [
+                Param('intOrInf', ParamTypes.intOrInf),
+            ],
+            ['123'],
+            {}),
+            ([123], {}),
+        )
+
+        self.assertEqual(validateParams(
+            'TestParam',
+            [
+                Param('intOrInf', ParamTypes.intOrInf),
+            ],
+            [],
+            {'intOrInf': float('inf')}),
+            ([], {'intOrInf': float('inf')}),
+        )
+
+    def test_impossible_type_conversions(self):
+        self.assertRaises(
+            InputParameterError,
+            validateParams,
+            'TestParam',
+            [Param('param', ParamTypes.integer)],
+            ['inf'],
             {},
-        ))
+        )
+
+        self.assertRaises(
+            InputParameterError,
+            validateParams,
+            'TestParam',
+            [Param('param', ParamTypes.boolean)],
+            ['1'],
+            {},
+        )


### PR DESCRIPTION
We've seen many cases where users make understandable mistakes, such as specifying boolean parameters as string (`'true'`) or specifying the `inf` value as a string (`'inf'`). 

Now the input validation doesn't only check whether the input is valid, but if possible it also does a type cast of the given parameters. All the validators are now either returning a value of the correct type or raise an exception.