### PR TITLE
flake8: re-enable E111,E114 (4-space indent) for most files

### DIFF
--- a/bin/run-graphite-devel-server.py
+++ b/bin/run-graphite-devel-server.py
@@ -17,17 +17,17 @@ option_parser.add_option('--noreload', action='store_true', help='Disable monito
 (options, args) = option_parser.parse_args()
 
 if not args:
-  option_parser.print_usage()
-  sys.exit(1)
+    option_parser.print_usage()
+    sys.exit(1)
 
 graphite_root = args[0]
 
 python_path = os.path.join(graphite_root, 'webapp')
 
 if options.libs:
-  libdir = os.path.expanduser(options.libs)
-  print('Adding %s to your PYTHONPATH' % libdir)
-  os.environ['PYTHONPATH'] = libdir + ':' + os.environ.get('PYTHONPATH','')
+    libdir = os.path.expanduser(options.libs)
+    print('Adding %s to your PYTHONPATH' % libdir)
+    os.environ['PYTHONPATH'] = libdir + ':' + os.environ.get('PYTHONPATH','')
 
 print("Running Graphite from %s under django development server\n" % graphite_root)
 
@@ -40,7 +40,7 @@ command = [
 ]
 
 if options.noreload:
-  command.append('--noreload')
+    command.append('--noreload')
 
 print(' '.join(command))
 

--- a/check-dependencies.py
+++ b/check-dependencies.py
@@ -3,9 +3,9 @@
 import sys
 
 if sys.version_info <= (2,7):
-  # SystemExit defaults to returning 1 when printing a string to stderr
-  raise SystemExit("You are using python %s, but version 2.7 or greater is "
-                   "required" % sys.version_info)
+    # SystemExit defaults to returning 1 when printing a string to stderr
+    raise SystemExit("You are using python %s, but version 2.7 or greater is "
+                     "required" % sys.version_info)
 
 required = 0
 optional = 0
@@ -13,121 +13,139 @@ optional = 0
 
 # Test for whisper
 try:
-  import whisper
+    import whisper
 except ImportError:
-  # No? test for ceres
-  try:
-    import ceres
-    # We imported ceres, but not whisper so it's an optional dependency
-    sys.stderr.write("[OPTIONAL] Unable to import the 'whisper' module. Without it the webapp will be unable to read .wsp files\n")
-    optional += 1
-  except ImportError:
-    sys.stderr.write("[REQUIRED] Unable to import the 'whisper' or 'ceres' modules, please download this package from the Graphite project page and install it.\n")
-    required += 1
+    # No? test for ceres
+    try:
+        import ceres
+        # We imported ceres, but not whisper so it's an optional dependency
+        sys.stderr.write("[OPTIONAL] Unable to import the 'whisper' module. "
+                         "Without it the webapp will be unable to read .wsp files\n")
+        optional += 1
+    except ImportError:
+        sys.stderr.write("[REQUIRED] Unable to import the 'whisper' or 'ceres' modules, "
+                         "please download this package from the Graphite project page and install it.\n")
+        required += 1
 
 
 # Test for cairocffi or pycairo
 try:
-  import cairocffi as cairo
+    import cairocffi as cairo
 except ImportError:
-  sys.stderr.write("[REQUIRED] Unable to import the 'cairocffi' module, attempting to fall back to pycairo\n")
-  try:
-    import cairo
-  except ImportError:
-    sys.stderr.write("[REQUIRED] Unable to import the 'cairo' module, do you have pycairo installed for python %s?\n" % sys.version_info.major)
-    cairo = None
-    required += 1
+    sys.stderr.write("[REQUIRED] Unable to import the 'cairocffi' module, attempting to fall back to pycairo\n")
+    try:
+        import cairo
+    except ImportError:
+        sys.stderr.write("[REQUIRED] Unable to import the 'cairo' module, "
+                         "do you have pycairo installed for python %s?\n" % sys.version_info.major)
+        cairo = None
+        required += 1
 
 
 # Test that pycairo has the PNG backend
 try:
-  if cairo:
-    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
-    del surface
+    if cairo:
+        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
+        del surface
 except Exception:
-  sys.stderr.write("[REQUIRED] Failed to create an ImageSurface with cairo, you probably need to recompile cairo with PNG support\n")
-  required += 1
+    sys.stderr.write("[REQUIRED] Failed to create an ImageSurface with cairo, "
+                     "you probably need to recompile cairo with PNG support\n")
+    required += 1
 
 
 # Test that cairo can find fonts
 try:
-  if cairo:
-    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
-    context = cairo.Context(surface)
-    context.font_extents()
-    del surface, context
+    if cairo:
+        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
+        context = cairo.Context(surface)
+        context.font_extents()
+        del surface, context
 except Exception:
-  sys.stderr.write("[REQUIRED] Failed to create text with cairo, this probably means cairo cant find any fonts. Install some system fonts and try again\n")
+    sys.stderr.write("[REQUIRED] Failed to create text with cairo, "
+                     "this probably means cairo cant find any fonts. "
+                     "Install some system fonts and try again\n")
 
 
 # Test for django
 try:
-  import django
+    import django
 except ImportError:
-  sys.stderr.write("[REQUIRED] Unable to import the 'django' module, do you have Django installed for python %s?\n" % sys.version_info.major)
-  django = None
-  required += 1
+    sys.stderr.write("[REQUIRED] Unable to import the 'django' module, "
+                     "do you have Django installed for python %s?\n" % sys.version_info.major)
+    django = None
+    required += 1
 
 
 # Test for pytz
 try:
-  import pytz
+    import pytz
 except ImportError:
-  sys.stderr.write("[REQUIRED] Unable to import the 'pytz' module, do you have pytz module installed for python %s?\n" % sys.version_info.major)
-  required += 1
+    sys.stderr.write("[REQUIRED] Unable to import the 'pytz' module, "
+                     "do you have pytz module installed for python %s?\n" % sys.version_info.major)
+    required += 1
 
 
 # Test for pyparsing
 try:
-  import pyparsing
+    import pyparsing
 except ImportError:
-  sys.stderr.write("[REQUIRED] Unable to import the 'pyparsing' module, do you have pyparsing module installed for python %s?\n" % sys.version_info.major)
-  required += 1
+    sys.stderr.write("[REQUIRED] Unable to import the 'pyparsing' module, "
+                     "do you have pyparsing module installed for python %s?\n" % sys.version_info.major)
+    required += 1
 
 
 # Test for django-tagging
 try:
-  import tagging
+    import tagging
 except ImportError:
-  sys.stderr.write("[REQUIRED] Unable to import the 'tagging' module, do you have django-tagging installed for python %s?\n" % sys.version_info.major)
-  required += 1
+    sys.stderr.write("[REQUIRED] Unable to import the 'tagging' module, "
+                     "do you have django-tagging installed for python %s?\n" % sys.version_info.major)
+    required += 1
 
 
 if django and django.VERSION[:2] < (1,8):
-  sys.stderr.write("[REQUIRED] You have django version %s installed, but version 1.8 or greater is required\n" % django.get_version())
-  required += 1
+    sys.stderr.write("[REQUIRED] You have django version %s installed, "
+                     "but version 1.8 or greater is required\n" % django.get_version())
+    required += 1
 
 
 # Test for python-memcached
 try:
-  import memcache
+    import memcache
 except ImportError:
-  sys.stderr.write("[OPTIONAL] Unable to import the 'memcache' module, do you have python-memcached installed for python %s? This feature is not required but greatly improves performance.\n" % sys.version_info.major)
-  optional += 1
+    sys.stderr.write("[OPTIONAL] Unable to import the 'memcache' module, "
+                     "do you have python-memcached installed for python %s? "
+                     "This feature is not required but greatly improves performance.\n" % sys.version_info.major)
+    optional += 1
 
 
 # Test for python-ldap
 try:
-  import ldap
+    import ldap
 except ImportError:
-  sys.stderr.write("[OPTIONAL] Unable to import the 'ldap' module, do you have python-ldap installed for python %s? Without python-ldap, you will not be able to use LDAP authentication in the graphite webapp.\n" % sys.version_info.major)
-  optional += 1
+    sys.stderr.write("[OPTIONAL] Unable to import the 'ldap' module, "
+                     "do you have python-ldap installed for python %s? "
+                     "Without python-ldap, you will not be able to use "
+                     "LDAP authentication in the graphite webapp.\n" % sys.version_info.major)
+    optional += 1
 
 
 # Test for txamqp
 try:
-  import txamqp
+    import txamqp
 except ImportError:
-  sys.stderr.write("[OPTIONAL] Unable to import the 'txamqp' module, this is required if you want to use AMQP as an input to Carbon. Note that txamqp requires python 2.5 or greater.\n")
-  optional += 1
+    sys.stderr.write("[OPTIONAL] Unable to import the 'txamqp' module, "
+                     "this is required if you want to use AMQP as an input to Carbon. "
+                     "Note that txamqp requires python 2.5 or greater.\n")
+    optional += 1
 
 
 # Test for python-rrdtool
 try:
-  import rrdtool
+    import rrdtool
 except ImportError:
-  sys.stderr.write("[OPTIONAL] Unable to import the 'python-rrdtool' module, this is required for reading RRD.\n")
-  optional += 1
+    sys.stderr.write("[OPTIONAL] Unable to import the 'python-rrdtool' module, this is required for reading RRD.\n")
+    optional += 1
 
 
 # Test for whitenoise
@@ -147,15 +165,15 @@ except ImportError:
 
 
 if optional:
-  sys.stderr.write("%d optional dependencies not met. Please consider the optional items before proceeding.\n" % optional)
+    sys.stderr.write("%d optional dependencies not met. Please consider the optional items before proceeding.\n" % optional)
 else:
-  print("All optional dependencies are met.")
+    print("All optional dependencies are met.")
 
 if required:
-  sys.stderr.write("%d necessary dependencies not met. Graphite will not function until these dependencies are fulfilled.\n" % required)
-  sys.exit(1)
+    sys.stderr.write("%d necessary dependencies not met. Graphite will not function until these dependencies are fulfilled.\n" % required)
+    sys.exit(1)
 else:
-  print("All necessary dependencies are met.")
+    print("All necessary dependencies are met.")
 
 
 # suppress unused-import warnings

--- a/contrib/test_aggregator_rules.py
+++ b/contrib/test_aggregator_rules.py
@@ -12,10 +12,13 @@ from carbon.aggregator.rules import RuleManager  # noqa: E402
 
 ### Basic usage
 if len(sys.argv) != 3:
-  print("Usage: %s 'aggregator rule' 'line item'" % (__file__))
-  print("\nSample invocation: %s %s %s" %
-    (__file__, "'<prefix>.<env>.<key>.sum.all (10) = sum <prefix>.<env>.<<key>>.sum.<node>'", 'stats.prod.js.ktime_sum.sum.host2' ))
-  sys.exit(42)
+    print("Usage: %s 'aggregator rule' 'line item'" % (__file__))
+    print("\nSample invocation: %s %s %s" % (
+        __file__,
+        "'<prefix>.<env>.<key>.sum.all (10) = sum <prefix>.<env>.<<key>>.sum.<node>'",
+        'stats.prod.js.ktime_sum.sum.host2'
+    ))
+    sys.exit(42)
 
 ### cli arguments
 me, raw_rule, raw_metric = sys.argv
@@ -36,8 +39,8 @@ match = rule.regex.match( raw_metric )
 
 print("Raw metric: %s" % raw_metric)
 if match:
-  print("Match dict: %s" % match.groupdict())
-  print("Result: %s" % rule.output_template % match.groupdict())
+    print("Match dict: %s" % match.groupdict())
+    print("Result: %s" % rule.output_template % match.groupdict())
 
 else:
-  print("ERROR: NO MATCH")
+    print("ERROR: NO MATCH")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,22 +43,22 @@ else:
 # Define a custom autodoc documenter for the render.functions module
 # This will remove the requestContext parameter which doesnt make sense in the context of the docs
 class RenderFunctionDocumenter(autodoc.FunctionDocumenter):
-  priority = 10 # Override FunctionDocumenter
+    priority = 10 # Override FunctionDocumenter
 
-  @classmethod
-  def can_document_member(cls, member, membername, isattr, parent):
-    return autodoc.FunctionDocumenter.can_document_member(member, membername, isattr, parent) and \
-      parent.name == 'graphite.render.functions'
+    @classmethod
+    def can_document_member(cls, member, membername, isattr, parent):
+        return autodoc.FunctionDocumenter.can_document_member(member, membername, isattr, parent) \
+            and parent.name == 'graphite.render.functions'
 
-  def format_args(self):
-    args = autodoc.FunctionDocumenter.format_args(self)
-    if args is not None:
-      # Really, a regex sub here is by far the easiest way
-      return re.sub('requestContext, ','',args)
+    def format_args(self):
+        args = autodoc.FunctionDocumenter.format_args(self)
+        if args is not None:
+            # Really, a regex sub here is by far the easiest way
+            return re.sub('requestContext, ','',args)
 
 
 def setup(app):
-  app.add_autodocumenter(RenderFunctionDocumenter)
+    app.add_autodocumenter(RenderFunctionDocumenter)
 
 
 # -- General configuration -----------------------------------------------------

--- a/examples/example-client.py
+++ b/examples/example-client.py
@@ -25,41 +25,43 @@ CARBON_PORT = 2003
 
 delay = 60
 if len(sys.argv) > 1:
-  delay = int( sys.argv[1] )
+    delay = int( sys.argv[1] )
 
 
 def get_loadavg():
-  # For more details, "man proc" and "man uptime"
-  if platform.system() == "Linux":
-    return open('/proc/loadavg').read().strip().split()[:3]
-  else:
-    command = "uptime"
-    process = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True)
-    os.waitpid(process.pid, 0)
-    output = process.stdout.read().replace(',', ' ').strip().split()
-    length = len(output)
-    return output[length - 3:length]
+    # For more details, "man proc" and "man uptime"
+    if platform.system() == "Linux":
+        return open('/proc/loadavg').read().strip().split()[:3]
+    else:
+        command = "uptime"
+        process = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True)
+        os.waitpid(process.pid, 0)
+        output = process.stdout.read().replace(',', ' ').strip().split()
+        length = len(output)
+        return output[length - 3:length]
 
 
 sock = socket()
 try:
-  sock.connect( (CARBON_SERVER,CARBON_PORT) )
+    sock.connect( (CARBON_SERVER,CARBON_PORT) )
 except Exception:
-  print("Couldn't connect to %(server)s on port %(port)d, is carbon-agent.py running?" % { 'server':CARBON_SERVER, 'port':CARBON_PORT })
-  sys.exit(1)
+    print("Couldn't connect to %(server)s on port %(port)d, is carbon-agent.py running?" % {
+        'server': CARBON_SERVER, 'port': CARBON_PORT
+    })
+    sys.exit(1)
 
 while True:
-  now = int( time.time() )
-  lines = []
-  #We're gonna report all three loadavg values
-  loadavg = get_loadavg()
-  lines.append("system.loadavg_1min %s %d" % (loadavg[0],now))
-  lines.append("system.loadavg_5min %s %d" % (loadavg[1],now))
-  lines.append("system.loadavg_15min %s %d" % (loadavg[2],now))
-  message = '\n'.join(lines) + '\n' #all lines must end in a newline
-  print("sending message\n")
-  print('-' * 80)
-  print(message)
-  print()
-  sock.sendall(message)
-  time.sleep(delay)
+    now = int( time.time() )
+    lines = []
+    #We're gonna report all three loadavg values
+    loadavg = get_loadavg()
+    lines.append("system.loadavg_1min %s %d" % (loadavg[0],now))
+    lines.append("system.loadavg_5min %s %d" % (loadavg[1],now))
+    lines.append("system.loadavg_15min %s %d" % (loadavg[2],now))
+    message = '\n'.join(lines) + '\n' #all lines must end in a newline
+    print("sending message\n")
+    print('-' * 80)
+    print(message)
+    print()
+    sock.sendall(message)
+    time.sleep(delay)

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,11 +19,24 @@ obsoletes = graphite <= 0.9.9
 
 [flake8]
 exclude = .tox
+# ignore 4-space-indent rules for biggest files with most lines to change
+per-file-ignores =
+    webapp/graphite/util.py:E111,E114
+    webapp/graphite/browser/views.py:E111,E114
+    webapp/graphite/metrics/views.py:E111,E114
+    webapp/graphite/dashboard/views.py:E111,E114
+    webapp/graphite/render/evaluator.py:E111,E114
+    webapp/graphite/render/functions.py:E111,E114
+    webapp/graphite/render/datalib.py:E111,E114
+    webapp/graphite/render/glyph.py:E111,E114
+    webapp/graphite/render/views.py:E111,E114
+    webapp/tests/test_tags.py:E111,E114
+    webapp/tests/test_storage.py:E111,E114
+    webapp/tests/test_render_glyph.py:E111,E114
+    webapp/tests/test_render_datalib.py:E111,E114
+    webapp/tests/test_finders_remote.py:E111,E114
+    contrib/memcache_whisper.py:E111,E114
 ignore =
-    # E111 indentation is not a multiple of four
-    E111,
-    # E114 indentation is not a multiple of four (comment)
-    E114,
     # E121 continuation line under-indented for hanging indent
     E121,
     # E126 continuation line over-indented for hanging indent

--- a/setup.py
+++ b/setup.py
@@ -48,25 +48,25 @@ with open('setup.cfg', 'w') as f:
     cf.write(f)
 
 if os.environ.get('USE_SETUPTOOLS'):
-  from setuptools import setup
-  setup_kwargs = dict(zip_safe=0)
+    from setuptools import setup
+    setup_kwargs = dict(zip_safe=0)
 
 else:
-  from distutils.core import setup
-  setup_kwargs = dict()
+    from distutils.core import setup
+    setup_kwargs = dict()
 
 
 storage_dirs = []
 
 for subdir in ('whisper/dummy.txt', 'ceres/dummy.txt', 'rrd/dummy.txt', 'log/dummy.txt', 'log/webapp/dummy.txt'):
-  storage_dirs.append( ('storage/%s' % subdir, []) )
+    storage_dirs.append( ('storage/%s' % subdir, []) )
 
 webapp_content = defaultdict(list)
 
 for root, dirs, files in os.walk('webapp/content'):
-  for filename in files:
-    filepath = os.path.join(root, filename)
-    webapp_content[root].append(filepath)
+    for filename in files:
+        filepath = os.path.join(root, filename)
+        webapp_content[root].append(filepath)
 
 conf_files = [ ('conf', glob('conf/*.example')) ]
 examples = [ ('examples', glob('examples/example-*')) ]

--- a/tox.ini
+++ b/tox.ini
@@ -62,8 +62,8 @@ commands =
 
 [testenv:lint]
 basepython = python3.8
+changedir = {toxinidir}
 deps =
-	flake8
+	flake8==3.7.9
 commands =
-	flake8 --version
-	flake8 --show-source {toxinidir}
+	flake8 --show-source

--- a/webapp/graphite/account/admin.py
+++ b/webapp/graphite/account/admin.py
@@ -3,8 +3,8 @@ from graphite.account.models import Profile,MyGraph
 
 
 class MyGraphAdmin(admin.ModelAdmin):
-  list_display = ('profile','name')
-  list_filter = ('profile',)
+    list_display = ('profile','name')
+    list_filter = ('profile',)
 
 
 admin.site.register(Profile)

--- a/webapp/graphite/account/ldapBackend.py
+++ b/webapp/graphite/account/ldapBackend.py
@@ -20,52 +20,52 @@ from django.contrib.auth.models import User
 
 
 class LDAPBackend:
-  def authenticate(self, username=None, password=None):
-    if settings.LDAP_USER_DN_TEMPLATE is not None:
-      settings.LDAP_BASE_USER = settings.LDAP_USER_DN_TEMPLATE % {'username': username}
-      settings.LDAP_BASE_PASS = password
-    try:
-      conn = ldap.initialize(settings.LDAP_URI)
-      conn.protocol_version = ldap.VERSION3
-      if settings.LDAP_USE_TLS:
-        conn.start_tls_s()
-      conn.simple_bind_s( settings.LDAP_BASE_USER, settings.LDAP_BASE_PASS )
-    except ldap.LDAPError:
-      traceback.print_exc()
-      return None
+    def authenticate(self, username=None, password=None):
+        if settings.LDAP_USER_DN_TEMPLATE is not None:
+            settings.LDAP_BASE_USER = settings.LDAP_USER_DN_TEMPLATE % {'username': username}
+            settings.LDAP_BASE_PASS = password
+        try:
+            conn = ldap.initialize(settings.LDAP_URI)
+            conn.protocol_version = ldap.VERSION3
+            if settings.LDAP_USE_TLS:
+                conn.start_tls_s()
+            conn.simple_bind_s( settings.LDAP_BASE_USER, settings.LDAP_BASE_PASS )
+        except ldap.LDAPError:
+            traceback.print_exc()
+            return None
 
-    scope = ldap.SCOPE_SUBTREE
-    filter = settings.LDAP_USER_QUERY % username
-    returnFields = ['dn','mail']
-    try:
-      resultID = conn.search( settings.LDAP_SEARCH_BASE, scope, filter, returnFields )
-      resultType, resultData = conn.result( resultID, 0 )
-      if len(resultData) != 1: # User does not exist
-        return None
+        scope = ldap.SCOPE_SUBTREE
+        filter = settings.LDAP_USER_QUERY % username
+        returnFields = ['dn','mail']
+        try:
+            resultID = conn.search( settings.LDAP_SEARCH_BASE, scope, filter, returnFields )
+            resultType, resultData = conn.result( resultID, 0 )
+            if len(resultData) != 1: # User does not exist
+                return None
 
-      userDN = resultData[0][0]
-      try:
-        userMail = resultData[0][1]['mail'][0].decode("utf-8")
-      except Exception:
-        userMail = "Unknown"
+            userDN = resultData[0][0]
+            try:
+                userMail = resultData[0][1]['mail'][0].decode("utf-8")
+            except Exception:
+                userMail = "Unknown"
 
-      conn.simple_bind_s(userDN,password)
-      try:
-        user = User.objects.get(username=username)
-      except Exception:  # First time login, not in django's database
-        # To prevent login from django db user
-        randomPasswd = User.objects.make_random_password(length=16)
-        user = User.objects.create_user(username, userMail, randomPasswd)
-        user.save()
+            conn.simple_bind_s(userDN,password)
+            try:
+                user = User.objects.get(username=username)
+            except Exception:  # First time login, not in django's database
+                # To prevent login from django db user
+                randomPasswd = User.objects.make_random_password(length=16)
+                user = User.objects.create_user(username, userMail, randomPasswd)
+                user.save()
 
-      return user
+            return user
 
-    except ldap.INVALID_CREDENTIALS:
-      traceback.print_exc()
-      return None
+        except ldap.INVALID_CREDENTIALS:
+            traceback.print_exc()
+            return None
 
-  def get_user(self,user_id):
-    try:
-      return User.objects.get(pk=user_id)
-    except User.DoesNotExist:
-      return None
+    def get_user(self,user_id):
+        try:
+            return User.objects.get(pk=user_id)
+        except User.DoesNotExist:
+            return None

--- a/webapp/graphite/account/models.py
+++ b/webapp/graphite/account/models.py
@@ -17,35 +17,35 @@ from django.contrib.auth import models as auth_models
 
 
 class Profile(models.Model):
-  user = models.OneToOneField(auth_models.User, on_delete=models.CASCADE)
-  history = models.TextField(default="")
-  advancedUI = models.BooleanField(default=False)
-  __str__ = lambda self: "Profile for %s" % self.user
+    user = models.OneToOneField(auth_models.User, on_delete=models.CASCADE)
+    history = models.TextField(default="")
+    advancedUI = models.BooleanField(default=False)
+    __str__ = lambda self: "Profile for %s" % self.user
 
 
 class Variable(models.Model):
-  profile = models.ForeignKey(Profile, on_delete=models.CASCADE)
-  name = models.CharField(max_length=64)
-  value = models.CharField(max_length=64)
+    profile = models.ForeignKey(Profile, on_delete=models.CASCADE)
+    name = models.CharField(max_length=64)
+    value = models.CharField(max_length=64)
 
 
 class View(models.Model):
-  profile = models.ForeignKey(Profile, on_delete=models.CASCADE)
-  name = models.CharField(max_length=64)
+    profile = models.ForeignKey(Profile, on_delete=models.CASCADE)
+    name = models.CharField(max_length=64)
 
 
 class Window(models.Model):
-  view = models.ForeignKey(View, on_delete=models.CASCADE)
-  name = models.CharField(max_length=64)
-  top = models.IntegerField()
-  left = models.IntegerField()
-  width = models.IntegerField()
-  height = models.IntegerField()
-  url = models.TextField()
-  interval = models.IntegerField(null=True)
+    view = models.ForeignKey(View, on_delete=models.CASCADE)
+    name = models.CharField(max_length=64)
+    top = models.IntegerField()
+    left = models.IntegerField()
+    width = models.IntegerField()
+    height = models.IntegerField()
+    url = models.TextField()
+    interval = models.IntegerField(null=True)
 
 
 class MyGraph(models.Model):
-  profile = models.ForeignKey(Profile, on_delete=models.CASCADE)
-  name = models.CharField(max_length=64)
-  url = models.TextField()
+    profile = models.ForeignKey(Profile, on_delete=models.CASCADE)
+    name = models.CharField(max_length=64)
+    url = models.TextField()

--- a/webapp/graphite/account/views.py
+++ b/webapp/graphite/account/views.py
@@ -23,42 +23,42 @@ from graphite.user_util import getProfile, isAuthenticated
 
 
 def loginView(request):
-  username = request.POST.get('username')
-  password = request.POST.get('password')
-  if request.method == 'GET':
-    nextPage = request.GET.get('nextPage', reverse('browser'))
-  else:
-    nextPage = request.POST.get('nextPage', reverse('browser'))
-  if username and password:
-    user = authenticate(username=username,password=password)
-    if user is None:
-      return render(request, "login.html",{'authenticationFailed' : True, 'nextPage' : nextPage})
-    elif not user.is_active:
-      return render(request, "login.html",{'accountDisabled' : True, 'nextPage' : nextPage})
+    username = request.POST.get('username')
+    password = request.POST.get('password')
+    if request.method == 'GET':
+        nextPage = request.GET.get('nextPage', reverse('browser'))
     else:
-      login(request,user)
-      return HttpResponseRedirect(nextPage)
-  else:
-    return render(request, "login.html",{'nextPage' : nextPage})
+        nextPage = request.POST.get('nextPage', reverse('browser'))
+    if username and password:
+        user = authenticate(username=username,password=password)
+        if user is None:
+            return render(request, "login.html",{'authenticationFailed' : True, 'nextPage' : nextPage})
+        elif not user.is_active:
+            return render(request, "login.html",{'accountDisabled' : True, 'nextPage' : nextPage})
+        else:
+            login(request,user)
+            return HttpResponseRedirect(nextPage)
+    else:
+        return render(request, "login.html",{'nextPage' : nextPage})
 
 
 def logoutView(request):
-  nextPage = request.GET.get('nextPage', reverse('browser'))
-  logout(request)
-  return HttpResponseRedirect(nextPage)
+    nextPage = request.GET.get('nextPage', reverse('browser'))
+    logout(request)
+    return HttpResponseRedirect(nextPage)
 
 
 def editProfile(request):
-  if not isAuthenticated(request.user):
-    return HttpResponseRedirect(reverse('browser'))
-  context = { 'profile' : getProfile(request) }
-  return render(request, "editProfile.html",context)
+    if not isAuthenticated(request.user):
+        return HttpResponseRedirect(reverse('browser'))
+    context = { 'profile' : getProfile(request) }
+    return render(request, "editProfile.html",context)
 
 
 def updateProfile(request):
-  profile = getProfile(request,allowDefault=False)
-  if profile:
-    profile.advancedUI = request.POST.get('advancedUI','off') == 'on'
-    profile.save()
-  nextPage = request.POST.get('nextPage', reverse('browser'))
-  return HttpResponseRedirect(nextPage)
+    profile = getProfile(request,allowDefault=False)
+    if profile:
+        profile.advancedUI = request.POST.get('advancedUI','off') == 'on'
+        profile.save()
+    nextPage = request.POST.get('nextPage', reverse('browser'))
+    return HttpResponseRedirect(nextPage)

--- a/webapp/graphite/carbonlink.py
+++ b/webapp/graphite/carbonlink.py
@@ -12,190 +12,190 @@ from graphite.singleton import ThreadSafeSingleton
 
 
 try:
-  import six.moves.cPickle as pickle
+    import six.moves.cPickle as pickle
 except ImportError:
-  import pickle
+    import pickle
 
 
 def load_keyfunc():
-  if settings.CARBONLINK_HASHING_KEYFUNC:
-    module_path, func_name = settings.CARBONLINK_HASHING_KEYFUNC.rsplit(':', 1)
-    log.cache("Using keyfunc %s found in %s" % (str(func_name), str(module_path)))
-    return load_module(module_path, member=func_name)
-  else:
-    return lambda x: x
+    if settings.CARBONLINK_HASHING_KEYFUNC:
+        module_path, func_name = settings.CARBONLINK_HASHING_KEYFUNC.rsplit(':', 1)
+        log.cache("Using keyfunc %s found in %s" % (str(func_name), str(module_path)))
+        return load_module(module_path, member=func_name)
+    else:
+        return lambda x: x
 
 
 class CarbonLinkRequestError(Exception):
-  pass
+    pass
 
 
 class CarbonLinkPool(object):
-  def __init__(self, hosts, timeout):
-    self.hosts = [ (server, instance) for (server, port, instance) in hosts ]
-    self.ports = dict(
-      ((server, instance), port) for (server, port, instance) in hosts )
-    self.timeout = float(timeout)
-    servers = set([server for (server, port, instance) in hosts])
-    if len(servers) < settings.REPLICATION_FACTOR:
-      raise Exception("REPLICATION_FACTOR=%d cannot exceed servers=%d" % (
-        settings.REPLICATION_FACTOR, len(servers)))
+    def __init__(self, hosts, timeout):
+        self.hosts = [ (server, instance) for (server, port, instance) in hosts ]
+        self.ports = { (server, instance): port for (server, port, instance) in hosts }
+        self.timeout = float(timeout)
+        servers = set([server for (server, port, instance) in hosts])
+        if len(servers) < settings.REPLICATION_FACTOR:
+            raise Exception("REPLICATION_FACTOR=%d cannot exceed servers=%d" % (
+                settings.REPLICATION_FACTOR, len(servers)))
 
-    self.hash_ring = ConsistentHashRing(
-      self.hosts, hash_type=settings.CARBONLINK_HASHING_TYPE)
-    self.keyfunc = load_keyfunc()
-    self.connections = {}
-    self.last_failure = {}
-    # Create a connection pool for each host
-    for host in self.hosts:
-      self.connections[host] = set()
+        self.hash_ring = ConsistentHashRing(
+            self.hosts, hash_type=settings.CARBONLINK_HASHING_TYPE)
+        self.keyfunc = load_keyfunc()
+        self.connections = {}
+        self.last_failure = {}
+        # Create a connection pool for each host
+        for host in self.hosts:
+            self.connections[host] = set()
 
-  def select_host(self, metric):
-    "Returns the carbon host that has data for the given metric"
-    key = self.keyfunc(metric)
-    nodes = []
-    servers = set()
-    for node in self.hash_ring.get_nodes(key):
-      (server, instance) = node
-      if server in servers:
-        continue
-      servers.add(server)
-      nodes.append(node)
-      if len(servers) >= settings.REPLICATION_FACTOR:
-        break
+    def select_host(self, metric):
+        "Returns the carbon host that has data for the given metric"
+        key = self.keyfunc(metric)
+        nodes = []
+        servers = set()
+        for node in self.hash_ring.get_nodes(key):
+            (server, instance) = node
+            if server in servers:
+                continue
+            servers.add(server)
+            nodes.append(node)
+            if len(servers) >= settings.REPLICATION_FACTOR:
+                break
 
-    available = [ n for n in nodes if self.is_available(n) ]
-    return random.choice(available or nodes)
+        available = [ n for n in nodes if self.is_available(n) ]
+        return random.choice(available or nodes)
 
-  def is_available(self, host):
-    now = time.time()
-    last_fail = self.last_failure.get(host, 0)
-    return (now - last_fail) < settings.CARBONLINK_RETRY_DELAY
+    def is_available(self, host):
+        now = time.time()
+        last_fail = self.last_failure.get(host, 0)
+        return (now - last_fail) < settings.CARBONLINK_RETRY_DELAY
 
-  def get_connection(self, host):
-    # First try to take one out of the pool for this host
-    (server, instance) = host
-    port = self.ports[host]
-    connectionPool = self.connections[host]
-    try:
-      return connectionPool.pop()
-    except KeyError:
-      pass #nothing left in the pool, gotta make a new connection
+    def get_connection(self, host):
+        # First try to take one out of the pool for this host
+        (server, instance) = host
+        port = self.ports[host]
+        connectionPool = self.connections[host]
+        try:
+            return connectionPool.pop()
+        except KeyError:
+            pass #nothing left in the pool, gotta make a new connection
 
-    log.cache("CarbonLink creating a new socket for %s" % str(host))
-    try:
-      connection = socket.create_connection((server, port), self.timeout)
-    except socket.error:
-      self.last_failure[host] = time.time()
-      raise
-    else:
-      connection.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-      return connection
-
-  def query(self, metric):
-    request = dict(type='cache-query', metric=metric)
-    results = self.send_request(request)
-    log.cache("CarbonLink cache-query request for %s returned %d datapoints" % (
-      metric, len(results['datapoints'])))
-    return results['datapoints']
-
-  def get_metadata(self, metric, key):
-    request = dict(type='get-metadata', metric=metric, key=key)
-    results = self.send_request(request)
-    log.cache("CarbonLink get-metadata request received for %s:%s" % (metric, key))
-    return results['value']
-
-  def set_metadata(self, metric, key, value):
-    request = dict(type='set-metadata', metric=metric, key=key, value=value)
-    results = self.send_request(request)
-    log.cache("CarbonLink set-metadata request received for %s:%s" % (metric, key))
-    return results
-
-  def send_request(self, request):
-    metric = request['metric']
-    serialized_request = pickle.dumps(request, protocol=-1)
-    len_prefix = struct.pack("!L", len(serialized_request))
-    request_packet = len_prefix + serialized_request
-    result = {}
-    result.setdefault('datapoints', [])
-
-    if metric.startswith(settings.CARBON_METRIC_PREFIX):
-      return self.send_request_to_all(request)
-
-    if not self.hosts:
-      log.cache("CarbonLink is not connected to any host. Returning empty nodes list")
-      return result
-
-    host = self.select_host(metric)
-    conn = self.get_connection(host)
-    log.cache("CarbonLink sending request for %s to %s" % (metric, str(host)))
-    try:
-      conn.sendall(request_packet)
-      result = self.recv_response(conn)
-    except Exception as e:
-      self.last_failure[host] = time.time()
-      log.cache("Exception getting data from cache %s: %s" % (str(host), e))
-    else:
-      self.connections[host].add(conn)
-      if 'error' in result:
-        log.cache("Error getting data from cache: %s" % result['error'])
-        raise CarbonLinkRequestError(result['error'])
-      log.cache("CarbonLink finished receiving %s from %s" % (str(metric), str(host)))
-    return result
-
-  def send_request_to_all(self, request):
-    metric = request['metric']
-    serialized_request = pickle.dumps(request, protocol=-1)
-    len_prefix = struct.pack("!L", len(serialized_request))
-    request_packet = len_prefix + serialized_request
-    results = {}
-    results.setdefault('datapoints', {})
-
-    for host in self.hosts:
-      conn = self.get_connection(host)
-      log.cache("CarbonLink sending request for %s to %s" % (metric, str(host)))
-      try:
-        conn.sendall(request_packet)
-        result = self.recv_response(conn)
-      except Exception as e:
-        self.last_failure[host] = time.time()
-        log.cache("Exception getting data from cache %s: %s" % (str(host), e))
-      else:
-        self.connections[host].add(conn)
-        if 'error' in result:
-          log.cache("Error getting data from cache %s: %s" % (str(host), result['error']))
+        log.cache("CarbonLink creating a new socket for %s" % str(host))
+        try:
+            connection = socket.create_connection((server, port), self.timeout)
+        except socket.error:
+            self.last_failure[host] = time.time()
+            raise
         else:
-          if len(result['datapoints']) > 1:
-              results['datapoints'].update(result['datapoints'])
-      log.cache("CarbonLink finished receiving %s from %s" % (str(metric), str(host)))
-    return results
+            connection.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+            return connection
 
-  def recv_response(self, conn):
-    len_prefix = self.recv_exactly(conn, 4)
-    body_size = struct.unpack("!L", len_prefix)[0]
-    body = self.recv_exactly(conn, body_size)
-    return unpickle.loads(body)
+    def query(self, metric):
+        request = dict(type='cache-query', metric=metric)
+        results = self.send_request(request)
+        log.cache("CarbonLink cache-query request for %s returned %d datapoints" % (
+            metric, len(results['datapoints'])))
+        return results['datapoints']
 
-  @staticmethod
-  def recv_exactly(conn, num_bytes):
-    buf = b''
-    while len(buf) < num_bytes:
-      data = conn.recv(num_bytes - len(buf))
-      if not data:
-        raise Exception("Connection lost")
-      buf += data
+    def get_metadata(self, metric, key):
+        request = dict(type='get-metadata', metric=metric, key=key)
+        results = self.send_request(request)
+        log.cache("CarbonLink get-metadata request received for %s:%s" % (metric, key))
+        return results['value']
 
-    return buf
+    def set_metadata(self, metric, key, value):
+        request = dict(type='set-metadata', metric=metric, key=key, value=value)
+        results = self.send_request(request)
+        log.cache("CarbonLink set-metadata request received for %s:%s" % (metric, key))
+        return results
+
+    def send_request(self, request):
+        metric = request['metric']
+        serialized_request = pickle.dumps(request, protocol=-1)
+        len_prefix = struct.pack("!L", len(serialized_request))
+        request_packet = len_prefix + serialized_request
+        result = {}
+        result.setdefault('datapoints', [])
+
+        if metric.startswith(settings.CARBON_METRIC_PREFIX):
+            return self.send_request_to_all(request)
+
+        if not self.hosts:
+            log.cache("CarbonLink is not connected to any host. Returning empty nodes list")
+            return result
+
+        host = self.select_host(metric)
+        conn = self.get_connection(host)
+        log.cache("CarbonLink sending request for %s to %s" % (metric, str(host)))
+        try:
+            conn.sendall(request_packet)
+            result = self.recv_response(conn)
+        except Exception as e:
+            self.last_failure[host] = time.time()
+            log.cache("Exception getting data from cache %s: %s" % (str(host), e))
+        else:
+            self.connections[host].add(conn)
+            if 'error' in result:
+                log.cache("Error getting data from cache: %s" % result['error'])
+                raise CarbonLinkRequestError(result['error'])
+            log.cache("CarbonLink finished receiving %s from %s" % (str(metric), str(host)))
+        return result
+
+    def send_request_to_all(self, request):
+        metric = request['metric']
+        serialized_request = pickle.dumps(request, protocol=-1)
+        len_prefix = struct.pack("!L", len(serialized_request))
+        request_packet = len_prefix + serialized_request
+        results = {}
+        results.setdefault('datapoints', {})
+
+        for host in self.hosts:
+            conn = self.get_connection(host)
+            log.cache("CarbonLink sending request for %s to %s" % (metric, str(host)))
+            try:
+                conn.sendall(request_packet)
+                result = self.recv_response(conn)
+            except Exception as e:
+                self.last_failure[host] = time.time()
+                log.cache("Exception getting data from cache %s: %s" % (str(host), e))
+            else:
+                self.connections[host].add(conn)
+                if 'error' in result:
+                    log.cache("Error getting data from cache %s: %s" % (str(host), result['error']))
+                else:
+                    if len(result['datapoints']) > 1:
+                        results['datapoints'].update(result['datapoints'])
+            log.cache("CarbonLink finished receiving %s from %s" % (str(metric), str(host)))
+
+        return results
+
+    def recv_response(self, conn):
+        len_prefix = self.recv_exactly(conn, 4)
+        body_size = struct.unpack("!L", len_prefix)[0]
+        body = self.recv_exactly(conn, body_size)
+        return unpickle.loads(body)
+
+    @staticmethod
+    def recv_exactly(conn, num_bytes):
+        buf = b''
+        while len(buf) < num_bytes:
+            data = conn.recv(num_bytes - len(buf))
+            if not data:
+                raise Exception("Connection lost")
+            buf += data
+
+        return buf
 
 
 @ThreadSafeSingleton
 class GlobalCarbonLinkPool(CarbonLinkPool):
-  def __init__(self):
-    hosts = parseHosts(settings.CARBONLINK_HOSTS)
-    timeout = settings.CARBONLINK_TIMEOUT
-    CarbonLinkPool.__init__(self, hosts, timeout)
+    def __init__(self):
+        hosts = parseHosts(settings.CARBONLINK_HOSTS)
+        timeout = settings.CARBONLINK_TIMEOUT
+        CarbonLinkPool.__init__(self, hosts, timeout)
 
 
 def CarbonLink():
-  """Handy accessor for the global singleton."""
-  return GlobalCarbonLinkPool.instance()
+    """Handy accessor for the global singleton."""
+    return GlobalCarbonLinkPool.instance()

--- a/webapp/graphite/composer/views.py
+++ b/webapp/graphite/composer/views.py
@@ -24,60 +24,60 @@ from django.core.exceptions import ObjectDoesNotExist
 
 
 def composer(request):
-  profile = getProfile(request)
-  context = {
-    'queryString' : request.GET.urlencode().replace('+','%20'),
-    'showTarget' : request.GET.get('showTarget',''),
-    'user' : request.user,
-    'profile' : profile,
-    'showMyGraphs' : int( profile.user.username != 'default' ),
-    'searchEnabled' : int( os.access(settings.INDEX_FILE, os.R_OK) ),
-    'refreshInterval': settings.AUTO_REFRESH_INTERVAL,
-    'debug' : settings.DEBUG,
-    'jsdebug' : settings.DEBUG,
-  }
-  return render(request, "composer.html",context)
+    profile = getProfile(request)
+    context = {
+        'queryString' : request.GET.urlencode().replace('+','%20'),
+        'showTarget' : request.GET.get('showTarget',''),
+        'user' : request.user,
+        'profile' : profile,
+        'showMyGraphs' : int( profile.user.username != 'default' ),
+        'searchEnabled' : int( os.access(settings.INDEX_FILE, os.R_OK) ),
+        'refreshInterval': settings.AUTO_REFRESH_INTERVAL,
+        'debug' : settings.DEBUG,
+        'jsdebug' : settings.DEBUG,
+    }
+    return render(request, "composer.html", context)
 
 
 def mygraph(request):
-  profile = getProfile(request, allowDefault=False)
+    profile = getProfile(request, allowDefault=False)
 
-  if not profile:
-    return HttpResponse( "You are not logged in!" )
+    if not profile:
+        return HttpResponse("You are not logged in!")
 
-  action = request.GET['action']
-  graphName = request.GET['graphName']
+    action = request.GET['action']
+    graphName = request.GET['graphName']
 
-  if not graphName:
-    return HttpResponse("You must type in a graph name.")
+    if not graphName:
+        return HttpResponse("You must type in a graph name.")
 
-  if action == 'save':
-    url = request.GET['url']
+    if action == 'save':
+        url = request.GET['url']
 
-    try:
-      existingGraph = profile.mygraph_set.get(name=graphName)
-      existingGraph.url = url
-      existingGraph.save()
+        try:
+            existingGraph = profile.mygraph_set.get(name=graphName)
+            existingGraph.url = url
+            existingGraph.save()
 
-    except ObjectDoesNotExist:
-      try:
-        newGraph = MyGraph(profile=profile,name=graphName,url=url)
-        newGraph.save()
-      except Exception:
-        log.exception("Failed to create new MyGraph in /composer/mygraph/, graphName=%s" % graphName)
-        return HttpResponse("Failed to save graph %s" % graphName)
+        except ObjectDoesNotExist:
+            try:
+                newGraph = MyGraph(profile=profile,name=graphName,url=url)
+                newGraph.save()
+            except Exception:
+                log.exception("Failed to create new MyGraph in /composer/mygraph/, graphName=%s" % graphName)
+                return HttpResponse("Failed to save graph %s" % graphName)
 
-    return HttpResponse("SAVED")
+        return HttpResponse("SAVED")
 
-  elif action == 'delete':
-    try:
-      existingGraph = profile.mygraph_set.get(name=graphName)
-      existingGraph.delete()
+    elif action == 'delete':
+        try:
+            existingGraph = profile.mygraph_set.get(name=graphName)
+            existingGraph.delete()
 
-    except ObjectDoesNotExist:
-      return HttpResponse("No such graph '%s'" % graphName)
+        except ObjectDoesNotExist:
+            return HttpResponse("No such graph '%s'" % graphName)
 
-    return HttpResponse("DELETED")
+        return HttpResponse("DELETED")
 
-  else:
-    return HttpResponse("Invalid operation '%s'" % action)
+    else:
+        return HttpResponse("Invalid operation '%s'" % action)

--- a/webapp/graphite/dashboard/models.py
+++ b/webapp/graphite/dashboard/models.py
@@ -5,39 +5,39 @@ import six
 
 
 class Dashboard(models.Model):
-  name = models.CharField(primary_key=True, max_length=128)
-  owners = models.ManyToManyField(Profile, related_name='dashboards')
-  state = models.TextField()
-  __str__ = lambda self: "Dashboard [%s]" % self.name
+    name = models.CharField(primary_key=True, max_length=128)
+    owners = models.ManyToManyField(Profile, related_name='dashboards')
+    state = models.TextField()
+    __str__ = lambda self: "Dashboard [%s]" % self.name
 
 
 class Template(models.Model):
 
-  class Admin: pass
-  name = models.CharField(primary_key=True, max_length=128)
-  owners = models.ManyToManyField(Profile, related_name='templates')
-  state = models.TextField()
-  __str__ = lambda self: "Template [%s]" % self.name
+    class Admin: pass
+    name = models.CharField(primary_key=True, max_length=128)
+    owners = models.ManyToManyField(Profile, related_name='templates')
+    state = models.TextField()
+    __str__ = lambda self: "Template [%s]" % self.name
 
-  def loadState(self, val):
-    return self.state.replace('__VALUE__', val)
+    def loadState(self, val):
+        return self.state.replace('__VALUE__', val)
 
-  def setState(self, state, key):
-    #XXX Might not need this
-    def replace_string(s):
-      if isinstance(s, six.text_type):
-        s = s.replace(key, '__VALUE__')
-      return s
+    def setState(self, state, key):
+        #XXX Might not need this
+        def replace_string(s):
+            if isinstance(s, six.text_type):
+                s = s.replace(key, '__VALUE__')
+            return s
 
-    def update_graph(graph):
-      graph_opts = graph[1]
-      graph_opts['target'] = [replace_string(s) for s in graph_opts['target']]
-      return [replace_string(graph[0]),
-              graph_opts,
-              replace_string(graph[2])]
+        def update_graph(graph):
+            graph_opts = graph[1]
+            graph_opts['target'] = [replace_string(s) for s in graph_opts['target']]
+            return [replace_string(graph[0]),
+                    graph_opts,
+                    replace_string(graph[2])]
 
-    # Parse JSON here and replace first five elements of target with __VALUE__
-    parsed_state = json.loads(state)
-    for i, graph in enumerate(parsed_state['graphs']):
-      parsed_state['graphs'][i] = update_graph(graph)
-    self.state = json.dumps(parsed_state)
+        # Parse JSON here and replace first five elements of target with __VALUE__
+        parsed_state = json.loads(state)
+        for i, graph in enumerate(parsed_state['graphs']):
+            parsed_state['graphs'][i] = update_graph(graph)
+        self.state = json.dumps(parsed_state)

--- a/webapp/graphite/errors.py
+++ b/webapp/graphite/errors.py
@@ -2,20 +2,20 @@ from django.http import HttpResponseBadRequest
 
 
 class NormalizeEmptyResultError(Exception):
-  # throw error for normalize() when empty
-  pass
+    # throw error for normalize() when empty
+    pass
 
 
 class InputParameterError(ValueError):
-  pass
+    pass
 
 
 # decorator which turns InputParameterExceptions into Django's HttpResponseBadRequest
 def handleInputParameterError(f):
     def new_f(*args, **kwargs):
-      try:
-        return f(*args, **kwargs)
-      except InputParameterError as e:
-        return HttpResponseBadRequest('Bad Request: {err}'.format(err=e))
+        try:
+            return f(*args, **kwargs)
+        except InputParameterError as e:
+            return HttpResponseBadRequest('Bad Request: {err}'.format(err=e))
 
     return new_f

--- a/webapp/graphite/events/views.py
+++ b/webapp/graphite/events/views.py
@@ -37,11 +37,11 @@ def view_events(request):
 @jsonResponse(encoder=DjangoJSONEncoder)
 def jsonDetail(request, queryParams, event_id):
     try:
-       e = Event.objects.get(id=event_id)
-       e.tags = e.tags.split()
-       return model_to_dict(e)
+        e = Event.objects.get(id=event_id)
+        e.tags = e.tags.split()
+        return model_to_dict(e)
     except ObjectDoesNotExist:
-       raise HttpError('Event matching query does not exist', status=404)
+        raise HttpError('Event matching query does not exist', status=404)
 
 
 def detail(request, event_id):

--- a/webapp/graphite/finders/standard.py
+++ b/webapp/graphite/finders/standard.py
@@ -34,12 +34,12 @@ class StandardFinder(BaseFinder):
         # translate query pattern if it is tagged
         tagged = not query.pattern.startswith('_tagged.') and ';' in query.pattern
         if tagged:
-          # tagged series are stored in whisper using encoded names, so to retrieve them we need to
-          # encode the query pattern using the same scheme used in carbon when they are written.
-          encoded_paths = [
-            TaggedSeries.encode(query.pattern, sep=os.sep, hash_only=True),
-            TaggedSeries.encode(query.pattern, sep=os.sep, hash_only=False),
-          ]
+            # tagged series are stored in whisper using encoded names, so to retrieve them we need to
+            # encode the query pattern using the same scheme used in carbon when they are written.
+            encoded_paths = [
+                TaggedSeries.encode(query.pattern, sep=os.sep, hash_only=True),
+                TaggedSeries.encode(query.pattern, sep=os.sep, hash_only=False),
+            ]
 
         pattern_parts = clean_pattern.split('.')
 
@@ -72,15 +72,15 @@ class StandardFinder(BaseFinder):
 
                 # if we're finding by tag, return the proper metric path
                 if tagged:
-                  metric_path = query.pattern
-                  real_metric_path = query.pattern
+                    metric_path = query.pattern
+                    real_metric_path = query.pattern
                 else:
-                  metric_path = fs_to_metric(relative_path)
-                  real_metric_path = get_real_metric_path(absolute_path, metric_path)
-                  metric_path_parts = metric_path.split('.')
-                  for field_index in find_escaped_pattern_fields(query.pattern):
-                      metric_path_parts[field_index] = pattern_parts[field_index].replace('\\', '')
-                  metric_path = '.'.join(metric_path_parts)
+                    metric_path = fs_to_metric(relative_path)
+                    real_metric_path = get_real_metric_path(absolute_path, metric_path)
+                    metric_path_parts = metric_path.split('.')
+                    for field_index in find_escaped_pattern_fields(query.pattern):
+                        metric_path_parts[field_index] = pattern_parts[field_index].replace('\\', '')
+                    metric_path = '.'.join(metric_path_parts)
 
                 # Now we construct and yield an appropriate Node object
                 if isdir(absolute_path):
@@ -180,26 +180,26 @@ class StandardFinder(BaseFinder):
         matches = []
 
         for root, _, files in walk(settings.WHISPER_DIR):
-          root = root.replace(settings.WHISPER_DIR, '')
-          for base_name in files:
-            if fnmatch.fnmatch(base_name, '*.wsp'):
-              match = join(root, base_name).replace('.wsp', '').replace('/', '.').lstrip('.')
-              bisect.insort_left(matches, match)
+            root = root.replace(settings.WHISPER_DIR, '')
+            for base_name in files:
+                if fnmatch.fnmatch(base_name, '*.wsp'):
+                    match = join(root, base_name).replace('.wsp', '').replace('/', '.').lstrip('.')
+                    bisect.insort_left(matches, match)
 
         # unlike 0.9.x, we're going to use os.walk with followlinks
         # since we require Python 2.7 and newer that supports it
         if RRDReader.supported:
-          for root, _, files in walk(settings.RRD_DIR, followlinks=True):
-            root = root.replace(settings.RRD_DIR, '')
-            for base_name in files:
-              if fnmatch.fnmatch(base_name, '*.rrd'):
-                absolute_path = join(settings.RRD_DIR, root, base_name)
-                base_name = splitext(base_name)[0]
-                metric_path = join(root, base_name)
-                rrd = RRDReader(absolute_path, metric_path)
-                for datasource_name in rrd.get_datasources(absolute_path):
-                  match = join(metric_path, datasource_name).replace('.rrd', '').replace('/', '.').lstrip('.')
-                  if match not in matches:
-                    bisect.insort_left(matches, match)
+            for root, _, files in walk(settings.RRD_DIR, followlinks=True):
+                root = root.replace(settings.RRD_DIR, '')
+                for base_name in files:
+                    if fnmatch.fnmatch(base_name, '*.rrd'):
+                        absolute_path = join(settings.RRD_DIR, root, base_name)
+                        base_name = splitext(base_name)[0]
+                        metric_path = join(root, base_name)
+                        rrd = RRDReader(absolute_path, metric_path)
+                        for datasource_name in rrd.get_datasources(absolute_path):
+                            match = join(metric_path, datasource_name).replace('.rrd', '').replace('/', '.').lstrip('.')
+                            if match not in matches:
+                                bisect.insort_left(matches, match)
 
         return matches

--- a/webapp/graphite/functions/__init__.py
+++ b/webapp/graphite/functions/__init__.py
@@ -18,90 +18,91 @@ _PieFunctions = {}
 
 
 def loadFunctions(force=False):
-  if _SeriesFunctions and not force:
-    return
+    if _SeriesFunctions and not force:
+        return
 
-  from graphite.render import functions
+    from graphite.render import functions
 
-  _SeriesFunctions.clear()
-  _SeriesFunctions.update(functions.SeriesFunctions)
+    _SeriesFunctions.clear()
+    _SeriesFunctions.update(functions.SeriesFunctions)
 
-  _PieFunctions.clear()
-  _PieFunctions.update(functions.PieFunctions)
+    _PieFunctions.clear()
+    _PieFunctions.update(functions.PieFunctions)
 
-  custom_modules = []
-  for filename in listdir(customDir):
-    module_name, extension = splitext(filename)
-    if extension != '.py' or module_name == '__init__':
-      continue
-    custom_modules.append(customModPrefix + module_name)
+    custom_modules = []
+    for filename in listdir(customDir):
+        module_name, extension = splitext(filename)
+        if extension != '.py' or module_name == '__init__':
+            continue
+        custom_modules.append(customModPrefix + module_name)
 
-  for module_name in custom_modules + settings.FUNCTION_PLUGINS:
-    try:
-      module = import_module(module_name)
-    except Exception as e:
-      log.warning('Error loading function plugin %s: %s' % (module_name, e))
-      continue
+    for module_name in custom_modules + settings.FUNCTION_PLUGINS:
+        try:
+            module = import_module(module_name)
+        except Exception as e:
+            log.warning('Error loading function plugin %s: %s' % (module_name, e))
+            continue
 
-    for func_name, func in getattr(module, 'SeriesFunctions', {}).items():
-      try:
-        addFunction(_SeriesFunctions, func, func_name)
-      except Exception as e:
-        log.warning('Error loading function plugin %s: %s' % (module_name, e))
+        for func_name, func in getattr(module, 'SeriesFunctions', {}).items():
+            try:
+                addFunction(_SeriesFunctions, func, func_name)
+            except Exception as e:
+                log.warning('Error loading function plugin %s: %s' % (module_name, e))
 
-    for func_name, func in getattr(module, 'PieFunctions', {}).items():
-      try:
-        addFunction(_PieFunctions, func, func_name)
-      except Exception as e:
-        log.warning('Error loading function plugin %s: %s' % (module_name, e))
+        for func_name, func in getattr(module, 'PieFunctions', {}).items():
+            try:
+                addFunction(_PieFunctions, func, func_name)
+            except Exception as e:
+                log.warning('Error loading function plugin %s: %s' % (module_name, e))
 
 
 def addFunction(dest, func, func_name):
-  if not hasattr(func, 'group'):
-    func.group = 'Ungrouped'
+    if not hasattr(func, 'group'):
+        func.group = 'Ungrouped'
 
-  if not hasattr(func, 'params'):
-    raise Exception('No params defined for %s' % func_name)
+    if not hasattr(func, 'params'):
+        raise Exception('No params defined for %s' % func_name)
 
-  for param in func.params:
-    if not isinstance(param, Param):
-      raise Exception('Invalid param specified for %s' % func_name)
-    dest[func_name] = func
+    for param in func.params:
+        if not isinstance(param, Param):
+            raise Exception('Invalid param specified for %s' % func_name)
+        dest[func_name] = func
 
 
 def SeriesFunctions():
-  loadFunctions()
-  return _SeriesFunctions
+    loadFunctions()
+    return _SeriesFunctions
 
 
 def SeriesFunction(name):
-  loadFunctions()
-  try:
-    return _SeriesFunctions[name]
-  except KeyError:
-    raise KeyError('Function "%s" not found' % name)
+    loadFunctions()
+    try:
+        return _SeriesFunctions[name]
+    except KeyError:
+        raise KeyError('Function "%s" not found' % name)
 
 
 def PieFunctions():
-  loadFunctions()
-  return _PieFunctions
+    loadFunctions()
+    return _PieFunctions
 
 
 def PieFunction(name):
-  loadFunctions()
-  try:
-    return _PieFunctions[name]
-  except KeyError:
-    raise KeyError('Function "%s" not found' % name)
+    loadFunctions()
+    try:
+        return _PieFunctions[name]
+    except KeyError:
+        raise KeyError('Function "%s" not found' % name)
 
 
 def functionInfo(name, func):
-  argspec = inspect.getargspec(func)
-  return {
-    'name': name,
-    'function': name + inspect.formatargspec(argspec[0][1:], argspec[1], argspec[2], argspec[3]),
-    'description': inspect.getdoc(func),
-    'module': inspect.getmodule(func).__name__,
-    'group': getattr(func, 'group', 'Ungrouped'),
-    'params': getattr(func, 'params', None),
-  }
+    argspec = inspect.getargspec(func)
+    argformat = inspect.formatargspec(argspec[0][1:], argspec[1], argspec[2], argspec[3])
+    return {
+        'name': name,
+        'function': name + argformat,
+        'description': inspect.getdoc(func),
+        'module': inspect.getmodule(func).__name__,
+        'group': getattr(func, 'group', 'Ungrouped'),
+        'params': getattr(func, 'params', None),
+    }

--- a/webapp/graphite/functions/aggfuncs.py
+++ b/webapp/graphite/functions/aggfuncs.py
@@ -27,8 +27,8 @@ aggFuncAliases = {
 
 
 def getAggFunc(func, rawFunc=None):
-  if func in aggFuncs:
-    return aggFuncs[func]
-  if func in aggFuncAliases:
-    return aggFuncAliases[func]
-  raise InputParameterError('Unsupported aggregation function: %s' % (rawFunc or func))
+    if func in aggFuncs:
+        return aggFuncs[func]
+    if func in aggFuncAliases:
+        return aggFuncAliases[func]
+    raise InputParameterError('Unsupported aggregation function: %s' % (rawFunc or func))

--- a/webapp/graphite/functions/safe.py
+++ b/webapp/graphite/functions/safe.py
@@ -6,27 +6,27 @@ import math
 
 
 def safeSum(values):
-  safeValues = [v for v in values if v is not None]
-  if safeValues:
-    return sum(safeValues)
+    safeValues = [v for v in values if v is not None]
+    if safeValues:
+        return sum(safeValues)
 
 
 def safeDiff(values):
-  safeValues = [v for v in values if v is not None]
-  if safeValues:
-    values = list(map(lambda x: x*-1, safeValues[1:]))
-    values.insert(0, safeValues[0])
-    return sum(values)
+    safeValues = [v for v in values if v is not None]
+    if safeValues:
+        values = list(map(lambda x: x*-1, safeValues[1:]))
+        values.insert(0, safeValues[0])
+        return sum(values)
 
 
 def safeLen(values):
-  return len([v for v in values if v is not None])
+    return len([v for v in values if v is not None])
 
 
 def safeDiv(a, b):
-  if a is None: return None
-  if b in (0,None): return None
-  return a / b
+    if a is None: return None
+    if b in (0,None): return None
+    return a / b
 
 
 def safeExp(a):
@@ -37,90 +37,93 @@ def safeExp(a):
 
 
 def safePow(a, b):
-  if a is None: return None
-  if b is None: return None
-  try:
-    result = math.pow(a, b)
-  except (ValueError, OverflowError):
-    return None
-  return result
+    if a is None or b is None:
+        return None
+    try:
+        result = math.pow(a, b)
+    except (ValueError, OverflowError):
+        return None
+    return result
 
 
 def safeMul(*factors):
-  if None in factors:
-    return None
+    if None in factors:
+        return None
 
-  factors = [float(x) for x in factors]
-  product = reduce(lambda x,y: x*y, factors)
-  return product
+    factors = [float(x) for x in factors]
+    product = reduce(lambda x,y: x*y, factors)
+    return product
 
 
 def safeSubtract(a,b):
-    if a is None or b is None: return None
+    if a is None or b is None:
+        return None
     return float(a) - float(b)
 
 
 def safeAvg(values):
-  safeValues = [v for v in values if v is not None]
-  if safeValues:
-    return sum(safeValues) / len(safeValues)
+    safeValues = [v for v in values if v is not None]
+    if safeValues:
+        return sum(safeValues) / len(safeValues)
 
 
 def safeAvgZero(values):
-  if values:
-    return sum([0 if v is None else v for v in values]) / len(values)
+    if values:
+        return sum([0 if v is None else v for v in values]) / len(values)
 
 
 def safeMedian(values):
-  safeValues = [v for v in values if v is not None]
-  if safeValues:
-    sortedVals = sorted(safeValues)
-    mid = len(sortedVals) // 2
-    if len(sortedVals) % 2 == 0:
-      return float(sortedVals[mid-1] + sortedVals[mid]) / 2
-    else:
-      return sortedVals[mid]
+    safeValues = [v for v in values if v is not None]
+    if safeValues:
+        sortedVals = sorted(safeValues)
+        mid = len(sortedVals) // 2
+        if len(sortedVals) % 2 == 0:
+            return float(sortedVals[mid-1] + sortedVals[mid]) / 2
+        else:
+            return sortedVals[mid]
 
 
 def safeStdDev(a):
-  sm = safeSum(a)
-  ln = safeLen(a)
-  avg = safeDiv(sm,ln)
-  if avg is None: return None
-  sum = 0
-  safeValues = [v for v in a if v is not None]
-  for val in safeValues:
-     sum = sum + (val - avg) * (val - avg)
-  return math.sqrt(sum/ln)
+    sm = safeSum(a)
+    ln = safeLen(a)
+    avg = safeDiv(sm,ln)
+    if avg is None:
+        return None
+    sum = 0
+    safeValues = [v for v in a if v is not None]
+    for val in safeValues:
+        sum = sum + (val - avg) * (val - avg)
+    return math.sqrt(sum/ln)
 
 
 def safeLast(values):
-  for v in reversed(values):
-    if v is not None: return v
+    for v in reversed(values):
+        if v is not None: return v
 
 
 def safeMin(values, default=None):
-  safeValues = [v for v in values if v is not None]
-  if safeValues:
-    return min(safeValues)
-  else:
-    return default
+    safeValues = [v for v in values if v is not None]
+    if safeValues:
+        return min(safeValues)
+    else:
+        return default
 
 
 def safeMax(values, default=None):
-  safeValues = [v for v in values if v is not None]
-  if safeValues:
-    return max(safeValues)
-  else:
-    return default
+    safeValues = [v for v in values if v is not None]
+    if safeValues:
+        return max(safeValues)
+    else:
+        return default
 
 
 def safeMap(function, values):
-  safeValues = [v for v in values if v is not None]
-  if safeValues:
-    return [function(x) for x in safeValues]
+    safeValues = [v for v in values if v is not None]
+    if safeValues:
+        return [function(x) for x in safeValues]
 
 
 def safeAbs(value):
-  if value is None: return None
-  return abs(value)
+    if value is None:
+        return None
+    return abs(value)

--- a/webapp/graphite/functions/views.py
+++ b/webapp/graphite/functions/views.py
@@ -3,51 +3,51 @@ from graphite.functions import SeriesFunctions, SeriesFunction, PieFunctions, Pi
 
 
 def jsonEncoder(obj):
-  if hasattr(obj, 'toJSON'):
-    return obj.toJSON()
-  return obj.__dict__
+    if hasattr(obj, 'toJSON'):
+        return obj.toJSON()
+    return obj.__dict__
 
 
 @jsonResponse(default=jsonEncoder)
 def functionList(request, queryParams):
-  if request.method != 'GET':
-    return HttpResponse(status=405)
+    if request.method != 'GET':
+        return HttpResponse(status=405)
 
-  if queryParams.get('type') == 'pie':
-    funcs = PieFunctions()
-  else:
-    funcs = SeriesFunctions()
-
-  grouped = queryParams.get('grouped', '').lower() in ['1', 'true']
-  group = queryParams.get('group')
-  result = {}
-
-  for (name, func) in funcs.items():
-    info = functionInfo(name, func)
-    if group is not None and group != info['group']:
-      continue
-
-    if grouped:
-      if info['group'] not in result:
-        result[info['group']] = {}
-      result[info['group']][name] = info
+    if queryParams.get('type') == 'pie':
+        funcs = PieFunctions()
     else:
-      result[name] = info
+        funcs = SeriesFunctions()
 
-  return result
+    grouped = queryParams.get('grouped', '').lower() in ['1', 'true']
+    group = queryParams.get('group')
+    result = {}
+
+    for (name, func) in funcs.items():
+        info = functionInfo(name, func)
+        if group is not None and group != info['group']:
+            continue
+
+        if grouped:
+            if info['group'] not in result:
+                result[info['group']] = {}
+            result[info['group']][name] = info
+        else:
+            result[name] = info
+
+    return result
 
 
 @jsonResponse(default=jsonEncoder)
 def functionDetails(request, queryParams, name):
-  if request.method != 'GET':
-    return HttpResponse(status=405)
+    if request.method != 'GET':
+        return HttpResponse(status=405)
 
-  try:
-    if queryParams.get('type') == 'pie':
-      func = PieFunction(name)
-    else:
-      func = SeriesFunction(name)
-  except KeyError:
-    raise HttpError('Function not found: %s' % name, status=404)
+    try:
+        if queryParams.get('type') == 'pie':
+            func = PieFunction(name)
+        else:
+            func = SeriesFunction(name)
+    except KeyError:
+        raise HttpError('Function not found: %s' % name, status=404)
 
-  return functionInfo(name, func)
+    return functionInfo(name, func)

--- a/webapp/graphite/intervals.py
+++ b/webapp/graphite/intervals.py
@@ -3,153 +3,153 @@ NEGATIVE_INFINITY = -INFINITY
 
 
 class IntervalSet:
-  __slots__ = ('intervals', 'size')
+    __slots__ = ('intervals', 'size')
 
-  def __init__(self, intervals, disjoint=False):
-    self.intervals = intervals
+    def __init__(self, intervals, disjoint=False):
+        self.intervals = intervals
 
-    if not disjoint:
-      self.intervals = union_overlapping(self.intervals)
+        if not disjoint:
+            self.intervals = union_overlapping(self.intervals)
 
-    self.size = sum(i.size for i in self.intervals)
+        self.size = sum(i.size for i in self.intervals)
 
-  def __repr__(self):
-    return repr(self.intervals)
+    def __repr__(self):
+        return repr(self.intervals)
 
-  def __iter__(self):
-    return iter(self.intervals)
+    def __iter__(self):
+        return iter(self.intervals)
 
-  def __len__(self):
-    return len(self.intervals)
+    def __len__(self):
+        return len(self.intervals)
 
-  def __getitem__(self, i):
-    return self.intervals[i]
+    def __getitem__(self, i):
+        return self.intervals[i]
 
-  def __nonzero__(self):
-    return self.size != 0
+    def __nonzero__(self):
+        return self.size != 0
 
-  def __sub__(self, other):
-    return self.intersect( other.complement() )
+    def __sub__(self, other):
+        return self.intersect( other.complement() )
 
-  def complement(self):
-    complementary = []
-    cursor = NEGATIVE_INFINITY
+    def complement(self):
+        complementary = []
+        cursor = NEGATIVE_INFINITY
 
-    for interval in self.intervals:
-      if cursor < interval.start:
-        complementary.append( Interval(cursor, interval.start) )
-        cursor = interval.end
+        for interval in self.intervals:
+            if cursor < interval.start:
+                complementary.append( Interval(cursor, interval.start) )
+                cursor = interval.end
 
-    if cursor < INFINITY:
-      complementary.append( Interval(cursor, INFINITY) )
+        if cursor < INFINITY:
+            complementary.append( Interval(cursor, INFINITY) )
 
-    return IntervalSet(complementary, disjoint=True)
+        return IntervalSet(complementary, disjoint=True)
 
-  def intersect(self, other): #XXX The last major bottleneck. Factorial-time hell.
-    # Then again, this function is entirely unused...
-    if (not self) or (not other):
-      return IntervalSet([])
+    def intersect(self, other): #XXX The last major bottleneck. Factorial-time hell.
+        # Then again, this function is entirely unused...
+        if (not self) or (not other):
+            return IntervalSet([])
 
-    #earliest = max(self.intervals[0].start, other.intervals[0].start)
-    #latest = min(self.intervals[-1].end, other.intervals[-1].end)
+        #earliest = max(self.intervals[0].start, other.intervals[0].start)
+        #latest = min(self.intervals[-1].end, other.intervals[-1].end)
 
-    #mine = [i for i in self.intervals if i.start >= earliest and i.end <= latest]
-    #theirs = [i for i in other.intervals if i.start >= earliest and i.end <= latest]
+        #mine = [i for i in self.intervals if i.start >= earliest and i.end <= latest]
+        #theirs = [i for i in other.intervals if i.start >= earliest and i.end <= latest]
 
-    intersections = [x for x in (i.intersect(j)
-                                 for i in self.intervals
-                                 for j in other.intervals)
-                     if x]
+        intersections = [x for x in (i.intersect(j)
+                                     for i in self.intervals
+                                     for j in other.intervals)
+                         if x]
 
-    return IntervalSet(intersections, disjoint=True)
+        return IntervalSet(intersections, disjoint=True)
 
-  def intersect_interval(self, interval):
-    intersections = [x for x in (i.intersect(interval)
-                                 for i in self.intervals)
-                     if x]
-    return IntervalSet(intersections, disjoint=True)
+    def intersect_interval(self, interval):
+        intersections = [x for x in (i.intersect(interval)
+                                     for i in self.intervals)
+                         if x]
+        return IntervalSet(intersections, disjoint=True)
 
-  def union(self, other):
-    return IntervalSet( sorted(self.intervals + other.intervals) )
+    def union(self, other):
+        return IntervalSet( sorted(self.intervals + other.intervals) )
 
 
 class Interval:
-  __slots__ = ('start', 'end', 'tuple', 'size')
+    __slots__ = ('start', 'end', 'tuple', 'size')
 
-  def __init__(self, start, end):
-    if end - start < 0:
-      raise ValueError("Invalid interval start=%s end=%s" % (start, end))
+    def __init__(self, start, end):
+        if end - start < 0:
+            raise ValueError("Invalid interval start=%s end=%s" % (start, end))
 
-    self.start = start
-    self.end = end
-    self.tuple = (start, end)
-    self.size = self.end - self.start
+        self.start = start
+        self.end = end
+        self.tuple = (start, end)
+        self.size = self.end - self.start
 
-  def __eq__(self, other):
-    return self.tuple == other.tuple
+    def __eq__(self, other):
+        return self.tuple == other.tuple
 
-  def __ne__(self, other):
-    return self.tuple != other.tuple
+    def __ne__(self, other):
+        return self.tuple != other.tuple
 
-  def __hash__(self):
-    return hash( self.tuple )
+    def __hash__(self):
+        return hash( self.tuple )
 
-  def __lt__(self, other):
-    return self.start < self.start
+    def __lt__(self, other):
+        return self.start < self.start
 
-  def __le__(self, other):
-    return self.start <= self.start
+    def __le__(self, other):
+        return self.start <= self.start
 
-  def __gt__(self, other):
-    return self.start > self.start
+    def __gt__(self, other):
+        return self.start > self.start
 
-  def __ge__(self, other):
-    return self.start >= self.start
+    def __ge__(self, other):
+        return self.start >= self.start
 
-  def __cmp__(self, other):
-    return (self.start > other.start) - (self.start < other.start)
+    def __cmp__(self, other):
+        return (self.start > other.start) - (self.start < other.start)
 
-  def __len__(self):
-    raise TypeError("len() doesn't support infinite values, use the 'size' attribute instead")
+    def __len__(self):
+        raise TypeError("len() doesn't support infinite values, use the 'size' attribute instead")
 
-  def __nonzero__(self):  # Python 2
-    return self.size != 0
+    def __nonzero__(self):  # Python 2
+        return self.size != 0
 
-  def __bool__(self):  # Python 3
-    return self.size != 0
+    def __bool__(self):  # Python 3
+        return self.size != 0
 
-  def __repr__(self):
-    return '<Interval: %s>' % str(self.tuple)
+    def __repr__(self):
+        return '<Interval: %s>' % str(self.tuple)
 
-  def intersect(self, other):
-    start = max(self.start, other.start)
-    end = min(self.end, other.end)
+    def intersect(self, other):
+        start = max(self.start, other.start)
+        end = min(self.end, other.end)
 
-    if end > start:
-      return Interval(start, end)
+        if end > start:
+            return Interval(start, end)
 
-  def overlaps(self, other):
-    earlier = self if self.start <= other.start else other
-    later = self if earlier is other else other
-    return earlier.end >= later.start
+    def overlaps(self, other):
+        earlier = self if self.start <= other.start else other
+        later = self if earlier is other else other
+        return earlier.end >= later.start
 
-  def union(self, other):
-    if not self.overlaps(other):
-      raise TypeError("Union of disjoint intervals is not an interval")
+    def union(self, other):
+        if not self.overlaps(other):
+            raise TypeError("Union of disjoint intervals is not an interval")
 
-    start = min(self.start, other.start)
-    end = max(self.end, other.end)
-    return Interval(start, end)
+        start = min(self.start, other.start)
+        end = max(self.end, other.end)
+        return Interval(start, end)
 
 
 def union_overlapping(intervals):
-  """Union any overlapping intervals in the given set."""
-  disjoint_intervals = []
+    """Union any overlapping intervals in the given set."""
+    disjoint_intervals = []
 
-  for interval in intervals:
-    if disjoint_intervals and disjoint_intervals[-1].overlaps(interval):
-      disjoint_intervals[-1] = disjoint_intervals[-1].union(interval)
-    else:
-      disjoint_intervals.append(interval)
+    for interval in intervals:
+        if disjoint_intervals and disjoint_intervals[-1].overlaps(interval):
+            disjoint_intervals[-1] = disjoint_intervals[-1].union(interval)
+        else:
+            disjoint_intervals.append(interval)
 
-  return disjoint_intervals
+    return disjoint_intervals

--- a/webapp/graphite/logger.py
+++ b/webapp/graphite/logger.py
@@ -21,76 +21,76 @@ from django.conf import settings
 
 
 class GraphiteLogger:
-  def __init__(self):
-    self.infoLogger = self._config_logger(
-        settings.LOG_FILE_INFO,
-        'info',
-        True,
-        level = logging.DEBUG if settings.DEBUG else logging.INFO,
-    )
-    self.exceptionLogger = self._config_logger(
-        settings.LOG_FILE_EXCEPTION,
-        'exception',
-        True,
-    )
-    self.cacheLogger = self._config_logger(
-        settings.LOG_FILE_CACHE,
-        'cache',
-        settings.LOG_CACHE_PERFORMANCE,
-        level = logging.DEBUG if settings.DEBUG else logging.INFO,
-    )
-    self.renderingLogger = self._config_logger(
-        settings.LOG_FILE_RENDERING,
-        'rendering',
-        settings.LOG_RENDERING_PERFORMANCE,
-        level = logging.DEBUG if settings.DEBUG else logging.INFO,
-    )
+    def __init__(self):
+        self.infoLogger = self._config_logger(
+            settings.LOG_FILE_INFO,
+            'info',
+            True,
+            level = logging.DEBUG if settings.DEBUG else logging.INFO,
+        )
+        self.exceptionLogger = self._config_logger(
+            settings.LOG_FILE_EXCEPTION,
+            'exception',
+            True,
+        )
+        self.cacheLogger = self._config_logger(
+            settings.LOG_FILE_CACHE,
+            'cache',
+            settings.LOG_CACHE_PERFORMANCE,
+            level = logging.DEBUG if settings.DEBUG else logging.INFO,
+        )
+        self.renderingLogger = self._config_logger(
+            settings.LOG_FILE_RENDERING,
+            'rendering',
+            settings.LOG_RENDERING_PERFORMANCE,
+            level = logging.DEBUG if settings.DEBUG else logging.INFO,
+        )
 
-  @staticmethod
-  def _config_logger(log_file_name, name, activate,
-                     level=None, when='midnight',
-                     backupCount=settings.LOG_ROTATION_COUNT):
-    logger = logging.getLogger(name)
-    if level is not None:
-        logger.setLevel(level)
-    if activate:  # if want to log this one
-        if log_file_name == '-':
-            formatter = logging.Formatter(
-                fmt='[%(asctime)s.%(msecs)03d] %(name)s %(levelname)s %(message)s',
-                datefmt='%d/%b/%Y %H:%M:%S')
-            handler = StreamHandler()
+    @staticmethod
+    def _config_logger(log_file_name, name, activate,
+                       level=None, when='midnight',
+                       backupCount=settings.LOG_ROTATION_COUNT):
+        logger = logging.getLogger(name)
+        if level is not None:
+            logger.setLevel(level)
+        if activate:  # if want to log this one
+            if log_file_name == '-':
+                formatter = logging.Formatter(
+                    fmt='[%(asctime)s.%(msecs)03d] %(name)s %(levelname)s %(message)s',
+                    datefmt='%d/%b/%Y %H:%M:%S')
+                handler = StreamHandler()
+            else:
+                formatter = logging.Formatter(
+                    fmt='%(asctime)s.%(msecs)03d :: %(message)s',
+                    datefmt='%Y-%m-%d,%H:%M:%S')
+                log_file = os.path.join(settings.LOG_DIR, log_file_name)
+                if settings.LOG_ROTATION:  # if we want to rotate logs
+                    handler = Rotater(log_file, when=when, backupCount=backupCount)
+                else:  # let someone else, e.g. logrotate, rotate the logs
+                    handler = FileHandler(log_file)
+            handler.setFormatter(formatter)
+            logger.addHandler(handler)
         else:
-            formatter = logging.Formatter(
-                fmt='%(asctime)s.%(msecs)03d :: %(message)s',
-                datefmt='%Y-%m-%d,%H:%M:%S')
-            log_file = os.path.join(settings.LOG_DIR, log_file_name)
-            if settings.LOG_ROTATION:  # if we want to rotate logs
-                handler = Rotater(log_file, when=when, backupCount=backupCount)
-            else:  # let someone else, e.g. logrotate, rotate the logs
-                handler = FileHandler(log_file)
-        handler.setFormatter(formatter)
-        logger.addHandler(handler)
-    else:
-        logger.addHandler(NullHandler())
-    return logger
+            logger.addHandler(NullHandler())
+        return logger
 
-  def info(self,msg,*args,**kwargs):
-    return self.infoLogger.info(msg,*args,**kwargs)
+    def info(self,msg,*args,**kwargs):
+        return self.infoLogger.info(msg,*args,**kwargs)
 
-  def debug(self,msg,*args,**kwargs):
-    return self.infoLogger.debug(msg,*args,**kwargs)
+    def debug(self,msg,*args,**kwargs):
+        return self.infoLogger.debug(msg,*args,**kwargs)
 
-  def warning(self,msg,*args,**kwargs):
-    return self.infoLogger.warn(msg,*args,**kwargs)
+    def warning(self,msg,*args,**kwargs):
+        return self.infoLogger.warn(msg,*args,**kwargs)
 
-  def exception(self,msg="Exception Caught",**kwargs):
-    return self.exceptionLogger.exception(msg,**kwargs)
+    def exception(self,msg="Exception Caught",**kwargs):
+        return self.exceptionLogger.exception(msg,**kwargs)
 
-  def cache(self,msg,*args,**kwargs):
-    return self.cacheLogger.info(msg,*args,**kwargs)
+    def cache(self,msg,*args,**kwargs):
+        return self.cacheLogger.info(msg,*args,**kwargs)
 
-  def rendering(self,msg,*args,**kwargs):
-    return self.renderingLogger.info(msg,*args,**kwargs)
+    def rendering(self,msg,*args,**kwargs):
+        return self.renderingLogger.info(msg,*args,**kwargs)
 
 
 log = GraphiteLogger() # import-shared logger instance

--- a/webapp/graphite/node.py
+++ b/webapp/graphite/node.py
@@ -1,42 +1,42 @@
 
 
 class Node(object):
-  __slots__ = ('name', 'path', 'local', 'is_leaf')
+    __slots__ = ('name', 'path', 'local', 'is_leaf')
 
-  def __init__(self, path):
-    self.path = path
-    self.name = path.split('.')[-1]
-    self.local = True
-    self.is_leaf = False
+    def __init__(self, path):
+        self.path = path
+        self.name = path.split('.')[-1]
+        self.local = True
+        self.is_leaf = False
 
-  def __repr__(self):
-    return '<%s[%x]: %s>' % (self.__class__.__name__, id(self), self.path)
+    def __repr__(self):
+        return '<%s[%x]: %s>' % (self.__class__.__name__, id(self), self.path)
 
 
 class BranchNode(Node):
-  pass
+    pass
 
 
 class LeafNode(Node):
-  __slots__ = ('reader', )
+    __slots__ = ('reader', )
 
-  def __init__(self, path, reader):
-    Node.__init__(self, path)
-    self.reader = reader
-    self.is_leaf = True
+    def __init__(self, path, reader):
+        Node.__init__(self, path)
+        self.reader = reader
+        self.is_leaf = True
 
-  def fetch(self, startTime, endTime, now=None, requestContext=None):
-    try:
-      result = self.reader.fetch(startTime, endTime, now, requestContext)
-    except TypeError:
-      # Support for legacy 3rd party, readers.
-      result = self.reader.fetch(startTime, endTime)
+    def fetch(self, startTime, endTime, now=None, requestContext=None):
+        try:
+            result = self.reader.fetch(startTime, endTime, now, requestContext)
+        except TypeError:
+            # Support for legacy 3rd party, readers.
+            result = self.reader.fetch(startTime, endTime)
 
-    return result
+        return result
 
-  @property
-  def intervals(self):
-    return self.reader.get_intervals()
+    @property
+    def intervals(self):
+        return self.reader.get_intervals()
 
-  def __repr__(self):
-    return '<LeafNode[%x]: %s (%s)>' % (id(self), self.path, self.reader)
+    def __repr__(self):
+        return '<LeafNode[%x]: %s (%s)>' % (id(self), self.path, self.reader)

--- a/webapp/graphite/readers/remote.py
+++ b/webapp/graphite/readers/remote.py
@@ -7,87 +7,86 @@ from graphite.readers.utils import BaseReader
 
 
 class RemoteReader(BaseReader):
-  __slots__ = (
-    'finder',
-    'metric_path',
-    'intervals',
-    'bulk_query',
-  )
-
-  def __init__(self, finder, node_info, bulk_query=None):
-    self.finder = finder
-    self.metric_path = node_info.get('path') or node_info.get('metric_path')
-    self.intervals = node_info.get('intervals', [])
-    self.bulk_query = set(bulk_query) if bulk_query else (
-      [self.metric_path] if self.metric_path else []
+    __slots__ = (
+        'finder',
+        'metric_path',
+        'intervals',
+        'bulk_query',
     )
 
-  def __repr__(self):
-    return '<RemoteReader[%x]: %s %s>' % (id(self), self.finder.host, ','.join(self.bulk_query))
-
-  def get_intervals(self):
-    return self.intervals
-
-  def fetch(self, startTime, endTime, now=None, requestContext=None):
-    for series in self.fetch_multi(startTime, endTime, now, requestContext):
-      if series['name'] == self.metric_path:
-        return (series['time_info'], series['values'])
-
-  def fetch_multi(self, startTime, endTime, now=None, requestContext=None):
-    if not self.bulk_query:
-      return []
-
-    query_params = [
-      ('format', self.finder.params.get('format', 'pickle')),
-      ('local', self.finder.params.get('local', '1')),
-      ('noCache', '1'),
-      ('from', int(startTime)),
-      ('until', int(endTime))
-    ]
-
-    for target in self.bulk_query:
-      query_params.append(('target', target))
-
-    if now is not None:
-      query_params.append(('now', int(now)))
-
-    headers = requestContext.get('forwardHeaders') if requestContext else None
-
-    retries = 1  # start counting at one to make log output and settings more readable
-    while True:
-      try:
-        result = self.finder.request(
-          '/render/',
-          fields=query_params,
-          headers=headers,
-          timeout=settings.FETCH_TIMEOUT,
+    def __init__(self, finder, node_info, bulk_query=None):
+        self.finder = finder
+        self.metric_path = node_info.get('path') or node_info.get('metric_path')
+        self.intervals = node_info.get('intervals', [])
+        self.bulk_query = set(bulk_query) if bulk_query else (
+            [self.metric_path] if self.metric_path else []
         )
-        break
-      except Exception:
-        if retries >= settings.MAX_FETCH_RETRIES:
-          log.exception("Failed after %s attempts! Root cause:\n%s" %
-                        (settings.MAX_FETCH_RETRIES, format_exc()))
-          raise
-        else:
-          log.exception("Got an exception when fetching data! Try: %i of %i. Root cause:\n%s" %
-                        (retries, settings.MAX_FETCH_RETRIES, format_exc()))
-        retries += 1
 
-    data = self.finder.deserialize(result)
+    def __repr__(self):
+        return '<RemoteReader[%x]: %s %s>' % (id(self), self.finder.host, ','.join(self.bulk_query))
 
-    try:
-      return [
-        {
-          'pathExpression': series.get('pathExpression', series['name']),
-          'name': series['name'],
-          'time_info': (series['start'], series['end'], series['step']),
-          'values': series['values'],
-        }
-        for series in data
-      ]
-    except Exception as err:
-      self.finder.fail()
-      log.exception(
-        "RemoteReader[%s] Invalid render response from %s: %s" %
-        (self.finder.host, result.url_full, repr(err)))
-      raise Exception("Invalid render response from %s: %s" % (result.url_full, repr(err)))
+    def get_intervals(self):
+        return self.intervals
+
+    def fetch(self, startTime, endTime, now=None, requestContext=None):
+        for series in self.fetch_multi(startTime, endTime, now, requestContext):
+            if series['name'] == self.metric_path:
+                return (series['time_info'], series['values'])
+
+    def fetch_multi(self, startTime, endTime, now=None, requestContext=None):
+        if not self.bulk_query:
+            return []
+
+        query_params = [
+            ('format', self.finder.params.get('format', 'pickle')),
+            ('local', self.finder.params.get('local', '1')),
+            ('noCache', '1'),
+            ('from', int(startTime)),
+            ('until', int(endTime))
+        ]
+
+        for target in self.bulk_query:
+            query_params.append(('target', target))
+
+        if now is not None:
+            query_params.append(('now', int(now)))
+
+        headers = requestContext.get('forwardHeaders') if requestContext else None
+
+        retries = 1  # start counting at one to make log output and settings more readable
+        while True:
+            try:
+                result = self.finder.request(
+                    '/render/',
+                    fields=query_params,
+                    headers=headers,
+                    timeout=settings.FETCH_TIMEOUT,
+                )
+                break
+            except Exception:
+                if retries >= settings.MAX_FETCH_RETRIES:
+                    log.exception("Failed after %s attempts! Root cause:\n%s" %
+                                  (settings.MAX_FETCH_RETRIES, format_exc()))
+                    raise
+                else:
+                    log.exception("Got an exception when fetching data! Try: %i of %i. Root cause:\n%s" %
+                                  (retries, settings.MAX_FETCH_RETRIES, format_exc()))
+                retries += 1
+
+        data = self.finder.deserialize(result)
+
+        try:
+            return [
+                {
+                    'pathExpression': series.get('pathExpression', series['name']),
+                    'name': series['name'],
+                    'time_info': (series['start'], series['end'], series['step']),
+                    'values': series['values'],
+                }
+                for series in data
+            ]
+        except Exception as err:
+            self.finder.fail()
+            log.exception("RemoteReader[%s] Invalid render response from %s: %s" %
+                          (self.finder.host, result.url_full, repr(err)))
+            raise Exception("Invalid render response from %s: %s" % (result.url_full, repr(err)))

--- a/webapp/graphite/render/attime.py
+++ b/webapp/graphite/render/attime.py
@@ -28,167 +28,173 @@ YEARS_STRING = 'years'
 
 
 def parseATTime(s, tzinfo=None, now=None):
-  if tzinfo is None:
-    tzinfo = pytz.timezone(settings.TIME_ZONE)
-  if isinstance(s, datetimetype):
-    if s.tzinfo:
-      return s.astimezone(tzinfo)
-    return tzinfo.localize(s)
+    if tzinfo is None:
+        tzinfo = pytz.timezone(settings.TIME_ZONE)
+    if isinstance(s, datetimetype):
+        if s.tzinfo:
+            return s.astimezone(tzinfo)
+        return tzinfo.localize(s)
 
-  s = s.strip().lower().replace('_','').replace(',','').replace(' ','')
-  if s.isdigit():
-    if len(s) == 8 and int(s[:4]) > 1900 and int(s[4:6]) < 13 and int(s[6:]) < 32:
-      pass #Fall back because its not a timestamp, its YYYYMMDD form
+    s = s.strip().lower().replace('_','').replace(',','').replace(' ','')
+    if s.isdigit():
+        if len(s) == 8 and int(s[:4]) > 1900 and int(s[4:6]) < 13 and int(s[6:]) < 32:
+            pass  # Fall back because its not a timestamp, its YYYYMMDD form
+        else:
+            return datetime.fromtimestamp(int(s),tzinfo)
+    if '+' in s:
+        ref,offset = s.split('+',1)
+        offset = '+' + offset
+    elif '-' in s:
+        ref,offset = s.split('-',1)
+        offset = '-' + offset
     else:
-      return datetime.fromtimestamp(int(s),tzinfo)
-  if '+' in s:
-    ref,offset = s.split('+',1)
-    offset = '+' + offset
-  elif '-' in s:
-    ref,offset = s.split('-',1)
-    offset = '-' + offset
-  else:
-    ref,offset = s,''
+        ref,offset = s,''
 
-  return tzinfo.normalize(parseTimeReference(ref, tzinfo, now) + parseTimeOffset(offset))
+    return tzinfo.normalize(parseTimeReference(ref, tzinfo, now) + parseTimeOffset(offset))
 
 
 def parseTimeReference(ref, tzinfo=None, now=None):
-  if tzinfo is None:
-    tzinfo = pytz.timezone(settings.TIME_ZONE)
-  if isinstance(ref, datetimetype):
-    if ref.tzinfo:
-      return ref.astimezone(tzinfo)
-    return tzinfo.localize(ref)
+    if tzinfo is None:
+        tzinfo = pytz.timezone(settings.TIME_ZONE)
+    if isinstance(ref, datetimetype):
+        if ref.tzinfo:
+            return ref.astimezone(tzinfo)
+        return tzinfo.localize(ref)
 
-  if now is None:
-    now = datetime.now(tzinfo)
-  else:
-    now = parseATTime(now, tzinfo)
-
-  if not ref or ref == 'now': return now
-
-  rawRef = ref
-
-  # Time-of-day reference
-  i = ref.find(':')
-  hour,minute = 0,0
-  if 0 < i < 3:
-    hour = int( ref[:i] )
-    minute = int( ref[i+1:i+3] )
-    ref = ref[i+3:]
-    if ref[:2] == 'am':
-      ref = ref[2:]
-    elif ref[:2] == 'pm':
-      hour = (hour + 12) % 24
-      ref = ref[2:]
-
-  # Xam or XXam
-  i = ref.find('am')
-  if 0 < i < 3:
-    hour = int( ref[:i] )
-    ref = ref[i+2:]
-
-  # Xpm or XXpm
-  i = ref.find('pm')
-  if 0 < i < 3:
-    hour = (int( ref[:i] ) + 12) % 24
-    ref = ref[i+2:]
-
-  if ref.startswith('noon'):
-    hour,minute = 12,0
-    ref = ref[4:]
-  elif ref.startswith('midnight'):
-    hour,minute = 0,0
-    ref = ref[8:]
-  elif ref.startswith('teatime'):
-    hour,minute = 16,0
-    ref = ref[7:]
-
-  refDate = now.replace(hour=hour,minute=minute,second=0,microsecond=0,tzinfo=None)
-
-  # Day reference
-  if ref in ('yesterday','today','tomorrow'): # yesterday, today, tomorrow
-    if ref == 'yesterday':
-      refDate -= timedelta(days=1)
-    elif ref == 'tomorrow':
-      refDate += timedelta(days=1)
-
-  elif ref.count('/') == 2: # MM/DD/YY[YY]
-    m,d,y = map(int,ref.split('/'))
-    if y < 1900: y += 1900
-    if y < 1970: y += 100
-    refDate = datetime(year=y,month=m,day=d,hour=hour,minute=minute)
-
-  elif len(ref) == 8 and ref.isdigit(): # YYYYMMDD
-    refDate = datetime(year=int(ref[:4]),month=int(ref[4:6]),day=int(ref[6:8]),hour=hour,minute=minute)
-
-  elif ref[:3] in months: # MonthName DayOfMonth
-    d = None
-    if ref[-2:].isdigit():
-      d = int(ref[-2:])
-    elif ref[-1:].isdigit():
-      d = int(ref[-1:])
+    if now is None:
+        now = datetime.now(tzinfo)
     else:
-      raise Exception("Day of month required after month name")
-    refDate = datetime(year=refDate.year,month=months.index(ref[:3]) + 1,day=d,hour=hour,minute=minute)
+        now = parseATTime(now, tzinfo)
 
-  elif ref[:3] in weekdays: # DayOfWeek (Monday, etc)
-    todayDayName = refDate.strftime("%a").lower()[:3]
-    today = weekdays.index( todayDayName )
-    twoWeeks = weekdays * 2
-    dayOffset = today - twoWeeks.index(ref[:3])
-    if dayOffset < 0: dayOffset += 7
-    refDate -= timedelta(days=dayOffset)
+    if not ref or ref == 'now':
+        return now
 
-  elif ref:
-    raise ValueError("Unknown day reference: %s" % rawRef)
+    rawRef = ref
 
-  return tzinfo.localize(refDate)
+    # Time-of-day reference
+    i = ref.find(':')
+    hour,minute = 0,0
+    if 0 < i < 3:
+        hour = int( ref[:i] )
+        minute = int( ref[i+1:i+3] )
+        ref = ref[i+3:]
+        if ref[:2] == 'am':
+            ref = ref[2:]
+        elif ref[:2] == 'pm':
+            hour = (hour + 12) % 24
+            ref = ref[2:]
+
+    # Xam or XXam
+    i = ref.find('am')
+    if 0 < i < 3:
+        hour = int( ref[:i] )
+        ref = ref[i+2:]
+
+    # Xpm or XXpm
+    i = ref.find('pm')
+    if 0 < i < 3:
+        hour = (int( ref[:i] ) + 12) % 24
+        ref = ref[i+2:]
+
+    if ref.startswith('noon'):
+        hour,minute = 12,0
+        ref = ref[4:]
+    elif ref.startswith('midnight'):
+        hour,minute = 0,0
+        ref = ref[8:]
+    elif ref.startswith('teatime'):
+        hour,minute = 16,0
+        ref = ref[7:]
+
+    refDate = now.replace(hour=hour,minute=minute,second=0,microsecond=0,tzinfo=None)
+
+    # Day reference
+    if ref in ('yesterday','today','tomorrow'):  # yesterday, today, tomorrow
+        if ref == 'yesterday':
+            refDate -= timedelta(days=1)
+        elif ref == 'tomorrow':
+            refDate += timedelta(days=1)
+
+    elif ref.count('/') == 2:  # MM/DD/YY[YY]
+        m,d,y = map(int,ref.split('/'))
+        if y < 1900:
+            y += 1900
+        if y < 1970:
+            y += 100
+        refDate = datetime(year=y,month=m,day=d,hour=hour,minute=minute)
+
+    elif len(ref) == 8 and ref.isdigit():  # YYYYMMDD
+        refDate = datetime(year=int(ref[:4]), month=int(ref[4:6]), day=int(ref[6:8]), hour=hour, minute=minute)
+
+    elif ref[:3] in months:  # MonthName DayOfMonth
+        d = None
+        if ref[-2:].isdigit():
+            d = int(ref[-2:])
+        elif ref[-1:].isdigit():
+            d = int(ref[-1:])
+        else:
+            raise Exception("Day of month required after month name")
+        refDate = datetime(year=refDate.year, month=months.index(ref[:3]) + 1, day=d, hour=hour, minute=minute)
+
+    elif ref[:3] in weekdays:  # DayOfWeek (Monday, etc)
+        todayDayName = refDate.strftime("%a").lower()[:3]
+        today = weekdays.index( todayDayName )
+        twoWeeks = weekdays * 2
+        dayOffset = today - twoWeeks.index(ref[:3])
+        if dayOffset < 0:
+            dayOffset += 7
+        refDate -= timedelta(days=dayOffset)
+
+    elif ref:
+        raise ValueError("Unknown day reference: %s" % rawRef)
+
+    return tzinfo.localize(refDate)
 
 
 def parseTimeOffset(offset):
-  if not offset:
-    return timedelta()
+    if not offset:
+        return timedelta()
 
-  t = timedelta()
+    t = timedelta()
 
-  if offset[0].isdigit():
-    sign = 1
-  else:
-    try:
-      sign = { '+' : 1, '-' : -1 }[offset[0]]
-    except KeyError:
-      raise KeyError('Invalid offset: %s' % offset)
-    offset = offset[1:]
+    if offset[0].isdigit():
+        sign = 1
+    else:
+        try:
+            sign = { '+' : 1, '-' : -1 }[offset[0]]
+        except KeyError:
+            raise KeyError('Invalid offset: %s' % offset)
+        offset = offset[1:]
 
-  while offset:
-    i = 1
-    while offset[:i].isdigit() and i <= len(offset): i += 1
-    num = int(offset[:i-1])
-    offset = offset[i-1:]
-    i = 1
-    while offset[:i].isalpha() and i <= len(offset): i += 1
-    unit = offset[:i-1]
-    offset = offset[i-1:]
-    unitString = getUnitString(unit)
-    if unitString == MONTHS_STRING:
-      unitString = DAYS_STRING
-      num = num * 30
-    if unitString == YEARS_STRING:
-      unitString = DAYS_STRING
-      num = num * 365
-    t += timedelta(**{ unitString : sign * num})
+    while offset:
+        i = 1
+        while offset[:i].isdigit() and i <= len(offset):
+            i += 1
+        num = int(offset[:i-1])
+        offset = offset[i-1:]
+        i = 1
+        while offset[:i].isalpha() and i <= len(offset):
+            i += 1
+        unit = offset[:i-1]
+        offset = offset[i-1:]
+        unitString = getUnitString(unit)
+        if unitString == MONTHS_STRING:
+            unitString = DAYS_STRING
+            num = num * 30
+        if unitString == YEARS_STRING:
+            unitString = DAYS_STRING
+            num = num * 365
+        t += timedelta(**{ unitString : sign * num})
 
-  return t
+    return t
 
 
 def getUnitString(s):
-  if s.startswith('s'): return SECONDS_STRING
-  if s.startswith('min'): return MINUTES_STRING
-  if s.startswith('h'): return HOURS_STRING
-  if s.startswith('d'): return DAYS_STRING
-  if s.startswith('w'): return WEEKS_STRING
-  if s.startswith('mon'): return MONTHS_STRING
-  if s.startswith('y'): return YEARS_STRING
-  raise ValueError("Invalid offset unit '%s'" % s)
+    if s.startswith('s'): return SECONDS_STRING
+    if s.startswith('min'): return MINUTES_STRING
+    if s.startswith('h'): return HOURS_STRING
+    if s.startswith('d'): return DAYS_STRING
+    if s.startswith('w'): return WEEKS_STRING
+    if s.startswith('mon'): return MONTHS_STRING
+    if s.startswith('y'): return YEARS_STRING
+    raise ValueError("Invalid offset unit '%s'" % s)

--- a/webapp/graphite/render/grammar.py
+++ b/webapp/graphite/render/grammar.py
@@ -78,7 +78,7 @@ kwargs = delimitedList(kwarg)
 
 
 def setRaw(s, loc, toks):
-  toks[0].raw = s[toks[0].start:toks[0].end]
+    toks[0].raw = s[toks[0].start:toks[0].end]
 
 
 call = Group(
@@ -143,9 +143,9 @@ else:
 
 
 def enableDebug():
-  for name, obj in globals().items():
-    try:
-      obj.setName(name)
-      obj.setDebug(True)
-    except Exception:
-      pass
+    for name, obj in globals().items():
+        try:
+            obj.setName(name)
+            obj.setDebug(True)
+        except Exception:
+            pass

--- a/webapp/graphite/render/hashing.py
+++ b/webapp/graphite/render/hashing.py
@@ -19,136 +19,136 @@ import bisect
 import sys
 
 try:
-  import mmh3
+    import mmh3
 except ImportError:
-  mmh3 = None
+    mmh3 = None
 
 try:
-  import pyhash
-  hasher = pyhash.fnv1a_32()
+    import pyhash
+    hasher = pyhash.fnv1a_32()
 
-  def fnv32a(data, seed=0x811c9dc5):
-    return hasher(data, seed=seed)
+    def fnv32a(data, seed=0x811c9dc5):
+        return hasher(data, seed=seed)
 except ImportError:
-  def fnv32a(data, seed=0x811c9dc5):
-    """
-    FNV-1a Hash (http://isthe.com/chongo/tech/comp/fnv/) in Python.
-    Taken from https://gist.github.com/vaiorabbit/5670985
-    """
-    hval = seed
-    fnv_32_prime = 0x01000193
-    uint32_max = 2 ** 32
-    if sys.version_info >= (3, 0):
-      # data is a bytes object, s is an integer
-      for s in data:
-        hval = hval ^ s
-        hval = (hval * fnv_32_prime) % uint32_max
-    else:
-      # data is an str object, s is a single character
-      for s in data:
-        hval = hval ^ ord(s)
-        hval = (hval * fnv_32_prime) % uint32_max
-    return hval
+    def fnv32a(data, seed=0x811c9dc5):
+        """
+        FNV-1a Hash (http://isthe.com/chongo/tech/comp/fnv/) in Python.
+        Taken from https://gist.github.com/vaiorabbit/5670985
+        """
+        hval = seed
+        fnv_32_prime = 0x01000193
+        uint32_max = 2 ** 32
+        if sys.version_info >= (3, 0):
+            # data is a bytes object, s is an integer
+            for s in data:
+                hval = hval ^ s
+                hval = (hval * fnv_32_prime) % uint32_max
+        else:
+            # data is an str object, s is a single character
+            for s in data:
+                hval = hval ^ ord(s)
+                hval = (hval * fnv_32_prime) % uint32_max
+        return hval
 
 
 def hashRequest(request):
-  # Normalize the request parameters to ensure we're deterministic
-  queryParams = [
-    "%s=%s" % (key, '&'.join(values))
-    for (key,values) in chain(request.POST.lists(), request.GET.lists())
-    if not key.startswith('_')
-  ]
-  normalizedParams = ','.join( sorted(queryParams) )
-  return compactHash(normalizedParams)
+    # Normalize the request parameters to ensure we're deterministic
+    queryParams = [
+        "%s=%s" % (key, '&'.join(values))
+        for (key,values) in chain(request.POST.lists(), request.GET.lists())
+        if not key.startswith('_')
+    ]
+    normalizedParams = ','.join( sorted(queryParams) )
+    return compactHash(normalizedParams)
 
 
 def hashData(targets, startTime, endTime, xFilesFactor):
-  targetsString = ','.join(sorted(targets))
-  startTimeString = startTime.strftime("%Y%m%d_%H%M")
-  endTimeString = endTime.strftime("%Y%m%d_%H%M")
-  myHash = targetsString + '@' + startTimeString + ':' + endTimeString + ':' + str(xFilesFactor)
-  return compactHash(myHash)
+    targetsString = ','.join(sorted(targets))
+    startTimeString = startTime.strftime("%Y%m%d_%H%M")
+    endTimeString = endTime.strftime("%Y%m%d_%H%M")
+    myHash = targetsString + '@' + startTimeString + ':' + endTimeString + ':' + str(xFilesFactor)
+    return compactHash(myHash)
 
 
 def compactHash(string):
-  return md5(string.encode('utf-8')).hexdigest()
+    return md5(string.encode('utf-8')).hexdigest()
 
 
 def carbonHash(key, hash_type):
-  if hash_type == 'fnv1a_ch':
-    big_hash = int(fnv32a(key.encode('utf-8')))
-    small_hash = (big_hash >> 16) ^ (big_hash & 0xffff)
-  elif hash_type == 'mmh3_ch':
-    if mmh3 is None:
-      raise Exception('Install "mmh3" to use this hashing function.')
-    small_hash = mmh3.hash(key)
-  else:
-    big_hash = compactHash(key)
-    small_hash = int(big_hash[:4], 16)
-  return small_hash
+    if hash_type == 'fnv1a_ch':
+        big_hash = int(fnv32a(key.encode('utf-8')))
+        small_hash = (big_hash >> 16) ^ (big_hash & 0xffff)
+    elif hash_type == 'mmh3_ch':
+        if mmh3 is None:
+            raise Exception('Install "mmh3" to use this hashing function.')
+        small_hash = mmh3.hash(key)
+    else:
+        big_hash = compactHash(key)
+        small_hash = int(big_hash[:4], 16)
+    return small_hash
 
 
 class ConsistentHashRing:
-  def __init__(self, nodes, replica_count=100, hash_type='carbon_ch'):
-    self.ring = []
-    self.ring_len = len(self.ring)
-    self.nodes = set()
-    self.nodes_len = len(self.nodes)
-    self.replica_count = replica_count
-    self.hash_type = hash_type
-    for node in nodes:
-      self.add_node(node)
+    def __init__(self, nodes, replica_count=100, hash_type='carbon_ch'):
+        self.ring = []
+        self.ring_len = len(self.ring)
+        self.nodes = set()
+        self.nodes_len = len(self.nodes)
+        self.replica_count = replica_count
+        self.hash_type = hash_type
+        for node in nodes:
+            self.add_node(node)
 
-  def compute_ring_position(self, key):
-    return carbonHash(key, self.hash_type)
+    def compute_ring_position(self, key):
+        return carbonHash(key, self.hash_type)
 
-  def add_node(self, key):
-    self.nodes.add(key)
-    self.nodes_len = len(self.nodes)
-    for i in range(self.replica_count):
-      if self.hash_type == 'fnv1a_ch':
-        replica_key = "%d-%s" % (i, key[1])
-      else:
-        replica_key = "%s:%d" % (key, i)
-      position = self.compute_ring_position(replica_key)
-      while position in [r[0] for r in self.ring]:
-        position = position + 1
-      entry = (position, key)
-      bisect.insort(self.ring, entry)
-    self.ring_len = len(self.ring)
+    def add_node(self, key):
+        self.nodes.add(key)
+        self.nodes_len = len(self.nodes)
+        for i in range(self.replica_count):
+            if self.hash_type == 'fnv1a_ch':
+                replica_key = "%d-%s" % (i, key[1])
+            else:
+                replica_key = "%s:%d" % (key, i)
+            position = self.compute_ring_position(replica_key)
+            while position in [r[0] for r in self.ring]:
+                position = position + 1
+            entry = (position, key)
+            bisect.insort(self.ring, entry)
+        self.ring_len = len(self.ring)
 
-  def remove_node(self, key):
-    self.nodes.discard(key)
-    self.nodes_len = len(self.nodes)
-    self.ring = [entry for entry in self.ring if entry[1] != key]
-    self.ring_len = len(self.ring)
+    def remove_node(self, key):
+        self.nodes.discard(key)
+        self.nodes_len = len(self.nodes)
+        self.ring = [entry for entry in self.ring if entry[1] != key]
+        self.ring_len = len(self.ring)
 
-  def get_node(self, key):
-    assert self.ring
-    position = self.compute_ring_position(key)
-    search_entry = (position, ())
-    index = bisect.bisect_left(self.ring, search_entry) % self.ring_len
-    entry = self.ring[index]
-    return entry[1]
+    def get_node(self, key):
+        assert self.ring
+        position = self.compute_ring_position(key)
+        search_entry = (position, ())
+        index = bisect.bisect_left(self.ring, search_entry) % self.ring_len
+        entry = self.ring[index]
+        return entry[1]
 
-  def get_nodes(self, key):
-    nodes = set()
-    if not self.ring:
-      return
-    if self.nodes_len == 1:
-      for node in self.nodes:
-        yield node
-    position = self.compute_ring_position(key)
-    search_entry = (position, ())
-    index = bisect.bisect_left(self.ring, search_entry) % self.ring_len
-    last_index = (index - 1) % self.ring_len
-    nodes_len = len(nodes)
-    while nodes_len < self.nodes_len and index != last_index:
-      next_entry = self.ring[index]
-      (position, next_node) = next_entry
-      if next_node not in nodes:
-        nodes.add(next_node)
-        nodes_len += 1
-        yield next_node
+    def get_nodes(self, key):
+        nodes = set()
+        if not self.ring:
+            return
+        if self.nodes_len == 1:
+            for node in self.nodes:
+                yield node
+        position = self.compute_ring_position(key)
+        search_entry = (position, ())
+        index = bisect.bisect_left(self.ring, search_entry) % self.ring_len
+        last_index = (index - 1) % self.ring_len
+        nodes_len = len(nodes)
+        while nodes_len < self.nodes_len and index != last_index:
+            next_entry = self.ring[index]
+            (position, next_node) = next_entry
+            if next_node not in nodes:
+                nodes.add(next_node)
+                nodes_len += 1
+                yield next_node
 
-      index = (index + 1) % self.ring_len
+            index = (index + 1) % self.ring_len

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -223,13 +223,13 @@ FLUSHRRDCACHED = ''
 ## Load our local_settings
 SETTINGS_MODULE = os.environ.get('GRAPHITE_SETTINGS_MODULE', 'graphite.local_settings')
 try:
-  globals().update(import_module(SETTINGS_MODULE).__dict__)
+    globals().update(import_module(SETTINGS_MODULE).__dict__)
 except ImportError:
-  print("Could not import {0}, using defaults!".format(SETTINGS_MODULE), file=sys.stderr)
+    print("Could not import {0}, using defaults!".format(SETTINGS_MODULE), file=sys.stderr)
 
 ## Load Django settings if they werent picked up in local_settings
 if not GRAPHITE_WEB_APP_SETTINGS_LOADED:
-  from graphite.app_settings import *  # noqa
+    from graphite.app_settings import *  # noqa
 
 
 STATICFILES_DIRS = (
@@ -243,48 +243,48 @@ FETCH_TIMEOUT = FETCH_TIMEOUT or REMOTE_FETCH_TIMEOUT or 6.0
 ## Set config dependent on flags set in local_settings
 # Path configuration
 if not STATIC_ROOT:
-  STATIC_ROOT = join(GRAPHITE_ROOT, 'static')
+    STATIC_ROOT = join(GRAPHITE_ROOT, 'static')
 
 if not CONF_DIR:
-  CONF_DIR = os.environ.get('GRAPHITE_CONF_DIR', join(GRAPHITE_ROOT, 'conf'))
+    CONF_DIR = os.environ.get('GRAPHITE_CONF_DIR', join(GRAPHITE_ROOT, 'conf'))
 if not DASHBOARD_CONF:
-  DASHBOARD_CONF = join(CONF_DIR, 'dashboard.conf')
+    DASHBOARD_CONF = join(CONF_DIR, 'dashboard.conf')
 if not GRAPHTEMPLATES_CONF:
-  GRAPHTEMPLATES_CONF = join(CONF_DIR, 'graphTemplates.conf')
+    GRAPHTEMPLATES_CONF = join(CONF_DIR, 'graphTemplates.conf')
 
 if not STORAGE_DIR:
-  STORAGE_DIR = os.environ.get('GRAPHITE_STORAGE_DIR', join(GRAPHITE_ROOT, 'storage'))
+    STORAGE_DIR = os.environ.get('GRAPHITE_STORAGE_DIR', join(GRAPHITE_ROOT, 'storage'))
 if not WHITELIST_FILE:
-  WHITELIST_FILE = join(STORAGE_DIR, 'lists', 'whitelist')
+    WHITELIST_FILE = join(STORAGE_DIR, 'lists', 'whitelist')
 if not INDEX_FILE:
-  INDEX_FILE = join(STORAGE_DIR, 'index')
+    INDEX_FILE = join(STORAGE_DIR, 'index')
 if not LOG_DIR:
-  LOG_DIR = join(STORAGE_DIR, 'log', 'webapp')
+    LOG_DIR = join(STORAGE_DIR, 'log', 'webapp')
 if not WHISPER_DIR:
-  WHISPER_DIR = join(STORAGE_DIR, 'whisper/')
+    WHISPER_DIR = join(STORAGE_DIR, 'whisper/')
 if not CERES_DIR:
-  CERES_DIR = join(STORAGE_DIR, 'ceres/')
+    CERES_DIR = join(STORAGE_DIR, 'ceres/')
 if not RRD_DIR:
-  RRD_DIR = join(STORAGE_DIR, 'rrd/')
+    RRD_DIR = join(STORAGE_DIR, 'rrd/')
 if not STANDARD_DIRS:
-  try:
-    import whisper  # noqa
-    if os.path.exists(WHISPER_DIR):
-      STANDARD_DIRS.append(WHISPER_DIR)
-  except ImportError:
-    print("WARNING: whisper module could not be loaded, whisper support disabled", file=sys.stderr)
-  try:
-    import ceres  # noqa
-    if os.path.exists(CERES_DIR):
-      STANDARD_DIRS.append(CERES_DIR)
-  except ImportError:
-    pass
-  try:
-    import rrdtool  # noqa
-    if os.path.exists(RRD_DIR):
-      STANDARD_DIRS.append(RRD_DIR)
-  except ImportError:
-    pass
+    try:
+        import whisper  # noqa
+        if os.path.exists(WHISPER_DIR):
+            STANDARD_DIRS.append(WHISPER_DIR)
+    except ImportError:
+        print("WARNING: whisper module could not be loaded, whisper support disabled", file=sys.stderr)
+    try:
+        import ceres  # noqa
+        if os.path.exists(CERES_DIR):
+            STANDARD_DIRS.append(CERES_DIR)
+    except ImportError:
+        pass
+    try:
+        import rrdtool  # noqa
+        if os.path.exists(RRD_DIR):
+            STANDARD_DIRS.append(RRD_DIR)
+    except ImportError:
+        pass
 
 if DATABASES is None:
     DATABASES = {
@@ -306,7 +306,7 @@ if URL_PREFIX and not STATIC_URL.startswith(URL_PREFIX):
 # This is set here so that a user-set STORAGE_DIR is available
 if 'sqlite3' in DATABASES.get('default',{}).get('ENGINE','') \
         and not DATABASES.get('default',{}).get('NAME'):
-  DATABASES['default']['NAME'] = join(STORAGE_DIR, 'graphite.db')
+    DATABASES['default']['NAME'] = join(STORAGE_DIR, 'graphite.db')
 
 # Caching shortcuts
 if MEMCACHE_HOSTS:
@@ -319,32 +319,32 @@ if MEMCACHE_HOSTS:
     }
 
 if not CACHES:
-  CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
-    },
-  }
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+        },
+    }
 
 # Authentication shortcuts
 if USE_LDAP_AUTH and LDAP_URI is None:
-  LDAP_URI = "ldap://%s:%d/" % (LDAP_SERVER, LDAP_PORT)
+    LDAP_URI = "ldap://%s:%d/" % (LDAP_SERVER, LDAP_PORT)
 
 if USE_REMOTE_USER_AUTHENTICATION or REMOTE_USER_BACKEND:
-  if REMOTE_USER_MIDDLEWARE:
-    MIDDLEWARE += (REMOTE_USER_MIDDLEWARE,)
-  else:
-    MIDDLEWARE += ('django.contrib.auth.middleware.RemoteUserMiddleware',)
-  if DJANGO_VERSION < (1, 10):
-      MIDDLEWARE_CLASSES = MIDDLEWARE
-  if REMOTE_USER_BACKEND:
-    AUTHENTICATION_BACKENDS.insert(0,REMOTE_USER_BACKEND)
-  else:
-    AUTHENTICATION_BACKENDS.insert(0,'django.contrib.auth.backends.RemoteUserBackend')
+    if REMOTE_USER_MIDDLEWARE:
+        MIDDLEWARE += (REMOTE_USER_MIDDLEWARE,)
+    else:
+        MIDDLEWARE += ('django.contrib.auth.middleware.RemoteUserMiddleware',)
+    if DJANGO_VERSION < (1, 10):
+        MIDDLEWARE_CLASSES = MIDDLEWARE
+    if REMOTE_USER_BACKEND:
+        AUTHENTICATION_BACKENDS.insert(0,REMOTE_USER_BACKEND)
+    else:
+        AUTHENTICATION_BACKENDS.insert(0,'django.contrib.auth.backends.RemoteUserBackend')
 
 if USE_LDAP_AUTH:
-  AUTHENTICATION_BACKENDS.insert(0,'graphite.account.ldapBackend.LDAPBackend')
+    AUTHENTICATION_BACKENDS.insert(0,'graphite.account.ldapBackend.LDAPBackend')
 
 if SECRET_KEY == 'UNSAFE_DEFAULT':
-  warn('SECRET_KEY is set to an unsafe default. This should be set in local_settings.py for better security')
+    warn('SECRET_KEY is set to an unsafe default. This should be set in local_settings.py for better security')
 
 USE_TZ = True

--- a/webapp/graphite/tags/base.py
+++ b/webapp/graphite/tags/base.py
@@ -8,296 +8,295 @@ from graphite.tags.utils import TaggedSeries
 
 
 class BaseTagDB(object):
-  __metaclass__ = abc.ABCMeta
+    __metaclass__ = abc.ABCMeta
 
-  def __init__(self, settings, *args, **kwargs):
-    """Initialize the tag db."""
-    self.settings = settings
-    self.cache = kwargs.get('cache')
-    self.log = kwargs.get('log')
+    def __init__(self, settings, *args, **kwargs):
+        """Initialize the tag db."""
+        self.settings = settings
+        self.cache = kwargs.get('cache')
+        self.log = kwargs.get('log')
 
-  def find_series(self, tags, requestContext=None):
-    """
-    Find series by tag, accepts a list of tag specifiers and returns a list of matching paths.
+    def find_series(self, tags, requestContext=None):
+        """
+        Find series by tag, accepts a list of tag specifiers and returns a list of matching paths.
 
-    Tags specifiers are strings, and may have the following formats:
+        Tags specifiers are strings, and may have the following formats:
 
-    .. code-block:: none
+        .. code-block:: none
 
-      tag=spec    tag value exactly matches spec
-      tag!=spec   tag value does not exactly match spec
-      tag=~value  tag value matches the regular expression spec
-      tag!=~spec  tag value does not match the regular expression spec
+          tag=spec    tag value exactly matches spec
+          tag!=spec   tag value does not exactly match spec
+          tag=~value  tag value matches the regular expression spec
+          tag!=~spec  tag value does not match the regular expression spec
 
-    Any tag spec that matches an empty value is considered to match series that don't have that tag.
+        Any tag spec that matches an empty value is considered to match series that don't have that tag.
 
-    At least one tag spec must require a non-empty value.
+        At least one tag spec must require a non-empty value.
 
-    Regular expression conditions are treated as being anchored at the start of the value.
+        Regular expression conditions are treated as being anchored at the start of the value.
 
-    Matching paths are returned as a list of strings.
-    """
-    start_time = time.time()
-    log_msg = 'completed in'
+        Matching paths are returned as a list of strings.
+        """
+        start_time = time.time()
+        log_msg = 'completed in'
 
-    try:
-      cacheKey = self.find_series_cachekey(tags, requestContext=requestContext)
-      result = self.cache.get(cacheKey) if self.cache else None
-      if result is not None:
-        log_msg = 'completed (cached) in'
-      else:
-        result = self._find_series(tags, requestContext)
-        if self.cache:
-          self.cache.set(cacheKey, result, self.settings.TAGDB_CACHE_DURATION)
-    except Exception:
-      log_msg = 'failed in'
-      raise
-    finally:
-      self.log_info(
-        'find_series',
-        '{msg} {sec:.6}s'.format(
-          msg=log_msg,
-          sec=time.time() - start_time,
-        )
-      )
+        try:
+            cacheKey = self.find_series_cachekey(tags, requestContext=requestContext)
+            result = self.cache.get(cacheKey) if self.cache else None
+            if result is not None:
+                log_msg = 'completed (cached) in'
+            else:
+                result = self._find_series(tags, requestContext)
+                if self.cache:
+                    self.cache.set(cacheKey, result, self.settings.TAGDB_CACHE_DURATION)
+        except Exception:
+            log_msg = 'failed in'
+            raise
+        finally:
+            self.log_info('find_series',
+                '{msg} {sec:.6}s'.format(
+                    msg=log_msg,
+                    sec=time.time() - start_time,
+                )
+            )
 
-    return result
+        return result
 
-  def find_series_cachekey(self, tags, requestContext=None):
-    return 'TagDB.find_series:' + ':'.join(sorted(tags))
+    def find_series_cachekey(self, tags, requestContext=None):
+        return 'TagDB.find_series:' + ':'.join(sorted(tags))
 
-  @abc.abstractmethod
-  def _find_series(self, tags, requestContext=None):
-    """
-    Internal function called by find_series, follows the same semantics allowing base class to implement caching
-    """
+    @abc.abstractmethod
+    def _find_series(self, tags, requestContext=None):
+        """
+        Internal function called by find_series, follows the same semantics allowing base class to implement caching
+        """
 
-  @abc.abstractmethod
-  def get_series(self, path, requestContext=None):
-    """
-    Get series by path, accepts a path string and returns a TaggedSeries object describing the series.
+    @abc.abstractmethod
+    def get_series(self, path, requestContext=None):
+        """
+        Get series by path, accepts a path string and returns a TaggedSeries object describing the series.
 
-    If the path is not found in the TagDB, returns None.
-    """
+        If the path is not found in the TagDB, returns None.
+        """
 
-  @abc.abstractmethod
-  def list_tags(self, tagFilter=None, limit=None, requestContext=None):
-    """
-    List defined tags, returns a list of dictionaries describing the tags stored in the TagDB.
+    @abc.abstractmethod
+    def list_tags(self, tagFilter=None, limit=None, requestContext=None):
+        """
+        List defined tags, returns a list of dictionaries describing the tags stored in the TagDB.
 
-    Each tag dict contains the key "tag" which holds the name of the tag.  Additional keys may be returned.
+        Each tag dict contains the key "tag" which holds the name of the tag.  Additional keys may be returned.
 
-    .. code-block:: none
+        .. code-block:: none
 
-      [
-        {
-          'tag': 'tag1',
-        },
-      ]
+          [
+            {
+              'tag': 'tag1',
+            },
+          ]
 
-    Accepts an optional tagFilter parameter which is a regular expression used to filter the list of returned tags.
-    """
+        Accepts an optional tagFilter parameter which is a regular expression used to filter the list of returned tags.
+        """
 
-  @abc.abstractmethod
-  def get_tag(self, tag, valueFilter=None, limit=None, requestContext=None):
-    """
-    Get details of a particular tag, accepts a tag name and returns a dict describing the tag.
+    @abc.abstractmethod
+    def get_tag(self, tag, valueFilter=None, limit=None, requestContext=None):
+        """
+        Get details of a particular tag, accepts a tag name and returns a dict describing the tag.
 
-    The dict contains the key "tag" which holds the name of the tag.  It also includes a "values" key,
-    which holds a list of the values for each tag.  See list_values() for the structure of each value.
+        The dict contains the key "tag" which holds the name of the tag.  It also includes a "values" key,
+        which holds a list of the values for each tag.  See list_values() for the structure of each value.
 
-    .. code-block:: none
+        .. code-block:: none
 
-      {
-        'tag': 'tag1',
-        'values': [
           {
-            'value': 'value1',
-            'count': 1,
+            'tag': 'tag1',
+            'values': [
+              {
+                'value': 'value1',
+                'count': 1,
+              }
+            ],
           }
-        ],
-      }
 
-    Accepts an optional valueFilter parameter which is a regular expression used to filter the list of returned values.
-    """
+        Accepts an optional valueFilter parameter which is a regular expression used to filter the list of returned values.
+        """
 
-  @abc.abstractmethod
-  def list_values(self, tag, valueFilter=None, limit=None, requestContext=None):
-    """
-    List values for a particular tag, returns a list of dictionaries describing the values stored in the TagDB.
+    @abc.abstractmethod
+    def list_values(self, tag, valueFilter=None, limit=None, requestContext=None):
+        """
+        List values for a particular tag, returns a list of dictionaries describing the values stored in the TagDB.
 
-    Each value dict contains the key "value" which holds the value, and the key "count" which is the number of
-    series that have that value.  Additional keys may be returned.
+        Each value dict contains the key "value" which holds the value, and the key "count" which is the number of
+        series that have that value.  Additional keys may be returned.
 
-    .. code-block:: none
+        .. code-block:: none
 
-      [
-        {
-          'value': 'value1',
-          'count': 1,
-        },
-      ]
+          [
+            {
+              'value': 'value1',
+              'count': 1,
+            },
+          ]
 
-    Accepts an optional valueFilter parameter which is a regular expression used to filter the list of returned values.
-    """
+        Accepts an optional valueFilter parameter which is a regular expression used to filter the list of returned values.
+        """
 
-  @abc.abstractmethod
-  def tag_series(self, series, requestContext=None):
-    """
-    Enter series into database.  Accepts a series string, upserts into the TagDB and returns the canonicalized series name.
-    """
+    @abc.abstractmethod
+    def tag_series(self, series, requestContext=None):
+        """
+        Enter series into database.  Accepts a series string, upserts into the TagDB and returns the canonicalized series name.
+        """
 
-  def tag_multi_series(self, seriesList, requestContext=None):
-    """
-    Enter series into database.  Accepts a list of series strings, upserts into the TagDB and returns a list of canonicalized series names.
-    """
-    return [self.tag_series(series, requestContext) for series in seriesList]
+    def tag_multi_series(self, seriesList, requestContext=None):
+        """
+        Enter series into database.  Accepts a list of series strings, upserts into the TagDB and returns a list of canonicalized series names.
+        """
+        return [self.tag_series(series, requestContext) for series in seriesList]
 
-  @abc.abstractmethod
-  def del_series(self, series, requestContext=None):
-    """
-    Remove series from database.  Accepts a series string and returns True
-    """
+    @abc.abstractmethod
+    def del_series(self, series, requestContext=None):
+        """
+        Remove series from database.  Accepts a series string and returns True
+        """
 
-  def del_multi_series(self, seriesList, requestContext=None):
-    """
-    Remove series from database.  Accepts a list of series strings, removes them from the TagDB and returns True
-    """
-    for series in seriesList:
-      self.del_series(series, requestContext)
-    return True
+    def del_multi_series(self, seriesList, requestContext=None):
+        """
+        Remove series from database.  Accepts a list of series strings, removes them from the TagDB and returns True
+        """
+        for series in seriesList:
+            self.del_series(series, requestContext)
+        return True
 
-  def auto_complete_tags(self, exprs, tagPrefix=None, limit=None, requestContext=None):
-    """
-    Return auto-complete suggestions for tags based on the matches for the specified expressions, optionally filtered by tag prefix
-    """
-    if limit is None:
-      limit = self.settings.TAGDB_AUTOCOMPLETE_LIMIT
-    else:
-      limit = int(limit)
-
-    if not exprs:
-      return [
-        tagInfo['tag'] for tagInfo in self.list_tags(
-          tagFilter='^(' + re.escape(tagPrefix) + ')' if tagPrefix else None,
-          limit=limit,
-          requestContext=requestContext,
-        )
-      ]
-
-    result = []
-
-    searchedTags = set([self.parse_tagspec(expr)[0] for expr in exprs])
-
-    for path in self.find_series(exprs, requestContext=requestContext):
-      try:
-        tags = self.parse(path).tags
-      except Exception:
-        continue
-
-      for tag in tags:
-        if tag in searchedTags:
-          continue
-        if tagPrefix and not tag.startswith(tagPrefix):
-          continue
-        if tag in result:
-          continue
-        if len(result) == 0 or tag >= result[-1]:
-          if len(result) >= limit:
-            continue
-          result.append(tag)
+    def auto_complete_tags(self, exprs, tagPrefix=None, limit=None, requestContext=None):
+        """
+        Return auto-complete suggestions for tags based on the matches for the specified expressions, optionally filtered by tag prefix
+        """
+        if limit is None:
+            limit = self.settings.TAGDB_AUTOCOMPLETE_LIMIT
         else:
-          bisect.insort_left(result, tag)
-        if len(result) > limit:
-          del result[-1]
+            limit = int(limit)
 
-    return result
+        if not exprs:
+            return [
+                tagInfo['tag'] for tagInfo in self.list_tags(
+                    tagFilter='^(' + re.escape(tagPrefix) + ')' if tagPrefix else None,
+                    limit=limit,
+                    requestContext=requestContext,
+                )
+            ]
 
-  def auto_complete_values(self, exprs, tag, valuePrefix=None, limit=None, requestContext=None):
-    """
-    Return auto-complete suggestions for tags and values based on the matches for the specified expressions, optionally filtered by tag and/or value prefix
-    """
-    if limit is None:
-      limit = self.settings.TAGDB_AUTOCOMPLETE_LIMIT
-    else:
-      limit = int(limit)
+        result = []
 
-    if not exprs:
-      return [
-        v['value'] for v in self.list_values(
-          tag,
-          valueFilter='^(' + re.escape(valuePrefix) + ')' if valuePrefix else None,
-          limit=limit,
-          requestContext=requestContext,
-        )
-      ]
+        searchedTags = set([self.parse_tagspec(expr)[0] for expr in exprs])
 
-    result = []
+        for path in self.find_series(exprs, requestContext=requestContext):
+            try:
+                tags = self.parse(path).tags
+            except Exception:
+                continue
 
-    for path in self.find_series(exprs + [tag + '!='], requestContext=requestContext):
-      try:
-        tags = self.parse(path).tags
-      except Exception:
-        continue
+            for tag in tags:
+                if tag in searchedTags:
+                    continue
+                if tagPrefix and not tag.startswith(tagPrefix):
+                    continue
+                if tag in result:
+                    continue
+                if len(result) == 0 or tag >= result[-1]:
+                    if len(result) >= limit:
+                        continue
+                    result.append(tag)
+                else:
+                    bisect.insort_left(result, tag)
+                if len(result) > limit:
+                    del result[-1]
 
-      if tag not in tags:
-        continue
-      value = tags[tag]
-      if valuePrefix and not value.startswith(valuePrefix):
-        continue
-      if value in result:
-        continue
-      if len(result) == 0 or value >= result[-1]:
-        if len(result) >= limit:
-          continue
-        result.append(value)
-      else:
-        bisect.insort_left(result, value)
-      if len(result) > limit:
-        del result[-1]
+        return result
 
-    return result
+    def auto_complete_values(self, exprs, tag, valuePrefix=None, limit=None, requestContext=None):
+        """
+        Return auto-complete suggestions for tags and values based on the matches for the specified expressions, optionally filtered by tag and/or value prefix
+        """
+        if limit is None:
+            limit = self.settings.TAGDB_AUTOCOMPLETE_LIMIT
+        else:
+            limit = int(limit)
 
-  def log_info(self, func, msg):
-    if self.log:
-      self.log.info('%s.%s.%s :: %s' % (self.__module__, self.__class__.__name__, func, msg))
+        if not exprs:
+            return [
+              v['value'] for v in self.list_values(
+                tag,
+                valueFilter='^(' + re.escape(valuePrefix) + ')' if valuePrefix else None,
+                limit=limit,
+                requestContext=requestContext,
+              )
+            ]
 
-  @staticmethod
-  def parse(path):
-    return TaggedSeries.parse(path)
+        result = []
 
-  @staticmethod
-  def parse_tagspec(tagspec):
-    m = re.match('^([^;!=]+)(!?=~?)([^;]*)$', tagspec)
-    if m is None:
-      raise ValueError("Invalid tagspec %s" % tagspec)
+        for path in self.find_series(exprs + [tag + '!='], requestContext=requestContext):
+            try:
+                tags = self.parse(path).tags
+            except Exception:
+                continue
 
-    tag = m.group(1)
-    operator = m.group(2)
-    spec = m.group(3)
+            if tag not in tags:
+                continue
+            value = tags[tag]
+            if valuePrefix and not value.startswith(valuePrefix):
+                continue
+            if value in result:
+                continue
+            if len(result) == 0 or value >= result[-1]:
+                if len(result) >= limit:
+                    continue
+                result.append(value)
+            else:
+                bisect.insort_left(result, value)
+            if len(result) > limit:
+                del result[-1]
 
-    return (tag, operator, spec)
+        return result
+
+    def log_info(self, func, msg):
+        if self.log:
+            self.log.info('%s.%s.%s :: %s' % (self.__module__, self.__class__.__name__, func, msg))
+
+    @staticmethod
+    def parse(path):
+        return TaggedSeries.parse(path)
+
+    @staticmethod
+    def parse_tagspec(tagspec):
+        m = re.match('^([^;!=]+)(!?=~?)([^;]*)$', tagspec)
+        if m is None:
+            raise ValueError("Invalid tagspec %s" % tagspec)
+
+        tag = m.group(1)
+        operator = m.group(2)
+        spec = m.group(3)
+
+        return (tag, operator, spec)
 
 
 class DummyTagDB(BaseTagDB):
 
-  def _find_series(self, tags, requestContext=None):
-    return []
+    def _find_series(self, tags, requestContext=None):
+        return []
 
-  def get_series(self, path, requestContext=None):
-    return None
+    def get_series(self, path, requestContext=None):
+        return None
 
-  def list_tags(self, tagFilter=None, limit=None, requestContext=None):
-    return []
+    def list_tags(self, tagFilter=None, limit=None, requestContext=None):
+        return []
 
-  def get_tag(self, tag, valueFilter=None, limit=None, requestContext=None):
-    return None
+    def get_tag(self, tag, valueFilter=None, limit=None, requestContext=None):
+        return None
 
-  def list_values(self, tag, valueFilter=None, limit=None, requestContext=None):
-    return []
+    def list_values(self, tag, valueFilter=None, limit=None, requestContext=None):
+        return []
 
-  def tag_series(self, series, requestContext=None):
-    raise NotImplementedError('Tagging not implemented with DummyTagDB')
+    def tag_series(self, series, requestContext=None):
+        raise NotImplementedError('Tagging not implemented with DummyTagDB')
 
-  def del_series(self, series, requestContext=None):
-    return True
+    def del_series(self, series, requestContext=None):
+        return True

--- a/webapp/graphite/tags/http.py
+++ b/webapp/graphite/tags/http.py
@@ -10,143 +10,147 @@ from graphite.tags.base import BaseTagDB
 
 
 class HttpTagDB(BaseTagDB):
-  """
-  Stores tag information using an external http service that implements the graphite tags API.
-  """
-  def __init__(self, settings, *args, **kwargs):
-    super(HttpTagDB, self).__init__(settings, *args, **kwargs)
-
-    self.base_url = settings.TAGDB_HTTP_URL
-    self.username = settings.TAGDB_HTTP_USER
-    self.password = settings.TAGDB_HTTP_PASSWORD
-
-  def request(self, method, url, fields, requestContext=None):
-    headers = requestContext.get('forwardHeaders') if requestContext else {}
-    if 'Authorization' not in headers and self.username and self.password:
-      user_pw = '%s:%s' % (self.username, self.password)
-      if sys.version_info[0] >= 3:
-        user_pw_b64 = b2a_base64(user_pw.encode('utf-8')).decode('ascii')
-      else:
-        user_pw_b64 = user_pw.encode('base64')
-      headers['Authorization'] = 'Basic ' + user_pw_b64
-
-    req_fields = []
-    for (field, value) in fields.items():
-      if value is None:
-        continue
-
-      if isinstance(value, list) or isinstance(value, tuple):
-        req_fields.extend([(field, v) for v in value if v is not None])
-      else:
-        req_fields.append((field, value))
-
-    result = http.request(
-      method,
-      self.base_url + url,
-      fields=req_fields,
-      headers=headers,
-      timeout=self.settings.FIND_TIMEOUT,
-    )
-
-    if result.status == 400:
-      raise ValueError(json.loads(result.data.decode('utf-8')).get('error'))
-
-    if result.status != 200:
-      raise Exception('HTTP Error from remote tagdb: %s %s' % (result.status, result.data))
-
-    return json.loads(result.data.decode('utf-8'))
-
-  def find_series_cachekey(self, tags, requestContext=None):
-    headers = [
-      header + '=' + value
-      for (header, value)
-      in (requestContext.get('forwardHeaders', {}) if requestContext else {}).items()
-    ]
-
-    return 'TagDB.find_series:' + ':'.join(sorted(tags)) + ':' + ':'.join(sorted(headers))
-
-  def _find_series(self, tags, requestContext=None):
-    return self.request(
-      'POST',
-      '/tags/findSeries',
-      {'expr': tags},
-      requestContext=requestContext,
-    )
-
-  def get_series(self, path, requestContext=None):
-    try:
-      parsed = self.parse(path)
-    except Exception:
-      return None
-
-    seriesList = self.find_series(
-      [('%s=%s' % (tag, parsed.tags[tag])) for tag in parsed.tags],
-      requestContext=requestContext,
-    )
-
-    if parsed.path in seriesList:
-      return parsed
-
-  def list_tags(self, tagFilter=None, limit=None, requestContext=None):
-    return self.request('GET', '/tags', {'filter': tagFilter, 'limit': limit}, requestContext)
-
-  def get_tag(self, tag, valueFilter=None, limit=None, requestContext=None):
-    return self.request('GET', '/tags/' + tag, {'filter': valueFilter, 'limit': limit}, requestContext)
-
-  def list_values(self, tag, valueFilter=None, limit=None, requestContext=None):
-    tagInfo = self.get_tag(tag, valueFilter=valueFilter, limit=limit, requestContext=requestContext)
-    if not tagInfo:
-      return []
-
-    return tagInfo['values']
-
-  def tag_series(self, series, requestContext=None):
-    return self.request('POST', '/tags/tagSeries', {'path': series}, requestContext)
-
-  def tag_multi_series(self, seriesList, requestContext=None):
-    return self.request('POST', '/tags/tagMultiSeries', {'path': seriesList}, requestContext)
-
-  def del_series(self, series, requestContext=None):
-    return self.request('POST', '/tags/delSeries', {'path': series}, requestContext)
-
-  def del_multi_series(self, seriesList, requestContext=None):
-    return self.request('POST', '/tags/delSeries', {'path': seriesList}, requestContext)
-
-  def auto_complete_tags(self, exprs, tagPrefix=None, limit=None, requestContext=None):
     """
-    Return auto-complete suggestions for tags based on the matches for the specified expressions, optionally filtered by tag prefix
+    Stores tag information using an external http service that implements the graphite tags API.
     """
-    if not self.settings.TAGDB_HTTP_AUTOCOMPLETE:
-      return super(HttpTagDB, self).auto_complete_tags(
-        exprs, tagPrefix=tagPrefix, limit=limit, requestContext=requestContext)
+    def __init__(self, settings, *args, **kwargs):
+        super(HttpTagDB, self).__init__(settings, *args, **kwargs)
 
-    if limit is None:
-      limit = self.settings.TAGDB_AUTOCOMPLETE_LIMIT
+        self.base_url = settings.TAGDB_HTTP_URL
+        self.username = settings.TAGDB_HTTP_USER
+        self.password = settings.TAGDB_HTTP_PASSWORD
 
-    fields = {
-      'tagPrefix': tagPrefix or '',
-      'limit': str(limit),
-      'expr': exprs,
-    }
+    def request(self, method, url, fields, requestContext=None):
+        headers = requestContext.get('forwardHeaders') if requestContext else {}
+        if 'Authorization' not in headers and self.username and self.password:
+            user_pw = '%s:%s' % (self.username, self.password)
+            if sys.version_info[0] >= 3:
+                user_pw_b64 = b2a_base64(user_pw.encode('utf-8')).decode('ascii')
+            else:
+                user_pw_b64 = user_pw.encode('base64')
+            headers['Authorization'] = 'Basic ' + user_pw_b64
 
-    return self.request('POST', '/tags/autoComplete/tags', fields, requestContext)
+        req_fields = []
+        for (field, value) in fields.items():
+            if value is None:
+                continue
 
-  def auto_complete_values(self, exprs, tag, valuePrefix=None, limit=None, requestContext=None):
-    """
-    Return auto-complete suggestions for tags and values based on the matches for the specified expressions, optionally filtered by tag and/or value prefix
-    """
-    if not self.settings.TAGDB_HTTP_AUTOCOMPLETE:
-      return super(HttpTagDB, self).auto_complete_values(
-        exprs, tag, valuePrefix=valuePrefix, limit=limit, requestContext=requestContext)
+            if isinstance(value, list) or isinstance(value, tuple):
+                req_fields.extend([(field, v) for v in value if v is not None])
+            else:
+                req_fields.append((field, value))
 
-    if limit is None:
-      limit = self.settings.TAGDB_AUTOCOMPLETE_LIMIT
+        result = http.request(
+            method,
+            self.base_url + url,
+            fields=req_fields,
+            headers=headers,
+            timeout=self.settings.FIND_TIMEOUT,
+        )
 
-    fields = {
-      'tag': tag or '',
-      'valuePrefix': valuePrefix or '',
-      'limit': str(limit),
-      'expr': exprs,
-    }
+        if result.status == 400:
+            raise ValueError(json.loads(result.data.decode('utf-8')).get('error'))
 
-    return self.request('POST', '/tags/autoComplete/values', fields, requestContext)
+        if result.status != 200:
+            raise Exception('HTTP Error from remote tagdb: %s %s' % (result.status, result.data))
+
+        return json.loads(result.data.decode('utf-8'))
+
+    def find_series_cachekey(self, tags, requestContext=None):
+        headers = [
+            header + '=' + value
+            for (header, value)
+            in (requestContext or {}).get('forwardHeaders', {}).items()
+        ]
+
+        return 'TagDB.find_series:' + ':'.join(sorted(tags)) + ':' + ':'.join(sorted(headers))
+
+    def _find_series(self, tags, requestContext=None):
+        return self.request(
+            'POST',
+            '/tags/findSeries',
+            {'expr': tags},
+            requestContext=requestContext,
+        )
+
+    def get_series(self, path, requestContext=None):
+        try:
+            parsed = self.parse(path)
+        except Exception:
+            return None
+
+        seriesList = self.find_series(
+            [('%s=%s' % (tag, parsed.tags[tag])) for tag in parsed.tags],
+            requestContext=requestContext,
+        )
+
+        if parsed.path in seriesList:
+            return parsed
+
+    def list_tags(self, tagFilter=None, limit=None, requestContext=None):
+        return self.request('GET', '/tags', {'filter': tagFilter, 'limit': limit}, requestContext)
+
+    def get_tag(self, tag, valueFilter=None, limit=None, requestContext=None):
+        return self.request('GET', '/tags/' + tag, {'filter': valueFilter, 'limit': limit}, requestContext)
+
+    def list_values(self, tag, valueFilter=None, limit=None, requestContext=None):
+        tagInfo = self.get_tag(tag, valueFilter=valueFilter, limit=limit, requestContext=requestContext)
+        if not tagInfo:
+            return []
+
+        return tagInfo['values']
+
+    def tag_series(self, series, requestContext=None):
+        return self.request('POST', '/tags/tagSeries', {'path': series}, requestContext)
+
+    def tag_multi_series(self, seriesList, requestContext=None):
+        return self.request('POST', '/tags/tagMultiSeries', {'path': seriesList}, requestContext)
+
+    def del_series(self, series, requestContext=None):
+        return self.request('POST', '/tags/delSeries', {'path': series}, requestContext)
+
+    def del_multi_series(self, seriesList, requestContext=None):
+        return self.request('POST', '/tags/delSeries', {'path': seriesList}, requestContext)
+
+    def auto_complete_tags(self, exprs, tagPrefix=None, limit=None, requestContext=None):
+        """
+        Return auto-complete suggestions for tags based on the matches
+        for the specified expressions, optionally filtered by tag prefix
+        """
+        if not self.settings.TAGDB_HTTP_AUTOCOMPLETE:
+            return super(HttpTagDB, self).auto_complete_tags(
+                exprs, tagPrefix=tagPrefix, limit=limit, requestContext=requestContext
+            )
+
+        if limit is None:
+            limit = self.settings.TAGDB_AUTOCOMPLETE_LIMIT
+
+        fields = {
+            'tagPrefix': tagPrefix or '',
+            'limit': str(limit),
+            'expr': exprs,
+        }
+
+        return self.request('POST', '/tags/autoComplete/tags', fields, requestContext)
+
+    def auto_complete_values(self, exprs, tag, valuePrefix=None, limit=None, requestContext=None):
+        """
+        Return auto-complete suggestions for tags and values based on the matches
+        for the specified expressions, optionally filtered by tag and/or value prefix
+        """
+        if not self.settings.TAGDB_HTTP_AUTOCOMPLETE:
+            return super(HttpTagDB, self).auto_complete_values(
+                exprs, tag, valuePrefix=valuePrefix, limit=limit, requestContext=requestContext
+            )
+
+        if limit is None:
+            limit = self.settings.TAGDB_AUTOCOMPLETE_LIMIT
+
+        fields = {
+            'tag': tag or '',
+            'valuePrefix': valuePrefix or '',
+            'limit': str(limit),
+            'expr': exprs,
+        }
+
+        return self.request('POST', '/tags/autoComplete/values', fields, requestContext)

--- a/webapp/graphite/tags/localdatabase.py
+++ b/webapp/graphite/tags/localdatabase.py
@@ -7,333 +7,333 @@ from graphite.tags.base import BaseTagDB, TaggedSeries
 
 
 class LocalDatabaseTagDB(BaseTagDB):
-  def find_series_query(self, tags):
-    # sql will select series that match all tag expressions that don't match empty tags
-    sql = 'SELECT s.path'
-    sql += ' FROM tags_series AS s'
-    params = []
+    def find_series_query(self, tags):
+        # sql will select series that match all tag expressions that don't match empty tags
+        sql = 'SELECT s.path'
+        sql += ' FROM tags_series AS s'
+        params = []
 
-    where = []
-    whereparams = []
+        where = []
+        whereparams = []
 
-    all_match_empty = True
+        all_match_empty = True
 
-    # expressions that do match empty tags will be used to filter the result
-    filters = []
+        # expressions that do match empty tags will be used to filter the result
+        filters = []
 
-    i = 0
-    for tagspec in tags:
-      (tag, operator, spec) = self.parse_tagspec(tagspec)
+        i = 0
+        for tagspec in tags:
+            (tag, operator, spec) = self.parse_tagspec(tagspec)
 
-      i += 1
-      s = str(i)
+            i += 1
+            s = str(i)
 
-      if operator == '=':
-        matches_empty = spec == ''
+            if operator == '=':
+                matches_empty = spec == ''
 
-        if not matches_empty:
-          where.append('v' + s + '.value=%s')
-          whereparams.append(spec)
+                if not matches_empty:
+                    where.append('v' + s + '.value=%s')
+                    whereparams.append(spec)
 
-      elif operator == '=~':
-        # make sure regex is anchored
-        if not spec.startswith('^'):
-          spec = '^(' + spec + ')'
+            elif operator == '=~':
+                # make sure regex is anchored
+                if not spec.startswith('^'):
+                    spec = '^(' + spec + ')'
 
-        matches_empty = bool(re.match(spec, ''))
+                matches_empty = bool(re.match(spec, ''))
 
-        if not matches_empty:
-          where.append('v' + s + '.value ' + self._regexp_operator(connection) + ' %s')
-          whereparams.append(spec)
+                if not matches_empty:
+                    where.append('v' + s + '.value ' + self._regexp_operator(connection) + ' %s')
+                    whereparams.append(spec)
 
-      elif operator == '!=':
-        matches_empty = spec != ''
+            elif operator == '!=':
+                matches_empty = spec != ''
 
-        if not matches_empty:
-          where.append('v' + s + '.value<>%s')
-          whereparams.append(spec)
+                if not matches_empty:
+                    where.append('v' + s + '.value<>%s')
+                    whereparams.append(spec)
 
-      elif operator == '!=~':
-        # make sure regex is anchored
-        if not spec.startswith('^'):
-          spec = '^(' + spec + ')'
+            elif operator == '!=~':
+                # make sure regex is anchored
+                if not spec.startswith('^'):
+                    spec = '^(' + spec + ')'
 
-        matches_empty = not re.match(spec, '')
+                matches_empty = not re.match(spec, '')
 
-        if not matches_empty:
-          where.append('v' + s + '.value ' + self._regexp_not_operator(connection) + ' %s')
-          whereparams.append(spec)
+                if not matches_empty:
+                    where.append('v' + s + '.value ' + self._regexp_not_operator(connection) + ' %s')
+                    whereparams.append(spec)
 
-      else:
-        raise ValueError("Invalid operator %s" % operator)
+            else:
+                raise ValueError("Invalid operator %s" % operator)
 
-      if matches_empty:
-        filters.append((tag, operator, spec))
-      else:
-        sql += ' JOIN tags_tag AS t' + s + ' ON t' + s + '.tag=%s'
-        params.append(tag)
-        sql += ' JOIN tags_seriestag AS st' + s + ' ON st' + s + '.series_id=s.id AND st' + s + '.tag_id=t' + s + '.id'
-        sql += ' JOIN tags_tagvalue AS v' + s + ' ON v' + s + '.id=st' + s + '.value_id'
+            if matches_empty:
+                filters.append((tag, operator, spec))
+            else:
+                sql += ' JOIN tags_tag AS t' + s + ' ON t' + s + '.tag=%s'
+                params.append(tag)
+                sql += ' JOIN tags_seriestag AS st' + s + ' ON st' + s + '.series_id=s.id AND st' + s + '.tag_id=t' + s + '.id'
+                sql += ' JOIN tags_tagvalue AS v' + s + ' ON v' + s + '.id=st' + s + '.value_id'
 
-      all_match_empty = all_match_empty and matches_empty
+            all_match_empty = all_match_empty and matches_empty
 
-    if all_match_empty:
-      raise ValueError("At least one tagspec must not match the empty string")
+        if all_match_empty:
+            raise ValueError("At least one tagspec must not match the empty string")
 
-    if where:
-      sql += ' WHERE ' + ' AND '.join(where)
-      params.extend(whereparams)
+        if where:
+            sql += ' WHERE ' + ' AND '.join(where)
+            params.extend(whereparams)
 
-    sql += ' ORDER BY s.path'
+        sql += ' ORDER BY s.path'
 
-    return sql, params, filters
+        return sql, params, filters
 
-  def _find_series(self, tags, requestContext=None):
-    sql, params, filters = self.find_series_query(tags)
+    def _find_series(self, tags, requestContext=None):
+        sql, params, filters = self.find_series_query(tags)
 
-    def matches_filters(path):
-      if not filters:
+        def matches_filters(path):
+            if not filters:
+                return True
+
+            try:
+                parsed = self.parse(path)
+            except Exception:
+                return False
+
+            for (tag, operator, spec) in filters:
+                value = parsed.tags.get(tag, '')
+                if (
+                    (operator == '=' and value != spec) or
+                    (operator == '=~' and re.match(spec, value) is None) or
+                    (operator == '!=' and value == spec) or
+                    (operator == '!=~' and re.match(spec, value) is not None)
+                ):
+                    return False
+
+            return True
+
+        with connection.cursor() as cursor:
+            cursor.execute(sql, params)
+
+            return [row[0] for row in cursor if matches_filters(row[0])]
+
+    @staticmethod
+    def _path_hash(path):
+        return sha256(path.encode('utf8')).hexdigest()
+
+    def get_series(self, path, requestContext=None):
+        return self._get_series(self._path_hash(path))
+
+    @staticmethod
+    def _get_series(path_hash):
+        with connection.cursor() as cursor:
+            sql = 'SELECT s.id, t.tag, v.value'
+            sql += ' FROM tags_series AS s'
+            sql += ' JOIN tags_seriestag AS st ON st.series_id=s.id'
+            sql += ' JOIN tags_tag AS t ON t.id=st.tag_id'
+            sql += ' JOIN tags_tagvalue AS v ON v.id=st.value_id'
+            sql += ' WHERE s.hash=%s'
+            params = [path_hash]
+            cursor.execute(sql, params)
+
+            series_id = None
+
+            tags = {tag: value for (series_id, tag, value) in cursor}
+
+            if not tags:
+                return None
+
+            return TaggedSeries(tags['name'], tags, series_id=series_id)
+
+    def list_tags(self, tagFilter=None, limit=None, requestContext=None):
+        with connection.cursor() as cursor:
+            sql = 'SELECT t.id, t.tag'
+            sql += ' FROM tags_tag AS t'
+            params = []
+
+            if tagFilter:
+                # make sure regex is anchored
+                if not tagFilter.startswith('^'):
+                    tagFilter = '^(' + tagFilter + ')'
+                sql += ' WHERE t.tag ' + self._regexp_operator(connection) + ' %s'
+                params.append(tagFilter)
+
+            sql += ' ORDER BY t.tag'
+
+            if limit:
+                sql += ' LIMIT %s'
+                params.append(int(limit))
+
+            cursor.execute(sql, params)
+
+            return [{'id': tag_id, 'tag': tag} for (tag_id, tag) in cursor]
+
+    def get_tag(self, tag, valueFilter=None, limit=None, requestContext=None):
+        with connection.cursor() as cursor:
+            sql = 'SELECT t.id, t.tag'
+            sql += ' FROM tags_tag AS t'
+            sql += ' WHERE t.tag=%s'
+            params = [tag]
+            cursor.execute(sql, params)
+
+            row = cursor.fetchone()
+
+        if not row:
+            return None
+
+        (tag_id, tag) = row
+
+        return {
+            'id': tag_id,
+            'tag': tag,
+            'values': self.list_values(
+                tag,
+                valueFilter=valueFilter,
+                limit=limit,
+                requestContext=requestContext
+            ),
+        }
+
+    def list_values(self, tag, valueFilter=None, limit=None, requestContext=None):
+        with connection.cursor() as cursor:
+            sql = 'SELECT v.id, v.value, COUNT(st.id)'
+            sql += ' FROM tags_tagvalue AS v'
+            sql += ' JOIN tags_seriestag AS st ON st.value_id=v.id'
+            sql += ' JOIN tags_tag AS t ON t.id=st.tag_id'
+            sql += ' WHERE t.tag=%s'
+            params = [tag]
+
+            if valueFilter:
+                # make sure regex is anchored
+                if not valueFilter.startswith('^'):
+                    valueFilter = '^(' + valueFilter + ')'
+                sql += ' AND v.value ' + self._regexp_operator(connection) + ' %s'
+                params.append(valueFilter)
+
+            sql += ' GROUP BY v.id, v.value'
+            sql += ' ORDER BY v.value'
+
+            if limit:
+                sql += ' LIMIT %s'
+                params.append(int(limit))
+
+            cursor.execute(sql, params)
+
+            return [{'id': value_id, 'value': value, 'count': count} for (value_id, value, count) in cursor]
+
+    @staticmethod
+    def _insert_ignore(table, cols, data):
+        sql = table + ' (' + ','.join(cols) + ') VALUES ' + ', '.join(['(' + ', '.join(['%s'] * len(cols)) + ')'] * len(data))
+        params = []
+        for row in data:
+            params.extend(row)
+
+        if connection.vendor == 'mysql':
+            sql = 'INSERT IGNORE INTO ' + sql
+        elif connection.vendor == 'sqlite':
+            sql = 'INSERT OR IGNORE INTO ' + sql
+        elif connection.vendor == 'postgresql':
+            sql = 'INSERT INTO ' + sql + ' ON CONFLICT DO NOTHING'  # nosec
+        else:
+            raise Exception('Unsupported database vendor ' + connection.vendor)
+
+        with connection.cursor() as cursor:
+            cursor.execute(sql, params)
+
+    @staticmethod
+    def _regexp_operator(connection):
+        if connection.vendor == 'mysql':
+            return 'REGEXP'
+        if connection.vendor == 'sqlite':
+            # django provides an implementation of REGEXP for sqlite
+            return 'REGEXP'
+        if connection.vendor == 'postgresql':
+            return '~*'
+        raise Exception('Database vendor ' + connection.vendor + ' does not support regular expressions')
+
+    @staticmethod
+    def _regexp_not_operator(connection):
+        if connection.vendor == 'mysql':
+            return 'NOT REGEXP'
+        if connection.vendor == 'sqlite':
+            # django provides an implementation of REGEXP for sqlite
+            return 'NOT REGEXP'
+        if connection.vendor == 'postgresql':
+            return '!~*'
+        raise Exception('Database vendor ' + connection.vendor + ' does not support regular expressions')
+
+    def tag_series(self, series, requestContext=None):
+        # extract tags and normalize path
+        parsed = self.parse(series)
+
+        path = parsed.path
+        path_hash = self._path_hash(path)
+
+        # check if path is already tagged
+        curr = self._get_series(path_hash)
+        if curr and parsed.tags == curr.tags:
+            return path
+
+        with connection.cursor() as cursor:
+            # tags
+            self._insert_ignore('tags_tag', ['tag'], [[tag] for tag in parsed.tags.keys()])
+
+            sql = 'SELECT id, tag FROM tags_tag WHERE tag IN (' + ', '.join(['%s'] * len(parsed.tags)) + ')'  # nosec
+            params = list(parsed.tags.keys())
+            cursor.execute(sql, params)
+            tag_ids = {tag: tag_id for (tag_id, tag) in cursor}
+
+            # tag values
+            self._insert_ignore('tags_tagvalue', ['value'], [[value] for value in parsed.tags.values()])
+
+            sql = 'SELECT id, value FROM tags_tagvalue WHERE value IN (' + ', '.join(['%s'] * len(parsed.tags)) + ')'  # nosec
+            params = list(parsed.tags.values())
+            cursor.execute(sql, params)
+            value_ids = {value: value_id for (value_id, value) in cursor}
+
+            # series
+            if curr:
+                series_id = curr.id
+            else:
+                # hash column is used to support a unique index in mysql since path can be longer than 191 characters
+                self._insert_ignore('tags_series', ['hash', 'path'], [[path_hash, path]])
+
+                sql = 'SELECT id FROM tags_series WHERE hash=%s'
+                params = [path_hash]
+                cursor.execute(sql, params)
+                series_id = cursor.fetchone()[0]
+
+            # series tags
+            self._insert_ignore(
+                'tags_seriestag',
+                ['series_id', 'tag_id', 'value_id'],
+                [[series_id, tag_ids[tag], value_ids[value]] for tag, value in parsed.tags.items()]
+            )
+
+        return path
+
+    def del_series(self, series, requestContext=None):
+        # extract tags and normalize path
+        parsed = self.parse(series)
+        path_hash = self._path_hash(parsed.path)
+
+        with connection.cursor() as cursor:
+            sql = 'SELECT id FROM tags_series WHERE hash=%s'
+            params = [path_hash]
+            cursor.execute(sql, params)
+
+            row = cursor.fetchone()
+            if not row:
+                return True
+
+            (series_id, ) = row
+
+            sql = 'DELETE FROM tags_seriestag WHERE series_id=%s'
+            params = [series_id]
+            cursor.execute(sql, params)
+
+            sql = 'DELETE FROM tags_series WHERE id=%s'
+            params = [series_id]
+            cursor.execute(sql, params)
+
         return True
-
-      try:
-        parsed = self.parse(path)
-      except Exception:
-        return False
-
-      for (tag, operator, spec) in filters:
-        value = parsed.tags.get(tag, '')
-        if (
-          (operator == '=' and value != spec) or
-          (operator == '=~' and re.match(spec, value) is None) or
-          (operator == '!=' and value == spec) or
-          (operator == '!=~' and re.match(spec, value) is not None)
-        ):
-          return False
-
-      return True
-
-    with connection.cursor() as cursor:
-      cursor.execute(sql, params)
-
-      return [row[0] for row in cursor if matches_filters(row[0])]
-
-  @staticmethod
-  def _path_hash(path):
-    return sha256(path.encode('utf8')).hexdigest()
-
-  def get_series(self, path, requestContext=None):
-    return self._get_series(self._path_hash(path))
-
-  @staticmethod
-  def _get_series(path_hash):
-    with connection.cursor() as cursor:
-      sql = 'SELECT s.id, t.tag, v.value'
-      sql += ' FROM tags_series AS s'
-      sql += ' JOIN tags_seriestag AS st ON st.series_id=s.id'
-      sql += ' JOIN tags_tag AS t ON t.id=st.tag_id'
-      sql += ' JOIN tags_tagvalue AS v ON v.id=st.value_id'
-      sql += ' WHERE s.hash=%s'
-      params = [path_hash]
-      cursor.execute(sql, params)
-
-      series_id = None
-
-      tags = {tag: value for (series_id, tag, value) in cursor}
-
-      if not tags:
-        return None
-
-      return TaggedSeries(tags['name'], tags, series_id=series_id)
-
-  def list_tags(self, tagFilter=None, limit=None, requestContext=None):
-    with connection.cursor() as cursor:
-      sql = 'SELECT t.id, t.tag'
-      sql += ' FROM tags_tag AS t'
-      params = []
-
-      if tagFilter:
-        # make sure regex is anchored
-        if not tagFilter.startswith('^'):
-          tagFilter = '^(' + tagFilter + ')'
-        sql += ' WHERE t.tag ' + self._regexp_operator(connection) + ' %s'
-        params.append(tagFilter)
-
-      sql += ' ORDER BY t.tag'
-
-      if limit:
-        sql += ' LIMIT %s'
-        params.append(int(limit))
-
-      cursor.execute(sql, params)
-
-      return [{'id': tag_id, 'tag': tag} for (tag_id, tag) in cursor]
-
-  def get_tag(self, tag, valueFilter=None, limit=None, requestContext=None):
-    with connection.cursor() as cursor:
-      sql = 'SELECT t.id, t.tag'
-      sql += ' FROM tags_tag AS t'
-      sql += ' WHERE t.tag=%s'
-      params = [tag]
-      cursor.execute(sql, params)
-
-      row = cursor.fetchone()
-
-    if not row:
-      return None
-
-    (tag_id, tag) = row
-
-    return {
-      'id': tag_id,
-      'tag': tag,
-      'values': self.list_values(
-        tag,
-        valueFilter=valueFilter,
-        limit=limit,
-        requestContext=requestContext
-      ),
-    }
-
-  def list_values(self, tag, valueFilter=None, limit=None, requestContext=None):
-    with connection.cursor() as cursor:
-      sql = 'SELECT v.id, v.value, COUNT(st.id)'
-      sql += ' FROM tags_tagvalue AS v'
-      sql += ' JOIN tags_seriestag AS st ON st.value_id=v.id'
-      sql += ' JOIN tags_tag AS t ON t.id=st.tag_id'
-      sql += ' WHERE t.tag=%s'
-      params = [tag]
-
-      if valueFilter:
-        # make sure regex is anchored
-        if not valueFilter.startswith('^'):
-          valueFilter = '^(' + valueFilter + ')'
-        sql += ' AND v.value ' + self._regexp_operator(connection) + ' %s'
-        params.append(valueFilter)
-
-      sql += ' GROUP BY v.id, v.value'
-      sql += ' ORDER BY v.value'
-
-      if limit:
-        sql += ' LIMIT %s'
-        params.append(int(limit))
-
-      cursor.execute(sql, params)
-
-      return [{'id': value_id, 'value': value, 'count': count} for (value_id, value, count) in cursor]
-
-  @staticmethod
-  def _insert_ignore(table, cols, data):
-    sql = table + ' (' + ','.join(cols) + ') VALUES ' + ', '.join(['(' + ', '.join(['%s'] * len(cols)) + ')'] * len(data))
-    params = []
-    for row in data:
-      params.extend(row)
-
-    if connection.vendor == 'mysql':
-      sql = 'INSERT IGNORE INTO ' + sql
-    elif connection.vendor == 'sqlite':
-      sql = 'INSERT OR IGNORE INTO ' + sql
-    elif connection.vendor == 'postgresql':
-      sql = 'INSERT INTO ' + sql + ' ON CONFLICT DO NOTHING'  # nosec
-    else:
-      raise Exception('Unsupported database vendor ' + connection.vendor)
-
-    with connection.cursor() as cursor:
-      cursor.execute(sql, params)
-
-  @staticmethod
-  def _regexp_operator(connection):
-    if connection.vendor == 'mysql':
-      return 'REGEXP'
-    if connection.vendor == 'sqlite':
-      # django provides an implementation of REGEXP for sqlite
-      return 'REGEXP'
-    if connection.vendor == 'postgresql':
-      return '~*'
-    raise Exception('Database vendor ' + connection.vendor + ' does not support regular expressions')
-
-  @staticmethod
-  def _regexp_not_operator(connection):
-    if connection.vendor == 'mysql':
-      return 'NOT REGEXP'
-    if connection.vendor == 'sqlite':
-      # django provides an implementation of REGEXP for sqlite
-      return 'NOT REGEXP'
-    if connection.vendor == 'postgresql':
-      return '!~*'
-    raise Exception('Database vendor ' + connection.vendor + ' does not support regular expressions')
-
-  def tag_series(self, series, requestContext=None):
-    # extract tags and normalize path
-    parsed = self.parse(series)
-
-    path = parsed.path
-    path_hash = self._path_hash(path)
-
-    # check if path is already tagged
-    curr = self._get_series(path_hash)
-    if curr and parsed.tags == curr.tags:
-      return path
-
-    with connection.cursor() as cursor:
-      # tags
-      self._insert_ignore('tags_tag', ['tag'], [[tag] for tag in parsed.tags.keys()])
-
-      sql = 'SELECT id, tag FROM tags_tag WHERE tag IN (' + ', '.join(['%s'] * len(parsed.tags)) + ')'  # nosec
-      params = list(parsed.tags.keys())
-      cursor.execute(sql, params)
-      tag_ids = {tag: tag_id for (tag_id, tag) in cursor}
-
-      # tag values
-      self._insert_ignore('tags_tagvalue', ['value'], [[value] for value in parsed.tags.values()])
-
-      sql = 'SELECT id, value FROM tags_tagvalue WHERE value IN (' + ', '.join(['%s'] * len(parsed.tags)) + ')'  # nosec
-      params = list(parsed.tags.values())
-      cursor.execute(sql, params)
-      value_ids = {value: value_id for (value_id, value) in cursor}
-
-      # series
-      if curr:
-        series_id = curr.id
-      else:
-        # hash column is used to support a unique index in mysql since path can be longer than 191 characters
-        self._insert_ignore('tags_series', ['hash', 'path'], [[path_hash, path]])
-
-        sql = 'SELECT id FROM tags_series WHERE hash=%s'
-        params = [path_hash]
-        cursor.execute(sql, params)
-        series_id = cursor.fetchone()[0]
-
-      # series tags
-      self._insert_ignore(
-        'tags_seriestag',
-        ['series_id', 'tag_id', 'value_id'],
-        [[series_id, tag_ids[tag], value_ids[value]] for tag, value in parsed.tags.items()]
-      )
-
-    return path
-
-  def del_series(self, series, requestContext=None):
-    # extract tags and normalize path
-    parsed = self.parse(series)
-    path_hash = self._path_hash(parsed.path)
-
-    with connection.cursor() as cursor:
-      sql = 'SELECT id FROM tags_series WHERE hash=%s'
-      params = [path_hash]
-      cursor.execute(sql, params)
-
-      row = cursor.fetchone()
-      if not row:
-        return True
-
-      (series_id, ) = row
-
-      sql = 'DELETE FROM tags_seriestag WHERE series_id=%s'
-      params = [series_id]
-      cursor.execute(sql, params)
-
-      sql = 'DELETE FROM tags_series WHERE id=%s'
-      params = [series_id]
-      cursor.execute(sql, params)
-
-    return True

--- a/webapp/graphite/tags/models.py
+++ b/webapp/graphite/tags/models.py
@@ -2,27 +2,27 @@ from django.db import models
 
 
 class Series(models.Model):
-  hash = models.CharField(max_length=64, unique=True)
-  path = models.TextField()
-  __str__ = lambda self: "Series [%s]" % self.path
+    hash = models.CharField(max_length=64, unique=True)
+    path = models.TextField()
+    __str__ = lambda self: "Series [%s]" % self.path
 
 
 class Tag(models.Model):
-  tag = models.CharField(max_length=191, unique=True)
-  __str__ = lambda self: "Tag [%s]" % self.tag
+    tag = models.CharField(max_length=191, unique=True)
+    __str__ = lambda self: "Tag [%s]" % self.tag
 
 
 class TagValue(models.Model):
-  value = models.CharField(max_length=191, unique=True)
-  __str__ = lambda self: "TagValue [%s]" % self.value
+    value = models.CharField(max_length=191, unique=True)
+    __str__ = lambda self: "TagValue [%s]" % self.value
 
 
 class SeriesTag(models.Model):
-  series = models.ForeignKey(Series, on_delete=models.CASCADE)
-  tag = models.ForeignKey(Tag, on_delete=models.CASCADE)
-  value = models.ForeignKey(TagValue, on_delete=models.CASCADE)
+    series = models.ForeignKey(Series, on_delete=models.CASCADE)
+    tag = models.ForeignKey(Tag, on_delete=models.CASCADE)
+    value = models.ForeignKey(TagValue, on_delete=models.CASCADE)
 
-  class Meta:
-    unique_together = ("series", "tag")
+    class Meta:
+        unique_together = ("series", "tag")
 
-  __str__ = lambda self: "SeriesTag [%s %s %s]" % (self.series, self.tag, self.value)
+    __str__ = lambda self: "SeriesTag [%s %s %s]" % (self.series, self.tag, self.value)

--- a/webapp/graphite/tags/redis.py
+++ b/webapp/graphite/tags/redis.py
@@ -8,257 +8,257 @@ from graphite.tags.base import BaseTagDB, TaggedSeries
 
 
 class RedisTagDB(BaseTagDB):
-  """
-  Stores tag information in a Redis database.
+    """
+    Stores tag information in a Redis database.
 
-  Keys used are:
+    Keys used are:
 
-  .. code-block:: none
+    .. code-block:: none
 
-    series                    # Set of all paths
-    series:<path>:tags        # Hash of all tag:value pairs for path
-    tags                      # Set of all tags
-    tags:<tag>:series         # Set of paths with entry for tag
-    tags:<tag>:values         # Set of values for tag
-    tags:<tag>:values:<value> # Set of paths matching tag/value
+      series                    # Set of all paths
+      series:<path>:tags        # Hash of all tag:value pairs for path
+      tags                      # Set of all tags
+      tags:<tag>:series         # Set of paths with entry for tag
+      tags:<tag>:values         # Set of values for tag
+      tags:<tag>:values:<value> # Set of paths matching tag/value
 
-  """
-  def __init__(self, settings, *args, **kwargs):
-    super(RedisTagDB, self).__init__(settings, *args, **kwargs)
+    """
+    def __init__(self, settings, *args, **kwargs):
+        super(RedisTagDB, self).__init__(settings, *args, **kwargs)
 
-    from redis import Redis
+        from redis import Redis
 
-    self.r = Redis(
-      host=settings.TAGDB_REDIS_HOST,
-      port=settings.TAGDB_REDIS_PORT,
-      db=settings.TAGDB_REDIS_DB,
-      password=settings.TAGDB_REDIS_PASSWORD,
-      decode_responses=(sys.version_info[0] >= 3),
-    )
+        self.r = Redis(
+            host=settings.TAGDB_REDIS_HOST,
+            port=settings.TAGDB_REDIS_PORT,
+            db=settings.TAGDB_REDIS_DB,
+            password=settings.TAGDB_REDIS_PASSWORD,
+            decode_responses=(sys.version_info[0] >= 3),
+        )
 
-  def _find_series(self, tags, requestContext=None):
-    selector = None
-    selector_cnt = None
-    filters = []
+    def _find_series(self, tags, requestContext=None):
+        selector = None
+        selector_cnt = None
+        filters = []
 
-    # loop through tagspecs, look for best spec to use as selector
-    for tagspec in tags:
-      (tag, operator, spec) = self.parse_tagspec(tagspec)
+        # loop through tagspecs, look for best spec to use as selector
+        for tagspec in tags:
+            (tag, operator, spec) = self.parse_tagspec(tagspec)
 
-      if operator == '=':
-        matches_empty = spec == ''
-        if not matches_empty:
-          cnt = self.r.scard('tags:' + tag + ':values:' + spec)
-          if not selector or selector[1] != '=' or selector_cnt > cnt:
-            if selector:
-              filters.append(selector)
-            selector = (tag, operator, spec)
-            selector_cnt = cnt
-            continue
-        filters.append((tag, operator, spec))
+            if operator == '=':
+                matches_empty = spec == ''
+                if not matches_empty:
+                    cnt = self.r.scard('tags:' + tag + ':values:' + spec)
+                    if not selector or selector[1] != '=' or selector_cnt > cnt:
+                        if selector:
+                            filters.append(selector)
+                        selector = (tag, operator, spec)
+                        selector_cnt = cnt
+                        continue
+                filters.append((tag, operator, spec))
 
-      elif operator == '=~':
-        pattern = re.compile(spec)
-        matches_empty = bool(pattern.match(''))
-        if not matches_empty and (not selector or selector[1] != '='):
-          cnt = self.r.scard('tags:' + tag + ':values')
-          if not selector or selector_cnt > cnt:
-            if selector:
-              filters.append(selector)
-            selector = (tag, operator, pattern)
-            selector_cnt = cnt
-            continue
-        filters.append((tag, operator, pattern))
+            elif operator == '=~':
+                pattern = re.compile(spec)
+                matches_empty = bool(pattern.match(''))
+                if not matches_empty and (not selector or selector[1] != '='):
+                    cnt = self.r.scard('tags:' + tag + ':values')
+                    if not selector or selector_cnt > cnt:
+                        if selector:
+                            filters.append(selector)
+                        selector = (tag, operator, pattern)
+                        selector_cnt = cnt
+                        continue
+                filters.append((tag, operator, pattern))
 
-      elif operator == '!=':
-        matches_empty = spec != ''
-        if not matches_empty and (not selector or selector[1] != '='):
-          cnt = self.r.scard('tags:' + tag + ':values')
-          if not selector or selector_cnt > cnt:
-            if selector:
-              filters.append(selector)
-            selector = (tag, operator, spec)
-            selector_cnt = cnt
-            continue
-        filters.append((tag, operator, spec))
+            elif operator == '!=':
+                matches_empty = spec != ''
+                if not matches_empty and (not selector or selector[1] != '='):
+                    cnt = self.r.scard('tags:' + tag + ':values')
+                    if not selector or selector_cnt > cnt:
+                        if selector:
+                            filters.append(selector)
+                        selector = (tag, operator, spec)
+                        selector_cnt = cnt
+                        continue
+                filters.append((tag, operator, spec))
 
-      elif operator == '!=~':
-        pattern = re.compile(spec)
-        matches_empty = not pattern.match('')
-        if not matches_empty and (not selector or selector[1] != '='):
-          cnt = self.r.scard('tags:' + tag + ':values')
-          if not selector or selector_cnt > cnt:
-            if selector:
-              filters.append(selector)
-            selector = (tag, operator, pattern)
-            selector_cnt = cnt
-            continue
-        filters.append((tag, operator, pattern))
+            elif operator == '!=~':
+                pattern = re.compile(spec)
+                matches_empty = not pattern.match('')
+                if not matches_empty and (not selector or selector[1] != '='):
+                    cnt = self.r.scard('tags:' + tag + ':values')
+                    if not selector or selector_cnt > cnt:
+                        if selector:
+                            filters.append(selector)
+                        selector = (tag, operator, pattern)
+                        selector_cnt = cnt
+                        continue
+                filters.append((tag, operator, pattern))
 
-      else:
-        raise ValueError("Invalid operator %s" % operator)
+            else:
+                raise ValueError("Invalid operator %s" % operator)
 
-    if not selector:
-      raise ValueError("At least one tagspec must not match the empty string")
+        if not selector:
+            raise ValueError("At least one tagspec must not match the empty string")
 
-    # get initial list of series
-    (tag, operator, spec) = selector
+        # get initial list of series
+        (tag, operator, spec) = selector
 
-    # find list of values that match the tagspec
-    values = None
-    if operator == '=':
-      values = [spec]
-    elif operator == '=~':
-      # see if we can identify a literal prefix to filter by in redis
-      match = None
-      m = re.match('([a-z0-9]+)([^*?|][^|]*)?$', spec.pattern)
-      if m:
-        match = m.group(1) + '*'
-      values = [value for value in self.r.sscan_iter('tags:' + tag + ':values', match=match) if spec.match(value) is not None]
-    elif operator == '!=':
-      values = [value for value in self.r.sscan_iter('tags:' + tag + ':values') if value != spec]
-    elif operator == '!=~':
-      values = [value for value in self.r.sscan_iter('tags:' + tag + ':values') if spec.match(value) is None]
+        # find list of values that match the tagspec
+        values = None
+        if operator == '=':
+            values = [spec]
+        elif operator == '=~':
+            # see if we can identify a literal prefix to filter by in redis
+            match = None
+            m = re.match('([a-z0-9]+)([^*?|][^|]*)?$', spec.pattern)
+            if m:
+                match = m.group(1) + '*'
+            values = [value for value in self.r.sscan_iter('tags:' + tag + ':values', match=match) if spec.match(value) is not None]
+        elif operator == '!=':
+            values = [value for value in self.r.sscan_iter('tags:' + tag + ':values') if value != spec]
+        elif operator == '!=~':
+            values = [value for value in self.r.sscan_iter('tags:' + tag + ':values') if spec.match(value) is None]
 
-    # if this query matched no values, just short-circuit since the result of the final intersect will be empty
-    if not values:
-      return []
+        # if this query matched no values, just short-circuit since the result of the final intersect will be empty
+        if not values:
+            return []
 
-    results = []
+        results = []
 
-    # apply filters
-    operators = ['=','!=','=~','!=~']
-    filters.sort(key=lambda a: operators.index(a[1]))
+        # apply filters
+        operators = ['=','!=','=~','!=~']
+        filters.sort(key=lambda a: operators.index(a[1]))
 
-    for series in self.r.sunion(*['tags:' + tag + ':values:' + value for value in values]):
-      try:
+        for series in self.r.sunion(*['tags:' + tag + ':values:' + value for value in values]):
+            try:
+                parsed = self.parse(series)
+            except Exception:
+                continue
+
+            matched = True
+
+            for (tag, operator, spec) in filters:
+                value = parsed.tags.get(tag, '')
+                if (
+                    (operator == '=' and value != spec) or
+                    (operator == '=~' and spec.match(value) is None) or
+                    (operator == '!=' and value == spec) or
+                    (operator == '!=~' and spec.match(value) is not None)
+                ):
+                    matched = False
+                    break
+
+            if matched:
+                bisect.insort_left(results, series)
+
+        return results
+
+    def get_series(self, path, requestContext=None):
+        tags = {}
+
+        tags = self.r.hgetall('series:' + path + ':tags')
+        if not tags:
+            return None
+
+        return TaggedSeries(tags['name'], tags)
+
+    def list_tags(self, tagFilter=None, limit=None, requestContext=None):
+        result = []
+
+        if tagFilter:
+            tagFilter = re.compile(tagFilter)
+
+        for tag in self.r.sscan_iter('tags'):
+            if tagFilter and tagFilter.match(tag) is None:
+                continue
+            if len(result) == 0 or tag >= result[-1]:
+                if limit and len(result) >= limit:
+                    continue
+                result.append(tag)
+            else:
+                bisect.insort_left(result, tag)
+            if limit and len(result) > limit:
+                del result[-1]
+
+        return [
+            {'tag': tag}
+            for tag in result
+        ]
+
+    def get_tag(self, tag, valueFilter=None, limit=None, requestContext=None):
+        if not self.r.sismember('tags', tag):
+            return None
+
+        return {
+            'tag': tag,
+            'values': self.list_values(
+                tag,
+                valueFilter=valueFilter,
+                limit=limit,
+                requestContext=requestContext
+            ),
+        }
+
+    def list_values(self, tag, valueFilter=None, limit=None, requestContext=None):
+        result = []
+
+        if valueFilter:
+            valueFilter = re.compile(valueFilter)
+
+        for value in self.r.sscan_iter('tags:' + tag + ':values'):
+            if valueFilter and valueFilter.match(value) is None:
+                continue
+            if len(result) == 0 or value >= result[-1]:
+                if limit and len(result) >= limit:
+                    continue
+                result.append(value)
+            else:
+                bisect.insort_left(result, value)
+            if limit and len(result) > limit:
+                del result[-1]
+
+        return [
+            {'value': value, 'count': self.r.scard('tags:' + tag + ':values:' + value)}
+            for value in result
+        ]
+
+    def tag_series(self, series, requestContext=None):
+        # extract tags and normalize path
         parsed = self.parse(series)
-      except Exception:
-        continue
 
-      matched = True
+        path = parsed.path
 
-      for (tag, operator, spec) in filters:
-        value = parsed.tags.get(tag, '')
-        if (
-          (operator == '=' and value != spec) or
-          (operator == '=~' and spec.match(value) is None) or
-          (operator == '!=' and value == spec) or
-          (operator == '!=~' and spec.match(value) is not None)
-        ):
-          matched = False
-          break
+        with self.r.pipeline() as pipe:
+            pipe.sadd('series', path)
 
-      if matched:
-        bisect.insort_left(results, series)
+            for tag, value in parsed.tags.items():
+                pipe.hset('series:' + path + ':tags', tag, value)
 
-    return results
+                pipe.sadd('tags', tag)
+                pipe.sadd('tags:' + tag + ':series', path)
+                pipe.sadd('tags:' + tag + ':values', value)
+                pipe.sadd('tags:' + tag + ':values:' + value, path)
 
-  def get_series(self, path, requestContext=None):
-    tags = {}
+            pipe.execute()
 
-    tags = self.r.hgetall('series:' + path + ':tags')
-    if not tags:
-      return None
+        return path
 
-    return TaggedSeries(tags['name'], tags)
+    def del_series(self, series, requestContext=None):
+        # extract tags and normalize path
+        parsed = self.parse(series)
 
-  def list_tags(self, tagFilter=None, limit=None, requestContext=None):
-    result = []
+        path = parsed.path
 
-    if tagFilter:
-      tagFilter = re.compile(tagFilter)
+        with self.r.pipeline() as pipe:
+            pipe.srem('series', path)
 
-    for tag in self.r.sscan_iter('tags'):
-      if tagFilter and tagFilter.match(tag) is None:
-        continue
-      if len(result) == 0 or tag >= result[-1]:
-        if limit and len(result) >= limit:
-          continue
-        result.append(tag)
-      else:
-        bisect.insort_left(result, tag)
-      if limit and len(result) > limit:
-        del result[-1]
+            pipe.delete('series:' + path + ':tags')
 
-    return [
-      {'tag': tag}
-      for tag in result
-    ]
+            for tag, value in parsed.tags.items():
+                pipe.srem('tags:' + tag + ':series', path)
+                pipe.srem('tags:' + tag + ':values:' + value, path)
 
-  def get_tag(self, tag, valueFilter=None, limit=None, requestContext=None):
-    if not self.r.sismember('tags', tag):
-      return None
+            pipe.execute()
 
-    return {
-      'tag': tag,
-      'values': self.list_values(
-        tag,
-        valueFilter=valueFilter,
-        limit=limit,
-        requestContext=requestContext
-      ),
-    }
-
-  def list_values(self, tag, valueFilter=None, limit=None, requestContext=None):
-    result = []
-
-    if valueFilter:
-      valueFilter = re.compile(valueFilter)
-
-    for value in self.r.sscan_iter('tags:' + tag + ':values'):
-      if valueFilter and valueFilter.match(value) is None:
-        continue
-      if len(result) == 0 or value >= result[-1]:
-        if limit and len(result) >= limit:
-          continue
-        result.append(value)
-      else:
-        bisect.insort_left(result, value)
-      if limit and len(result) > limit:
-        del result[-1]
-
-    return [
-      {'value': value, 'count': self.r.scard('tags:' + tag + ':values:' + value)}
-      for value in result
-    ]
-
-  def tag_series(self, series, requestContext=None):
-    # extract tags and normalize path
-    parsed = self.parse(series)
-
-    path = parsed.path
-
-    with self.r.pipeline() as pipe:
-      pipe.sadd('series', path)
-
-      for tag, value in parsed.tags.items():
-        pipe.hset('series:' + path + ':tags', tag, value)
-
-        pipe.sadd('tags', tag)
-        pipe.sadd('tags:' + tag + ':series', path)
-        pipe.sadd('tags:' + tag + ':values', value)
-        pipe.sadd('tags:' + tag + ':values:' + value, path)
-
-      pipe.execute()
-
-    return path
-
-  def del_series(self, series, requestContext=None):
-    # extract tags and normalize path
-    parsed = self.parse(series)
-
-    path = parsed.path
-
-    with self.r.pipeline() as pipe:
-      pipe.srem('series', path)
-
-      pipe.delete('series:' + path + ':tags')
-
-      for tag, value in parsed.tags.items():
-        pipe.srem('tags:' + tag + ':series', path)
-        pipe.srem('tags:' + tag + ':values:' + value, path)
-
-      pipe.execute()
-
-    return True
+        return True

--- a/webapp/graphite/tags/utils.py
+++ b/webapp/graphite/tags/utils.py
@@ -5,165 +5,163 @@ from hashlib import sha256
 
 
 class TaggedSeries(object):
-  prohibitedTagChars = ';!^='
+    prohibitedTagChars = ';!^='
 
-  @classmethod
-  def validateTagAndValue(cls, tag, value):
-    """validate the given tag / value based on the specs in the documentation"""
-    if len(tag) == 0:
-      raise Exception('Tag may not be empty')
-    if len(value) == 0:
-      raise Exception('Value for tag "{tag}" may not be empty'.format(tag=tag))
+    @classmethod
+    def validateTagAndValue(cls, tag, value):
+        """validate the given tag / value based on the specs in the documentation"""
+        if len(tag) == 0:
+            raise Exception('Tag may not be empty')
+        if len(value) == 0:
+            raise Exception('Value for tag "{tag}" may not be empty'.format(tag=tag))
 
-    for char in cls.prohibitedTagChars:
-      if char in tag:
-        raise Exception(
-          'Character "{char}" is not allowed in tag "{tag}"'.format(char=char, tag=tag))
+        for char in cls.prohibitedTagChars:
+            if char in tag:
+                raise Exception('Character "{}" is not allowed in tag "{}"'.format(char, tag))
 
-    if ';' in value:
-      raise Exception(
-        'Character ";" is not allowed in value "{value}" of tag {tag}'.format(value=value, tag=tag))
+        if ';' in value:
+            raise Exception('Character ";" is not allowed in value "{}" of tag {}'.format(value, tag))
 
-    if value[0] == '~':
-      raise Exception('Tag values are not allowed to start with "~" in tag "{tag}"'.format(tag=tag))
+        if value[0] == '~':
+            raise Exception('Tag values are not allowed to start with "~" in tag "{tag}"'.format(tag=tag))
 
-  @classmethod
-  def parse(cls, path):
-    # if path is in openmetrics format: metric{tag="value",...}
-    if path[-2:] == '"}' and '{' in path:
-      return cls.parse_openmetrics(path)
+    @classmethod
+    def parse(cls, path):
+        # if path is in openmetrics format: metric{tag="value",...}
+        if path[-2:] == '"}' and '{' in path:
+            return cls.parse_openmetrics(path)
 
-    # path is a carbon path with optional tags: metric;tag=value;...
-    return cls.parse_carbon(path)
+        # path is a carbon path with optional tags: metric;tag=value;...
+        return cls.parse_carbon(path)
 
-  @classmethod
-  def parse_openmetrics(cls, path):
-    """parse a path in openmetrics format: metric{tag="value",...}
+    @classmethod
+    def parse_openmetrics(cls, path):
+        """parse a path in openmetrics format: metric{tag="value",...}
 
-    https://github.com/RichiH/OpenMetrics
-    """
-    (metric, rawtags) = path[0:-1].split('{', 2)
-    if not metric:
-      raise Exception('Cannot parse path %s, no metric found' % path)
+        https://github.com/RichiH/OpenMetrics
+        """
+        (metric, rawtags) = path[0:-1].split('{', 2)
+        if not metric:
+            raise Exception('Cannot parse path %s, no metric found' % path)
 
-    tags = {}
+        tags = {}
 
-    while len(rawtags) > 0:
-      m = re.match(r'([^=]+)="((?:[\\]["\\]|[^"\\])+)"(:?,|$)', rawtags)
-      if not m:
-        raise Exception('Cannot parse path %s, invalid segment %s' % (path, rawtags))
+        while len(rawtags) > 0:
+            m = re.match(r'([^=]+)="((?:[\\]["\\]|[^"\\])+)"(:?,|$)', rawtags)
+            if not m:
+                raise Exception('Cannot parse path %s, invalid segment %s' % (path, rawtags))
 
-      tag = m.group(1)
-      value = m.group(2).replace(r'\"', '"').replace(r'\\', '\\')
+            tag = m.group(1)
+            value = m.group(2).replace(r'\"', '"').replace(r'\\', '\\')
 
-      cls.validateTagAndValue(tag, value)
+            cls.validateTagAndValue(tag, value)
 
-      tags[tag] = value
-      rawtags = rawtags[len(m.group(0)):]
+            tags[tag] = value
+            rawtags = rawtags[len(m.group(0)):]
 
-    tags['name'] = cls.sanitize_name_as_tag_value(metric)
-    return cls(metric, tags)
+        tags['name'] = cls.sanitize_name_as_tag_value(metric)
+        return cls(metric, tags)
 
-  @classmethod
-  def parse_carbon(cls, path):
-    """parse a carbon path with optional tags: metric;tag=value;..."""
-    segments = path.split(';')
+    @classmethod
+    def parse_carbon(cls, path):
+        """parse a carbon path with optional tags: metric;tag=value;..."""
+        segments = path.split(';')
 
-    metric = segments[0]
-    if not metric:
-      raise Exception('Cannot parse path %s, no metric found' % path)
+        metric = segments[0]
+        if not metric:
+            raise Exception('Cannot parse path %s, no metric found' % path)
 
-    tags = {}
+        tags = {}
 
-    for segment in segments[1:]:
-      tag = segment.split('=', 1)
-      if len(tag) != 2 or not tag[0]:
-        raise Exception('Cannot parse path %s, invalid segment %s' % (path, segment))
+        for segment in segments[1:]:
+            tag = segment.split('=', 1)
+            if len(tag) != 2 or not tag[0]:
+                raise Exception('Cannot parse path %s, invalid segment %s' % (path, segment))
 
-      cls.validateTagAndValue(*tag)
+            cls.validateTagAndValue(*tag)
 
-      tags[tag[0]] = tag[1]
+            tags[tag[0]] = tag[1]
 
-    tags['name'] = cls.sanitize_name_as_tag_value(metric)
-    return cls(metric, tags)
+        tags['name'] = cls.sanitize_name_as_tag_value(metric)
+        return cls(metric, tags)
 
-  @staticmethod
-  def sanitize_name_as_tag_value(name):
-    """take a metric name and sanitize it so it is guaranteed to be a valid tag value"""
-    sanitized = name.lstrip('~')
+    @staticmethod
+    def sanitize_name_as_tag_value(name):
+        """take a metric name and sanitize it so it is guaranteed to be a valid tag value"""
+        sanitized = name.lstrip('~')
 
-    if len(sanitized) == 0:
-      raise Exception('Cannot use metric name %s as tag value, results in emptry string' % (name))
+        if len(sanitized) == 0:
+            raise Exception('Cannot use metric name %s as tag value, results in emptry string' % (name))
 
-    return sanitized
+        return sanitized
 
-  @staticmethod
-  def format(tags):
-    return tags.get('name', '') + ''.join(sorted([
-      ';%s=%s' % (tag, value)
-      for tag, value in tags.items()
-      if tag != 'name'
-    ]))
+    @staticmethod
+    def format(tags):
+        return tags.get('name', '') + ''.join(sorted([
+            ';%s=%s' % (tag, value)
+            for tag, value in tags.items()
+            if tag != 'name'
+        ]))
 
-  @staticmethod
-  def encode(metric, sep='.', hash_only=False):
-    """
-    Helper function to encode tagged series for storage in whisper etc
+    @staticmethod
+    def encode(metric, sep='.', hash_only=False):
+        """
+        Helper function to encode tagged series for storage in whisper etc
 
-    When tagged series are detected, they are stored in a separate hierarchy of folders under a
-    top-level _tagged folder, where subfolders are created by using the first 3 hex digits of the
-    sha256 hash of the tagged metric path (4096 possible folders), and second-level subfolders are
-    based on the following 3 hex digits (another 4096 possible folders) for a total of 4096^2
-    possible subfolders. The metric files themselves are created with any . in the metric path
-    replaced with -, to avoid any issues where metrics, tags or values containing a '.' would end
-    up creating further subfolders. This helper is used by both whisper and ceres, but by design
-    each carbon database and graphite-web finder is responsible for handling its own encoding so
-    that different backends can create their own schemes if desired.
+        When tagged series are detected, they are stored in a separate hierarchy of folders under a
+        top-level _tagged folder, where subfolders are created by using the first 3 hex digits of the
+        sha256 hash of the tagged metric path (4096 possible folders), and second-level subfolders are
+        based on the following 3 hex digits (another 4096 possible folders) for a total of 4096^2
+        possible subfolders. The metric files themselves are created with any . in the metric path
+        replaced with -, to avoid any issues where metrics, tags or values containing a '.' would end
+        up creating further subfolders. This helper is used by both whisper and ceres, but by design
+        each carbon database and graphite-web finder is responsible for handling its own encoding so
+        that different backends can create their own schemes if desired.
 
-    The hash_only parameter can be set to True to use the hash as the filename instead of a
-    human-readable name.  This avoids issues with filename length restrictions, at the expense of
-    being unable to decode the filename and determine the original metric name.
+        The hash_only parameter can be set to True to use the hash as the filename instead of a
+        human-readable name.  This avoids issues with filename length restrictions, at the expense of
+        being unable to decode the filename and determine the original metric name.
 
-    A concrete example:
+        A concrete example:
 
-    .. code-block:: none
+        .. code-block:: none
 
-      some.metric;tag1=value2;tag2=value.2
+          some.metric;tag1=value2;tag2=value.2
 
-      with sha256 hash starting effaae would be stored in:
+          with sha256 hash starting effaae would be stored in:
 
-      _tagged/eff/aae/some-metric;tag1=value2;tag2=value-2.wsp (whisper)
-      _tagged/eff/aae/some-metric;tag1=value2;tag2=value-2 (ceres)
+          _tagged/eff/aae/some-metric;tag1=value2;tag2=value-2.wsp (whisper)
+          _tagged/eff/aae/some-metric;tag1=value2;tag2=value-2 (ceres)
 
-    """
-    if ';' in metric:
-      metric_hash = sha256(metric.encode('utf8')).hexdigest()
-      return sep.join([
-        '_tagged',
-        metric_hash[0:3],
-        metric_hash[3:6],
-        metric_hash if hash_only else metric.replace('.', '_DOT_')
-      ])
+        """
+        if ';' in metric:
+            metric_hash = sha256(metric.encode('utf8')).hexdigest()
+            return sep.join([
+                '_tagged',
+                metric_hash[0:3],
+                metric_hash[3:6],
+                metric_hash if hash_only else metric.replace('.', '_DOT_')
+            ])
 
-    # metric isn't tagged, just replace dots with the separator and trim any leading separator
-    return metric.replace('.', sep).lstrip(sep)
+        # metric isn't tagged, just replace dots with the separator and trim any leading separator
+        return metric.replace('.', sep).lstrip(sep)
 
-  @staticmethod
-  def decode(path, sep='.'):
-    """
-    Helper function to decode tagged series from storage in whisper etc
-    """
-    if path.startswith('_tagged'):
-      return path.split(sep, 3)[-1].replace('_DOT_', '.')
+    @staticmethod
+    def decode(path, sep='.'):
+        """
+        Helper function to decode tagged series from storage in whisper etc
+        """
+        if path.startswith('_tagged'):
+            return path.split(sep, 3)[-1].replace('_DOT_', '.')
 
-    # metric isn't tagged, just replace the separator with dots
-    return path.replace(sep, '.')
+        # metric isn't tagged, just replace the separator with dots
+        return path.replace(sep, '.')
 
-  def __init__(self, metric, tags, series_id=None):
-    self.metric = metric
-    self.tags = tags
-    self.id = series_id
+    def __init__(self, metric, tags, series_id=None):
+        self.metric = metric
+        self.tags = tags
+        self.id = series_id
 
-  @property
-  def path(self):
-    return self.__class__.format(self.tags)
+    @property
+    def path(self):
+        return self.__class__.format(self.tags)

--- a/webapp/graphite/tags/views.py
+++ b/webapp/graphite/tags/views.py
@@ -3,146 +3,146 @@ from graphite.storage import STORE, extractForwardHeaders
 
 
 def _requestContext(request, queryParams):
-  return {
-    'forwardHeaders': extractForwardHeaders(request),
-    'localOnly': queryParams.get('local') == '1',
-  }
+    return {
+        'forwardHeaders': extractForwardHeaders(request),
+        'localOnly': queryParams.get('local') == '1',
+    }
 
 
 @jsonResponse
 def tagSeries(request, queryParams):
-  if request.method != 'POST':
-    return HttpResponse(status=405)
+    if request.method != 'POST':
+        return HttpResponse(status=405)
 
-  path = queryParams.get('path')
-  if not path:
-    raise HttpError('no path specified', status=400)
+    path = queryParams.get('path')
+    if not path:
+        raise HttpError('no path specified', status=400)
 
-  return STORE.tagdb.tag_series(path, requestContext=_requestContext(request, queryParams))
+    return STORE.tagdb.tag_series(path, requestContext=_requestContext(request, queryParams))
 
 
 @jsonResponse
 def tagMultiSeries(request, queryParams):
-  if request.method != 'POST':
-    return HttpResponse(status=405)
+    if request.method != 'POST':
+        return HttpResponse(status=405)
 
-  paths = []
-  # Normal format: ?path=name;tag1=value1;tag2=value2&path=name;tag1=value2;tag2=value2
-  if len(queryParams.getlist('path')) > 0:
-    paths = queryParams.getlist('path')
-  # Rails/PHP/jQuery common practice format: ?path[]=...&path[]=...
-  elif len(queryParams.getlist('path[]')) > 0:
-    paths = queryParams.getlist('path[]')
-  else:
-    raise HttpError('no paths specified',status=400)
+    paths = []
+    # Normal format: ?path=name;tag1=value1;tag2=value2&path=name;tag1=value2;tag2=value2
+    if len(queryParams.getlist('path')) > 0:
+        paths = queryParams.getlist('path')
+    # Rails/PHP/jQuery common practice format: ?path[]=...&path[]=...
+    elif len(queryParams.getlist('path[]')) > 0:
+        paths = queryParams.getlist('path[]')
+    else:
+        raise HttpError('no paths specified',status=400)
 
-  return STORE.tagdb.tag_multi_series(paths, requestContext=_requestContext(request, queryParams))
+    return STORE.tagdb.tag_multi_series(paths, requestContext=_requestContext(request, queryParams))
 
 
 @jsonResponse
 def delSeries(request, queryParams):
-  if request.method != 'POST':
-    return HttpResponse(status=405)
+    if request.method != 'POST':
+        return HttpResponse(status=405)
 
-  paths = []
-  # Normal format: ?path=name;tag1=value1;tag2=value2&path=name;tag1=value2;tag2=value2
-  if len(queryParams.getlist('path')) > 0:
-    paths = queryParams.getlist('path')
-  # Rails/PHP/jQuery common practice format: ?path[]=...&path[]=...
-  elif len(queryParams.getlist('path[]')) > 0:
-    paths = queryParams.getlist('path[]')
-  else:
-    raise HttpError('no path specified', status=400)
+    paths = []
+    # Normal format: ?path=name;tag1=value1;tag2=value2&path=name;tag1=value2;tag2=value2
+    if len(queryParams.getlist('path')) > 0:
+        paths = queryParams.getlist('path')
+    # Rails/PHP/jQuery common practice format: ?path[]=...&path[]=...
+    elif len(queryParams.getlist('path[]')) > 0:
+        paths = queryParams.getlist('path[]')
+    else:
+        raise HttpError('no path specified', status=400)
 
-  return STORE.tagdb.del_multi_series(paths, requestContext=_requestContext(request, queryParams))
+    return STORE.tagdb.del_multi_series(paths, requestContext=_requestContext(request, queryParams))
 
 
 @jsonResponse
 def findSeries(request, queryParams):
-  if request.method not in ['GET', 'POST']:
-    return HttpResponse(status=405)
+    if request.method not in ['GET', 'POST']:
+        return HttpResponse(status=405)
 
-  exprs = []
-  # Normal format: ?expr=tag1=value1&expr=tag2=value2
-  if len(queryParams.getlist('expr')) > 0:
-    exprs = queryParams.getlist('expr')
-  # Rails/PHP/jQuery common practice format: ?expr[]=tag1=value1&expr[]=tag2=value2
-  elif len(queryParams.getlist('expr[]')) > 0:
-    exprs = queryParams.getlist('expr[]')
+    exprs = []
+    # Normal format: ?expr=tag1=value1&expr=tag2=value2
+    if len(queryParams.getlist('expr')) > 0:
+        exprs = queryParams.getlist('expr')
+    # Rails/PHP/jQuery common practice format: ?expr[]=tag1=value1&expr[]=tag2=value2
+    elif len(queryParams.getlist('expr[]')) > 0:
+        exprs = queryParams.getlist('expr[]')
 
-  if not exprs:
-    raise HttpError('no tag expressions specified', status=400)
+    if not exprs:
+        raise HttpError('no tag expressions specified', status=400)
 
-  return STORE.tagdb.find_series(exprs, requestContext=_requestContext(request, queryParams))
+    return STORE.tagdb.find_series(exprs, requestContext=_requestContext(request, queryParams))
 
 
 @jsonResponse
 def tagList(request, queryParams):
-  if request.method != 'GET':
-    return HttpResponse(status=405)
+    if request.method != 'GET':
+        return HttpResponse(status=405)
 
-  return STORE.tagdb.list_tags(
-    tagFilter=request.GET.get('filter'),
-    limit=request.GET.get('limit'),
-    requestContext=_requestContext(request, queryParams),
-  )
+    return STORE.tagdb.list_tags(
+        tagFilter=request.GET.get('filter'),
+        limit=request.GET.get('limit'),
+        requestContext=_requestContext(request, queryParams),
+    )
 
 
 @jsonResponse
 def tagDetails(request, queryParams, tag):
-  if request.method != 'GET':
-    return HttpResponse(status=405)
+    if request.method != 'GET':
+        return HttpResponse(status=405)
 
-  return STORE.tagdb.get_tag(
-    tag,
-    valueFilter=queryParams.get('filter'),
-    limit=queryParams.get('limit'),
-    requestContext=_requestContext(request, queryParams),
-  )
+    return STORE.tagdb.get_tag(
+        tag,
+        valueFilter=queryParams.get('filter'),
+        limit=queryParams.get('limit'),
+        requestContext=_requestContext(request, queryParams),
+    )
 
 
 @jsonResponse
 def autoCompleteTags(request, queryParams):
-  if request.method not in ['GET', 'POST']:
-    return HttpResponse(status=405)
+    if request.method not in ['GET', 'POST']:
+        return HttpResponse(status=405)
 
-  exprs = []
-  # Normal format: ?expr=tag1=value1&expr=tag2=value2
-  if len(queryParams.getlist('expr')) > 0:
-    exprs = queryParams.getlist('expr')
-  # Rails/PHP/jQuery common practice format: ?expr[]=tag1=value1&expr[]=tag2=value2
-  elif len(queryParams.getlist('expr[]')) > 0:
-    exprs = queryParams.getlist('expr[]')
+    exprs = []
+    # Normal format: ?expr=tag1=value1&expr=tag2=value2
+    if len(queryParams.getlist('expr')) > 0:
+        exprs = queryParams.getlist('expr')
+    # Rails/PHP/jQuery common practice format: ?expr[]=tag1=value1&expr[]=tag2=value2
+    elif len(queryParams.getlist('expr[]')) > 0:
+        exprs = queryParams.getlist('expr[]')
 
-  return STORE.tagdb_auto_complete_tags(
-    exprs,
-    tagPrefix=queryParams.get('tagPrefix'),
-    limit=queryParams.get('limit'),
-    requestContext=_requestContext(request, queryParams)
-  )
+    return STORE.tagdb_auto_complete_tags(
+        exprs,
+        tagPrefix=queryParams.get('tagPrefix'),
+        limit=queryParams.get('limit'),
+        requestContext=_requestContext(request, queryParams)
+    )
 
 
 @jsonResponse
 def autoCompleteValues(request, queryParams):
-  if request.method not in ['GET', 'POST']:
-    return HttpResponse(status=405)
+    if request.method not in ['GET', 'POST']:
+        return HttpResponse(status=405)
 
-  exprs = []
-  # Normal format: ?expr=tag1=value1&expr=tag2=value2
-  if len(queryParams.getlist('expr')) > 0:
-    exprs = queryParams.getlist('expr')
-  # Rails/PHP/jQuery common practice format: ?expr[]=tag1=value1&expr[]=tag2=value2
-  elif len(queryParams.getlist('expr[]')) > 0:
-    exprs = queryParams.getlist('expr[]')
+    exprs = []
+    # Normal format: ?expr=tag1=value1&expr=tag2=value2
+    if len(queryParams.getlist('expr')) > 0:
+        exprs = queryParams.getlist('expr')
+    # Rails/PHP/jQuery common practice format: ?expr[]=tag1=value1&expr[]=tag2=value2
+    elif len(queryParams.getlist('expr[]')) > 0:
+        exprs = queryParams.getlist('expr[]')
 
-  tag = queryParams.get('tag')
-  if not tag:
-    raise HttpError('no tag specified', status=400)
+    tag = queryParams.get('tag')
+    if not tag:
+        raise HttpError('no tag specified', status=400)
 
-  return STORE.tagdb_auto_complete_values(
-    exprs,
-    tag,
-    valuePrefix=queryParams.get('valuePrefix'),
-    limit=queryParams.get('limit'),
-    requestContext=_requestContext(request, queryParams)
-  )
+    return STORE.tagdb_auto_complete_values(
+        exprs,
+        tag,
+        valuePrefix=queryParams.get('valuePrefix'),
+        limit=queryParams.get('limit'),
+        requestContext=_requestContext(request, queryParams)
+    )

--- a/webapp/graphite/url_shortener/baseconv.py
+++ b/webapp/graphite/url_shortener/baseconv.py
@@ -36,7 +36,7 @@ class BaseConverter(object):
         # make an integer out of the number
         x = 0
         for digit in str(number):
-           x = x * len(fromdigits) + fromdigits.index(digit)
+            x = x * len(fromdigits) + fromdigits.index(digit)
 
         # create the result in base 'len(todigits)'
         if x == 0:

--- a/webapp/graphite/user_util.py
+++ b/webapp/graphite/user_util.py
@@ -20,26 +20,26 @@ from graphite.logger import log
 
 
 def isAuthenticated(user):
-  # is_authenticated() is changed to a boolean since 1.10, 2.0 removes the
-  # backwards compatibilty
-  if DJANGO_VERSION >= (1, 10):
-    return user.is_authenticated
-  else:
-    return user.is_authenticated()
+    # is_authenticated() is changed to a boolean since 1.10, 2.0 removes the
+    # backwards compatibilty
+    if DJANGO_VERSION >= (1, 10):
+        return user.is_authenticated
+    else:
+        return user.is_authenticated()
 
 
 def getProfile(request, allowDefault=True):
-  if isAuthenticated(request.user):
-    return Profile.objects.get_or_create(user=request.user)[0]
-  elif allowDefault:
-    return default_profile()
+    if isAuthenticated(request.user):
+        return Profile.objects.get_or_create(user=request.user)[0]
+    elif allowDefault:
+        return default_profile()
 
 
 def getProfileByUsername(username):
-  try:
-    return Profile.objects.get(user__username=username)
-  except Profile.DoesNotExist:
-    return None
+    try:
+        return Profile.objects.get(user__username=username)
+    except Profile.DoesNotExist:
+        return None
 
 
 def default_profile():

--- a/webapp/graphite/version/views.py
+++ b/webapp/graphite/version/views.py
@@ -3,7 +3,7 @@ from graphite import settings
 
 
 def index(request):
-  context = {
-    'version' : settings.WEBAPP_VERSION,
-  }
-  return render(request, 'version.html', context)
+    context = {
+        'version' : settings.WEBAPP_VERSION,
+    }
+    return render(request, 'version.html', context)

--- a/webapp/graphite/views.py
+++ b/webapp/graphite/views.py
@@ -4,6 +4,6 @@ from django.template import loader
 
 
 def server_error(request, template_name='500.html'):
-  template = loader.get_template(template_name)
-  context = {'stacktrace' : traceback.format_exc()}
-  return HttpResponseServerError(template.render(context))
+    template = loader.get_template(template_name)
+    context = {'stacktrace' : traceback.format_exc()}
+    return HttpResponseServerError(template.render(context))

--- a/webapp/graphite/whitelist/views.py
+++ b/webapp/graphite/whitelist/views.py
@@ -22,43 +22,44 @@ from graphite.util import unpickle
 
 
 def add(request):
-  metrics = set( request.POST['metrics'].split() )
-  whitelist = load_whitelist()
-  new_whitelist = whitelist | metrics
-  save_whitelist(new_whitelist)
-  return HttpResponse(content_type="text/plain", content="OK")
+    metrics = set( request.POST['metrics'].split() )
+    whitelist = load_whitelist()
+    new_whitelist = whitelist | metrics
+    save_whitelist(new_whitelist)
+    return HttpResponse(content_type="text/plain", content="OK")
 
 
 def remove(request):
-  metrics = set( request.POST['metrics'].split() )
-  whitelist = load_whitelist()
-  new_whitelist = whitelist - metrics
-  save_whitelist(new_whitelist)
-  return HttpResponse(content_type="text/plain", content="OK")
+    metrics = set( request.POST['metrics'].split() )
+    whitelist = load_whitelist()
+    new_whitelist = whitelist - metrics
+    save_whitelist(new_whitelist)
+    return HttpResponse(content_type="text/plain", content="OK")
 
 
 def show(request):
-  whitelist = load_whitelist()
-  members = '\n'.join( sorted(whitelist) )
-  return HttpResponse(content_type="text/plain", content=members)
+    whitelist = load_whitelist()
+    members = '\n'.join( sorted(whitelist) )
+    return HttpResponse(content_type="text/plain", content=members)
 
 
 def load_whitelist():
-  buffer = open(settings.WHITELIST_FILE, 'rb').read()
-  whitelist = unpickle.loads(buffer)
-  return whitelist
+    buffer = open(settings.WHITELIST_FILE, 'rb').read()
+    whitelist = unpickle.loads(buffer)
+    return whitelist
 
 
 def save_whitelist(whitelist):
-  serialized = pickle.dumps(whitelist, protocol=-1) #do this instead of dump() to raise potential exceptions before open()
-  tmpfile = '%s-%d' % (settings.WHITELIST_FILE, randint(0, 100000))
-  try:
-    fh = open(tmpfile, 'wb')
-    fh.write(serialized)
-    fh.close()
-    if os.path.exists(settings.WHITELIST_FILE):
-      os.unlink(settings.WHITELIST_FILE)
-    os.rename(tmpfile, settings.WHITELIST_FILE)
-  finally:
-    if os.path.exists(tmpfile):
-      os.unlink(tmpfile)
+    # do this instead of dump() to raise potential exceptions before open()
+    serialized = pickle.dumps(whitelist, protocol=-1)
+    tmpfile = '%s-%d' % (settings.WHITELIST_FILE, randint(0, 100000))
+    try:
+        fh = open(tmpfile, 'wb')
+        fh.write(serialized)
+        fh.close()
+        if os.path.exists(settings.WHITELIST_FILE):
+            os.unlink(settings.WHITELIST_FILE)
+        os.rename(tmpfile, settings.WHITELIST_FILE)
+    finally:
+        if os.path.exists(tmpfile):
+            os.unlink(tmpfile)

--- a/webapp/graphite/worker_pool/pool.py
+++ b/webapp/graphite/worker_pool/pool.py
@@ -11,116 +11,115 @@ _pools = {}
 
 
 class Job(object):
-  """A job to be executed by a pool
+    """A job to be executed by a pool
 
-  The job accepts a function and arguments.
+    The job accepts a function and arguments.
 
-  When it is run, it will execute the function with the specified arguments.
+    When it is run, it will execute the function with the specified arguments.
 
-  The return value of the function will be stored in the result property of the job.
+    The return value of the function will be stored in the result property of the job.
 
-  If the function raises an exception, it will be stored in the exception property of the job.
-  """
-  __slots__ = (
-    'func', 'description',
-    'args', 'kwargs', 'result',
-    'exception', 'exception_info',
-  )
+    If the function raises an exception, it will be stored in the exception property of the job.
+    """
+    __slots__ = (
+        'func', 'description',
+        'args', 'kwargs', 'result',
+        'exception', 'exception_info',
+    )
 
-  def __init__(self, func, description, *args, **kwargs):
-    self.func = func
-    self.args = args
-    self.description = description
-    self.kwargs = kwargs
-    self.result = None
-    self.exception = None
+    def __init__(self, func, description, *args, **kwargs):
+        self.func = func
+        self.args = args
+        self.description = description
+        self.kwargs = kwargs
+        self.result = None
+        self.exception = None
 
-  def __str__(self):
-    return self.description
+    def __str__(self):
+        return self.description
 
-  def run(self):
-    try:
-      self.result = self.func(*self.args, **self.kwargs)
-    except Exception as e:
-      self.exception_info = sys.exc_info()
-      self.exception = e
+    def run(self):
+        try:
+            self.result = self.func(*self.args, **self.kwargs)
+        except Exception as e:
+            self.exception_info = sys.exc_info()
+            self.exception = e
 
 
 def get_pool(name="default", thread_count=1):
-  """Get (and initialize) a Thread pool.
+    """Get (and initialize) a Thread pool.
 
-  If thread_count is 0, then None is returned.
+    If thread_count is 0, then None is returned.
 
-  If the thread pool had already been initialized, thread_count will
-  be ignored.
-  """
-  if not thread_count:
-    return None
+    If the thread pool had already been initialized, thread_count will
+    be ignored.
+    """
+    if not thread_count:
+        return None
 
-  with _init_lock:
-    pool = _pools.get(name, None)
-    if pool is None:
-      pool = ThreadPool(thread_count)
-      _pools[name] = pool
-  return pool
+    with _init_lock:
+        pool = _pools.get(name, None)
+        if pool is None:
+            pool = ThreadPool(thread_count)
+            _pools[name] = pool
+    return pool
 
 
 def stop_pools():
-  with _init_lock:
-    for name in list(_pools.keys()):
-      pool = _pools.pop(name)
-      pool.close()
+    with _init_lock:
+        for name in list(_pools.keys()):
+            pool = _pools.pop(name)
+            pool.close()
 
 
 def stop_pool(name="default"):
-  with _init_lock:
-    _pools[name].close()
-    del _pools[name]
+    with _init_lock:
+        _pools[name].close()
+        del _pools[name]
 
 
 class PoolTimeoutError(Exception):
-  pass
+    pass
 
 
 def pool_exec(pool, jobs, timeout):
-  """Execute a list of jobs, yielding each one as it completes.
+    """Execute a list of jobs, yielding each one as it completes.
 
-  If a pool is specified then the jobs will be executed asynchronously,
-  otherwise they are executed in order.
+    If a pool is specified then the jobs will be executed asynchronously,
+    otherwise they are executed in order.
 
-  If not all jobs have been executed after the specified timeout a
-  PoolTimeoutError will be raised. When operating synchronously the
-  timeout is checked before each job is run.
-  """
-  start = time.time()
-  deadline = start + timeout
-  if pool:
-    queue = six.moves.queue.Queue()
+    If not all jobs have been executed after the specified timeout a
+    PoolTimeoutError will be raised. When operating synchronously the
+    timeout is checked before each job is run.
+    """
+    start = time.time()
+    deadline = start + timeout
+    if pool:
+        queue = six.moves.queue.Queue()
 
-    def pool_executor(job):
-      job.run()
-      queue.put(job)
+        def pool_executor(job):
+            job.run()
+            queue.put(job)
 
-    for job in jobs:
-      pool.apply_async(func=pool_executor, args=[job])
+        for job in jobs:
+            pool.apply_async(func=pool_executor, args=[job])
 
-    done = 0
-    total = len(jobs)
+        done = 0
+        total = len(jobs)
 
-    while done < total:
-      wait_time = max(0, deadline - time.time())
-      try:
-        job = queue.get(True, wait_time)
-      except six.moves.queue.Empty:
-        raise PoolTimeoutError("Timed out after %fs" % (time.time() - start))
+        while done < total:
+            wait_time = max(0, deadline - time.time())
+            try:
+                job = queue.get(True, wait_time)
+            except six.moves.queue.Empty:
+                raise PoolTimeoutError("Timed out after %fs" % (time.time() - start))
 
-      done += 1
-      yield job
-  else:
-    for job in jobs:
-      if time.time() > deadline:
-        raise PoolTimeoutError("Timed out after %fs" % (time.time() - start))
+            done += 1
+            yield job
+    else:
+        for job in jobs:
+            if time.time() > deadline:
+                raise PoolTimeoutError("Timed out after %fs" % (time.time() - start))
 
-      job.run()
-
-      yield job
+            job.run()
+            yield job

--- a/webapp/tests/base.py
+++ b/webapp/tests/base.py
@@ -3,5 +3,5 @@ from graphite.worker_pool.pool import stop_pools
 
 
 class TestCase(OriginalTestCase):
-  def tearDown(self):
-    stop_pools()
+    def tearDown(self):
+        stop_pools()

--- a/webapp/tests/funcplugins/plugin.py
+++ b/webapp/tests/funcplugins/plugin.py
@@ -2,8 +2,8 @@ from graphite.functions.params import Param, ParamTypes
 
 
 def test(seriesList):
-  """This is a test function"""
-  return seriesList
+    """This is a test function"""
+    return seriesList
 
 
 test.group = 'Test'
@@ -17,8 +17,8 @@ SeriesFunctions = {
 
 
 def pieTest(series):
-  """This is a test pie function"""
-  return max(series)
+    """This is a test pie function"""
+    return max(series)
 
 
 pieTest.group = 'Test'

--- a/webapp/tests/funcplugins/plugin_bad_param.py
+++ b/webapp/tests/funcplugins/plugin_bad_param.py
@@ -2,8 +2,8 @@ from graphite.functions.params import Param, ParamTypes
 
 
 def test(seriesList):
-  """This is a test function"""
-  return seriesList
+    """This is a test function"""
+    return seriesList
 
 
 test.group = 'Test'
@@ -18,8 +18,8 @@ SeriesFunctions = {
 
 
 def pieTest(series):
-  """This is a test pie function"""
-  return max(series)
+    """This is a test pie function"""
+    return max(series)
 
 
 pieTest.group = 'Test'

--- a/webapp/tests/funcplugins/plugin_bad_paramtype.py
+++ b/webapp/tests/funcplugins/plugin_bad_paramtype.py
@@ -2,8 +2,8 @@ from graphite.functions.params import Param, ParamTypes
 
 
 def test(seriesList):
-  """This is a test function"""
-  return seriesList
+    """This is a test function"""
+    return seriesList
 
 
 test.group = 'Test'

--- a/webapp/tests/funcplugins/plugin_no_group.py
+++ b/webapp/tests/funcplugins/plugin_no_group.py
@@ -2,8 +2,8 @@ from graphite.functions.params import Param, ParamTypes
 
 
 def test(seriesList):
-  """This is a test function"""
-  return seriesList
+    """This is a test function"""
+    return seriesList
 
 
 test.params = [

--- a/webapp/tests/funcplugins/plugin_no_params.py
+++ b/webapp/tests/funcplugins/plugin_no_params.py
@@ -1,6 +1,6 @@
 def test(seriesList):
-  """This is a test function"""
-  return seriesList
+    """This is a test function"""
+    return seriesList
 
 
 test.group = 'Test'

--- a/webapp/tests/funcplugins/plugin_string_paramtype.py
+++ b/webapp/tests/funcplugins/plugin_string_paramtype.py
@@ -2,8 +2,8 @@ from graphite.functions.params import Param
 
 
 def test(seriesList):
-  """This is a test function"""
-  return seriesList
+    """This is a test function"""
+    return seriesList
 
 
 test.group = 'Test'

--- a/webapp/tests/test_attime.py
+++ b/webapp/tests/test_attime.py
@@ -13,14 +13,14 @@ import mock
 
 
 def mockDateTime(year, month, day, hour, minute, second):
-  class MockedDateTime(datetime):
-      @classmethod
-      def now(cls, tzinfo=None):
-          if tzinfo:
-            return tzinfo.localize(cls(year, month, day, hour, minute, second))
-          return cls(year, month, day, hour, minute, second)
+    class MockedDateTime(datetime):
+        @classmethod
+        def now(cls, tzinfo=None):
+            if tzinfo:
+                return tzinfo.localize(cls(year, month, day, hour, minute, second))
+            return cls(year, month, day, hour, minute, second)
 
-  return MockedDateTime
+    return MockedDateTime
 
 
 @mock.patch('graphite.render.attime.datetime', mockDateTime(2015, 3, 8, 12, 0, 0))

--- a/webapp/tests/test_finders.py
+++ b/webapp/tests/test_finders.py
@@ -118,9 +118,9 @@ class StandardFinderTest(TestCase):
             os.makedirs(dirname(path))
         whisper.create(path, [(1, 60)])
         if gz:
-          with open(path, 'rb') as f_in, gzip.open("%s.gz" % path, 'wb') as f_out:
-             shutil.copyfileobj(f_in, f_out)
-          os.remove(path)
+            with open(path, 'rb') as f_in, gzip.open("%s.gz" % path, 'wb') as f_out:
+                shutil.copyfileobj(f_in, f_out)
+            os.remove(path)
 
     def wipe_whisper(self):
         try:

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -14,9 +14,9 @@ from .base import TestCase
 from django.conf import settings
 
 try:
-  from django.urls import reverse
+    from django.urls import reverse
 except ImportError:  # Django < 1.10
-  from django.core.urlresolvers import reverse
+    from django.core.urlresolvers import reverse
 
 from graphite.errors import NormalizeEmptyResultError
 from graphite.functions import _SeriesFunctions, loadFunctions, safe
@@ -39,9 +39,9 @@ def return_less(series, value):
 class FunctionsTest(TestCase):
 
     def setUp(self):
-      super(FunctionsTest, self).setUp()
-      # Display more diff.
-      self.maxDiff = 1024
+        super(FunctionsTest, self).setUp()
+        # Display more diff.
+        self.maxDiff = 1024
 
     #
     # Test safeSum()
@@ -311,7 +311,7 @@ class FunctionsTest(TestCase):
 
     def test_safeAbs_empty_list(self):
         with self.assertRaises(TypeError):
-          safe.safeAbs([])
+            safe.safeAbs([])
 
     def test_safeAbs_pos_number(self):
         self.assertEqual(safe.safeAbs(1), 1)
@@ -993,9 +993,9 @@ class FunctionsTest(TestCase):
         result = functions.asPercent({}, seriesList)
 
         for i, series in enumerate(result):
-          for k, v in enumerate(series):
-            if type(v) is float:
-              series[k] = round(v,2)
+            for k, v in enumerate(series):
+                if type(v) is float:
+                    series[k] = round(v,2)
 
         self.assertEqual(result, expectedResult)
 
@@ -1030,8 +1030,8 @@ class FunctionsTest(TestCase):
 
         for i, series in enumerate(result):
             for k, v in enumerate(series):
-              if type(v) is float:
-                series[k] = round(v,2)
+                if type(v) is float:
+                    series[k] = round(v,2)
 
         self.assertEqual(result, expectedResult)
 
@@ -1075,9 +1075,9 @@ class FunctionsTest(TestCase):
         result = functions.asPercent({}, seriesList, seriesList2)
 
         for i, series in enumerate(result):
-          for k, v in enumerate(series):
-            if type(v) is float:
-              series[k] = round(v,2)
+            for k, v in enumerate(series):
+                if type(v) is float:
+                    series[k] = round(v,2)
 
         self.assertEqual(result, expectedResult)
 
@@ -1129,9 +1129,9 @@ class FunctionsTest(TestCase):
         result = functions.asPercent({}, seriesList, seriesList2)
 
         for i, series in enumerate(result):
-          for k, v in enumerate(series):
-            if type(v) is float:
-              series[k] = round(v,2)
+            for k, v in enumerate(series):
+                if type(v) is float:
+                    series[k] = round(v,2)
 
         self.assertEqual(result, expectedResult)
 
@@ -1205,9 +1205,9 @@ class FunctionsTest(TestCase):
         result = functions.asPercent({}, seriesList, seriesList2, 1)
 
         for i, series in enumerate(result):
-          for k, v in enumerate(series):
-            if type(v) is float:
-              series[k] = round(v,2)
+            for k, v in enumerate(series):
+                if type(v) is float:
+                    series[k] = round(v,2)
 
         self.assertEqual(result, expectedResult)
 
@@ -1258,9 +1258,9 @@ class FunctionsTest(TestCase):
         result = functions.asPercent({}, seriesList, None, 1)
 
         for i, series in enumerate(result):
-          for k, v in enumerate(series):
-            if type(v) is float:
-              series[k] = round(v,2)
+            for k, v in enumerate(series):
+                if type(v) is float:
+                    series[k] = round(v,2)
 
         self.assertEqual(result, expectedResult)
 
@@ -1348,9 +1348,9 @@ class FunctionsTest(TestCase):
         result = functions.divideSeries({}, seriesList, seriesList2)
 
         for i, series in enumerate(result):
-          for k, v in enumerate(series):
-            if type(v) is float:
-              series[k] = round(v,2)
+            for k, v in enumerate(series):
+                if type(v) is float:
+                    series[k] = round(v,2)
 
         self.assertEqual(result, expectedResult)
 
@@ -1387,9 +1387,9 @@ class FunctionsTest(TestCase):
         result = functions.divideSeriesLists({}, seriesList1, seriesList2)
 
         for i, series in enumerate(result):
-          for k, v in enumerate(series):
-            if type(v) is float:
-              series[k] = round(v,2)
+            for k, v in enumerate(series):
+                if type(v) is float:
+                    series[k] = round(v,2)
 
         self.assertEqual(result, expectedResult)
 
@@ -2683,7 +2683,7 @@ class FunctionsTest(TestCase):
         referenceSeries = copy.deepcopy(seriesList[0])
         for k, v in enumerate(referenceSeries):
             if k % 2 != 0:
-              referenceSeries[k] = None
+                referenceSeries[k] = None
 
         results = functions.transformNull({}, copy.deepcopy(seriesList), transform, [referenceSeries])
 
@@ -3016,7 +3016,7 @@ class FunctionsTest(TestCase):
             series = TimeSeries(expected, 0, 1, 1, [1])
             expectedResult.append(series)
         for i, series in enumerate(seriesList):
-          verify_groupByNode([expectedResult[i]], 3, [series])
+            verify_groupByNode([expectedResult[i]], 3, [series])
 
     def test_groupByNodes(self):
         seriesList, inputList = self._generate_mr_series()
@@ -3234,9 +3234,9 @@ class FunctionsTest(TestCase):
         result = functions.logarithm(requestContext, seriesList)
         # Round values to 7 digits for easier equality testing
         for i, series in enumerate(result):
-          for k, v in enumerate(series):
-            if type(v) is float:
-              series[k] = round(v,7)
+            for k, v in enumerate(series):
+                if type(v) is float:
+                    series[k] = round(v,7)
         self.assertEqual(result, expectedResult)
 
     def test_maximumAbove(self):
@@ -3705,14 +3705,14 @@ class FunctionsTest(TestCase):
         )
 
         with self.assertRaisesRegexp(ValueError, '^Unsupported aggregation function: bad$'):
-          functions.aggregateLine(
-            self._build_requestContext(
-                startTime=datetime(1970,1,1,1,0,0,0,pytz.timezone(settings.TIME_ZONE)),
-                endTime=datetime(1970,1,1,1,0,0,0,pytz.timezone(settings.TIME_ZONE))
-            ),
-            seriesList,
-            'bad'
-          )
+            functions.aggregateLine(
+                self._build_requestContext(
+                    startTime=datetime(1970,1,1,1,0,0,0,pytz.timezone(settings.TIME_ZONE)),
+                    endTime=datetime(1970,1,1,1,0,0,0,pytz.timezone(settings.TIME_ZONE))
+                ),
+                seriesList,
+                'bad'
+            )
 
     def test_threshold_default(self):
         expectedResult = [
@@ -4620,8 +4620,8 @@ class FunctionsTest(TestCase):
 
         def frange(x,y,jump):
             while x<y:
-              yield x
-              x+=jump
+                yield x
+                x+=jump
         expectedResults = [
             TimeSeries('movingAverage(collectd.test-db0.load.value,60)', 660, 700, 1, frange(29.5, 69.5, 1)),
         ]
@@ -4654,8 +4654,8 @@ class FunctionsTest(TestCase):
 
         def frange(x,y,jump):
             while x<y:
-              yield x
-              x+=jump
+                yield x
+                x+=jump
 
         expectedResults = [
             TimeSeries('movingAverage(collectd.test-db0.load.value,"-1min")', 660, 700, 1, frange(29.5, 69.5, 1)),
@@ -5154,8 +5154,8 @@ class FunctionsTest(TestCase):
 
         def hw_range(x,y,jump):
             while x<y:
-              yield (x/jump) % 10
-              x+=jump
+                yield (x/jump) % 10
+                x+=jump
 
         def gen_seriesList(start=0, points=10):
             seriesList = [
@@ -5193,8 +5193,8 @@ class FunctionsTest(TestCase):
 
         def hw_range(x,y,jump):
             while x<y:
-              yield (x/jump) % 10
-              x+=jump
+                yield (x/jump) % 10
+                x+=jump
 
         def gen_seriesList(start=0, points=10):
             seriesList = [
@@ -5234,8 +5234,8 @@ class FunctionsTest(TestCase):
 
         def hw_range(x,y,jump,t=0):
             while x<y:
-              yield t + (x/jump) % 10
-              x+=jump
+                yield t + (x/jump) % 10
+                x+=jump
 
         def gen_seriesList(start=0, points=10):
             seriesList = [
@@ -5712,17 +5712,17 @@ class FunctionsTest(TestCase):
         }
 
         for func in expectedResults:
-          for series in expectedResults[func]:
-              series.pathExpression = series.name
-          result = functions.summarize(
-              self._build_requestContext(endTime=datetime(1970, 1, 1, 0, 4, 0, 0, pytz.timezone(settings.TIME_ZONE))),
-              seriesList,
-              "1minute",
-              func
-          )
-          self.maxDiff = None
-          self.assertEqual(list(result[0]), list(expectedResults[func][0]))
-          self.assertEqual(result, expectedResults[func])
+            for series in expectedResults[func]:
+                series.pathExpression = series.name
+            result = functions.summarize(
+                self._build_requestContext(endTime=datetime(1970, 1, 1, 0, 4, 0, 0, pytz.timezone(settings.TIME_ZONE))),
+                seriesList,
+                "1minute",
+                func
+            )
+            self.maxDiff = None
+            self.assertEqual(list(result[0]), list(expectedResults[func][0]))
+            self.assertEqual(result, expectedResults[func])
 
     def test_summarize_1minute_alignToFrom(self):
         seriesList = self._gen_series_list_with_data(
@@ -5766,8 +5766,8 @@ class FunctionsTest(TestCase):
         }
 
         for func in expectedResults:
-          for series in expectedResults[func]:
-              series.pathExpression = series.name
+            for series in expectedResults[func]:
+                series.pathExpression = series.name
 
         result = functions.summarize(
           self._build_requestContext(endTime=datetime(1970, 1, 1, 0, 4, 0, 0, pytz.timezone(settings.TIME_ZONE))),
@@ -6097,9 +6097,9 @@ class FunctionsTest(TestCase):
             result = evaluateTarget(request_context, query)
 
         for i, series in enumerate(result):
-          for k, v in enumerate(series):
-            if type(v) is float:
-              series[k] = round(v,2)
+            for k, v in enumerate(series):
+                if type(v) is float:
+                    series[k] = round(v,2)
 
         self.assertEqual(result, expectedResult)
 

--- a/webapp/tests/test_metrics.py
+++ b/webapp/tests/test_metrics.py
@@ -84,14 +84,14 @@ class MetricsTester(TestCase):
 
         # failure
         def mock_STORE_get_index(self, requestContext=None):
-          raise Exception('test')
+            raise Exception('test')
 
         with patch('graphite.metrics.views.STORE.get_index', mock_STORE_get_index):
-          request = {}
-          response = self.client.post(url, request)
-          self.assertEqual(response.status_code, 500)
-          data = json.loads(response.content)
-          self.assertEqual(data, [])
+            request = {}
+            response = self.client.post(url, request)
+            self.assertEqual(response.status_code, 500)
+            data = json.loads(response.content)
+            self.assertEqual(data, [])
 
     def test_find_view(self):
         ts = int(time.time())
@@ -152,12 +152,12 @@ class MetricsTester(TestCase):
         self.assertEqual(response.content, b"Invalid value for 'format' parameter")
 
         def test_find_view_basics(data):
-          response = self.client.post(url, data)
-          self.assertEqual(response.status_code, 200)
-          self.assertTrue(response.has_header('Pragma'))
-          self.assertTrue(response.has_header('Cache-Control'))
+            response = self.client.post(url, data)
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(response.has_header('Pragma'))
+            self.assertTrue(response.has_header('Cache-Control'))
 
-          return response.content
+            return response.content
 
         #
         # Default values

--- a/webapp/tests/test_readers_ceres.py
+++ b/webapp/tests/test_readers_ceres.py
@@ -55,8 +55,8 @@ class CeresReaderTests(TestCase):
         reader = CeresReader(ceres.CeresTree(self.test_dir).getNode('ceres.reader.tests.worker1.cpu'), 'ceres.reader.tests.worker1.cpu')
         intervals = reader.get_intervals()
         for interval in intervals:
-          self.assertEqual(interval.start, self.start_ts)
-          self.assertEqual(interval.end, self.start_ts+1)
+            self.assertEqual(interval.start, self.start_ts)
+            self.assertEqual(interval.end, self.start_ts+1)
 
     # Confirm fetch works.
     def test_CeresReader_fetch(self):

--- a/webapp/tests/test_readers_multi.py
+++ b/webapp/tests/test_readers_multi.py
@@ -86,8 +86,8 @@ class MultiReaderTests(TestCase):
         reader = MultiReader([node1, node2])
         intervals = reader.get_intervals()
         for interval in intervals:
-          self.assertEqual(int(interval.start), self.start_ts - 60)
-          self.assertIn(int(interval.end), [self.start_ts, self.start_ts - 1])
+            self.assertEqual(int(interval.start), self.start_ts - 60)
+            self.assertIn(int(interval.end), [self.start_ts, self.start_ts - 1])
 
     # Confirm fetch works.
     def test_MultiReader_fetch(self):

--- a/webapp/tests/test_readers_remote.py
+++ b/webapp/tests/test_readers_remote.py
@@ -151,7 +151,7 @@ class RemoteReaderTests(TestCase):
         http_request.return_value = responseObject
 
         with self.assertRaisesRegexp(Exception, 'Error decoding response from http://[^ ]+: .+'):
-          reader.fetch(startTime, endTime)
+            reader.fetch(startTime, endTime)
 
         # invalid response data
         data = [
@@ -166,20 +166,20 @@ class RemoteReaderTests(TestCase):
         http_request.return_value = responseObject
 
         with self.assertRaisesRegexp(Exception, r'Invalid render response from http://[^ ]+: KeyError\(\'name\',?\)'):
-          reader.fetch(startTime, endTime)
+            reader.fetch(startTime, endTime)
 
         # non-200 response
         responseObject = HTTPResponse(body=BytesIO(b'error'), status=500, preload_content=False)
         http_request.return_value = responseObject
 
         with self.assertRaisesRegexp(Exception, 'Error response 500 from http://[^ ]+'):
-          reader.fetch(startTime, endTime)
+            reader.fetch(startTime, endTime)
 
         # exception raised by request()
         http_request.side_effect = Exception('error')
 
         with self.assertRaisesRegexp(Exception, 'Error requesting http://[^ ]+: error'):
-          reader.fetch(startTime, endTime)
+            reader.fetch(startTime, endTime)
 
     #
     # Test RemoteReader.fetch()

--- a/webapp/tests/test_readers_whisper.py
+++ b/webapp/tests/test_readers_whisper.py
@@ -79,14 +79,14 @@ class WhisperReadersTests(TestCase):
         ts = int(time.time())
         intervals = reader.get_intervals()
         for interval in intervals:
-          self.assertEqual(int(interval.start), ts - 60)
-          self.assertIn(int(interval.end), [ts, ts - 1])
+            self.assertEqual(int(interval.start), ts - 60)
+            self.assertIn(int(interval.end), [ts, ts - 1])
 
         # read it again to validate cache works
         intervals = reader.get_intervals()
         for interval in intervals:
-          self.assertEqual(int(interval.start),ts - 60)
-          self.assertIn(int(interval.end), [ts, ts - 1])
+            self.assertEqual(int(interval.start),ts - 60)
+            self.assertIn(int(interval.end), [ts, ts - 1])
 
     # Confirm fetch works.
     def test_GzippedWhisperReader_fetch(self):
@@ -120,14 +120,14 @@ class WhisperReadersTests(TestCase):
         ts = int(time.time())
         intervals = reader.get_intervals()
         for interval in intervals:
-          self.assertEqual(int(interval.start),ts - 60)
-          self.assertIn(int(interval.end), [ts, ts - 1])
+            self.assertEqual(int(interval.start),ts - 60)
+            self.assertIn(int(interval.end), [ts, ts - 1])
 
         # read it again to validate cache works
         intervals = reader.get_intervals()
         for interval in intervals:
-          self.assertEqual(int(interval.start),ts - 60)
-          self.assertIn(int(interval.end), [ts, ts - 1])
+            self.assertEqual(int(interval.start),ts - 60)
+            self.assertIn(int(interval.end), [ts, ts - 1])
 
     # Confirm get_raw_step works
     def test_WhisperReader_get_raw_step(self):

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -132,27 +132,27 @@ class RenderTest(TestCase):
 
         message = r'invalid template\(\) syntax, only string/numeric arguments are allowed'
         with self.assertRaisesRegexp(ValueError, message):
-          evaluateTarget({}, test_input)
+            evaluateTarget({}, test_input)
 
     @patch('graphite.render.evaluator.prefetchData', lambda *_: None)
     def test_render_evaluateTokens_NormalizeEmptyResultError(self):
         def raiseError(requestContext):
-          raise NormalizeEmptyResultError
+            raise NormalizeEmptyResultError
 
         with patch('graphite.functions._SeriesFunctions', {'test': raiseError}):
-          outputs = evaluateTarget({}, 'test()')
-          self.assertEqual(outputs, [])
+            outputs = evaluateTarget({}, 'test()')
+            self.assertEqual(outputs, [])
 
     @patch('graphite.render.evaluator.prefetchData', lambda *_: None)
     def test_render_evaluateTokens_TimeSeries(self):
         timeseries = TimeSeries('test', 0, 1, 1, [1])
 
         def returnTimeSeries(requestContext):
-          return timeseries
+            return timeseries
 
         with patch('graphite.functions._SeriesFunctions', {'test': returnTimeSeries}):
-          outputs = evaluateTarget({}, 'test()')
-          self.assertEqual(outputs, [timeseries])
+            outputs = evaluateTarget({}, 'test()')
+            self.assertEqual(outputs, [timeseries])
 
     def test_render_evaluateScalarTokens(self):
         # test parsing numeric arguments
@@ -169,25 +169,25 @@ class RenderTest(TestCase):
 
         # test invalid tokens
         class ScalarToken(object):
-          number = None
-          string = None
-          boolean = None
-          none = None
-          infinity = None
+            number = None
+            string = None
+            boolean = None
+            none = None
+            infinity = None
 
         class ScalarTokenNumber(object):
-          integer = None
-          float = None
-          scientific = None
+            integer = None
+            float = None
+            scientific = None
 
         with self.assertRaisesRegexp(ValueError, 'unknown token in target evaluator'):
-          tokens = ScalarToken()
-          evaluateScalarTokens(tokens)
+            tokens = ScalarToken()
+            evaluateScalarTokens(tokens)
 
         with self.assertRaisesRegexp(ValueError, 'unknown numeric type in target evaluator'):
-          tokens = ScalarToken()
-          tokens.number = ScalarTokenNumber()
-          evaluateScalarTokens(tokens)
+            tokens = ScalarToken()
+            tokens.number = ScalarTokenNumber()
+            evaluateScalarTokens(tokens)
 
     def test_render_view(self):
         url = reverse('render')

--- a/webapp/tests/test_util.py
+++ b/webapp/tests/test_util.py
@@ -98,24 +98,24 @@ class UtilTest(TestCase):
 
     @patch('graphite.util.log')
     def test_logtime(self, log):
-      @util.logtime
-      def test_logtime(ok, custom=None, timer=None):
-        timer.set_name('test')
-        if custom:
-          timer.set_msg(custom)
-        if ok:
-          return True
-        raise Exception('testException')
+        @util.logtime
+        def test_logtime(ok, custom=None, timer=None):
+            timer.set_name('test')
+            if custom:
+                timer.set_msg(custom)
+            if ok:
+                return True
+            raise Exception('testException')
 
-      test_logtime(True)
-      self.assertEqual(log.info.call_count, 1)
-      self.assertRegexpMatches(log.info.call_args[0][0], r'test :: completed in [-.e0-9]+s')
+        test_logtime(True)
+        self.assertEqual(log.info.call_count, 1)
+        self.assertRegexpMatches(log.info.call_args[0][0], r'test :: completed in [-.e0-9]+s')
 
-      test_logtime(True, 'custom')
-      self.assertEqual(log.info.call_count, 2)
-      self.assertRegexpMatches(log.info.call_args[0][0], r'test :: custom [-.e0-9]+s')
+        test_logtime(True, 'custom')
+        self.assertEqual(log.info.call_count, 2)
+        self.assertRegexpMatches(log.info.call_args[0][0], r'test :: custom [-.e0-9]+s')
 
-      with self.assertRaisesRegexp(Exception, 'testException'):
-        test_logtime(False)
-      self.assertEqual(log.info.call_count, 3)
-      self.assertRegexpMatches(log.info.call_args[0][0], r'test :: failed in [-.e0-9]+s')
+        with self.assertRaisesRegexp(Exception, 'testException'):
+            test_logtime(False)
+        self.assertEqual(log.info.call_count, 3)
+        self.assertRegexpMatches(log.info.call_args[0][0], r'test :: failed in [-.e0-9]+s')

--- a/webapp/tests/test_whitelist.py
+++ b/webapp/tests/test_whitelist.py
@@ -36,7 +36,7 @@ class WhitelistTester(TestCase):
     def test_whitelist_show_no_whitelist(self):
         url = reverse('whitelist_show')
         with self.assertRaises(IOError):
-          _ = self.client.get(url)
+            _ = self.client.get(url)
 
     def test_whitelist_show(self):
         url = reverse('whitelist_show')

--- a/webapp/tests/test_worker_pool.py
+++ b/webapp/tests/test_worker_pool.py
@@ -20,7 +20,7 @@ class TestPool(unittest.TestCase):
         err = Exception('this is a test')
 
         def testfunc():
-          raise err
+            raise err
 
         results = pool.pool_exec(p, [pool.Job(testfunc, 'job')], 1)
 
@@ -59,9 +59,8 @@ class TestPool(unittest.TestCase):
         jobs = [pool.Job(lambda v: time.sleep(1) and v, 'job', i) for i in range(1, 5)]
 
         with self.assertRaises(pool.PoolTimeoutError):
-          results = pool.pool_exec(p, jobs, 1)
-
-          list(results)
+            results = pool.pool_exec(p, jobs, 1)
+            list(results)
 
     def test_timeout_sync(self):
         p = pool.get_pool(thread_count=0)
@@ -69,9 +68,8 @@ class TestPool(unittest.TestCase):
         jobs = [pool.Job(lambda v: time.sleep(1) and v, 'job', i) for i in range(1, 5)]
 
         with self.assertRaises(pool.PoolTimeoutError):
-          results = pool.pool_exec(p, jobs, 1)
-
-          list(results)
+            results = pool.pool_exec(p, jobs, 1)
+            list(results)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The 4-space indent thing would be nice to enable checks for, but it's a huge amount of churn throughout the code-base. So my idea is to ignore this rule from the files with the most  warnings, and start working from the files with the fewest warnings.

(A reasonable alternative is to not re-enable this for flake8, and continue to let Deep Source complain about it just for functions which are modified, as we saw in #2574.)

After re-enabling the indent rules, before ignoring or fixing any files, here's the ranking of violations per file:

```
graphite-web]$ flake8 | cut -d: -f1 | uniq -c | sort -n
   1 ./webapp/graphite/url_shortener/baseconv.py
   1 ./webapp/tests/base.py
   1 ./webapp/tests/test_whitelist.py
   2 ./webapp/graphite/account/admin.py
   2 ./webapp/graphite/version/views.py
   2 ./webapp/tests/funcplugins/plugin_bad_paramtype.py
   2 ./webapp/tests/funcplugins/plugin_no_group.py
   2 ./webapp/tests/funcplugins/plugin_no_params.py
   2 ./webapp/tests/funcplugins/plugin_string_paramtype.py
   2 ./webapp/tests/test_readers_ceres.py
   2 ./webapp/tests/test_readers_multi.py
   3 ./webapp/graphite/functions/aggfuncs.py
   3 ./webapp/graphite/views.py
   3 ./webapp/tests/test_finders.py
   4 ./webapp/graphite/events/views.py
   4 ./webapp/tests/funcplugins/plugin.py
   4 ./webapp/tests/funcplugins/plugin_bad_param.py
   4 ./webapp/tests/test_readers_remote.py
   5 ./webapp/graphite/errors.py
   5 ./webapp/graphite/render/grammar.py
   5 ./webapp/tests/test_worker_pool.py
   6 ./bin/run-graphite-devel-server.py
   6 ./contrib/test_aggregator_rules.py
   6 ./setup.py
   6 ./webapp/tests/test_attime.py
   7 ./docs/conf.py
   8 ./webapp/graphite/user_util.py
   8 ./webapp/tests/test_readers_whisper.py
   9 ./webapp/graphite/logger.py
  11 ./webapp/tests/test_metrics.py
  12 ./webapp/graphite/tags/models.py
  13 ./webapp/graphite/node.py
  13 ./webapp/tests/test_util.py
  17 ./webapp/graphite/dashboard/models.py
  19 ./webapp/graphite/composer/views.py
  19 ./webapp/graphite/finders/standard.py
  19 ./webapp/graphite/readers/remote.py
  20 ./webapp/graphite/account/models.py
  20 ./webapp/graphite/account/views.py
  20 ./webapp/graphite/functions/views.py
  20 ./webapp/tests/test_render.py
  21 ./examples/example-client.py
  22 ./webapp/graphite/whitelist/views.py
  24 ./webapp/graphite/account/ldapBackend.py
  32 ./webapp/graphite/tags/http.py
  33 ./webapp/graphite/functions/__init__.py
  33 ./webapp/graphite/settings.py
  35 ./webapp/graphite/worker_pool/pool.py
  39 ./webapp/graphite/storage.py
  42 ./webapp/graphite/intervals.py
  43 ./webapp/graphite/tags/utils.py
  44 ./webapp/graphite/functions/safe.py
  44 ./webapp/graphite/render/hashing.py
  46 ./webapp/tests/test_functions.py
  47 ./check-dependencies.py
  49 ./webapp/graphite/tags/views.py
  56 ./webapp/graphite/carbonlink.py
  65 ./webapp/graphite/tags/redis.py
  68 ./webapp/graphite/render/attime.py
  71 ./webapp/graphite/tags/base.py
  76 ./webapp/tests/test_tags.py
  87 ./webapp/graphite/render/evaluator.py
 103 ./webapp/graphite/browser/views.py
 111 ./webapp/graphite/render/datalib.py
 116 ./webapp/graphite/util.py
 126 ./webapp/tests/test_storage.py
 135 ./webapp/graphite/tags/localdatabase.py
 136 ./webapp/tests/test_finders_remote.py
 142 ./webapp/graphite/dashboard/views.py
 161 ./webapp/graphite/metrics/views.py
 213 ./webapp/tests/test_render_datalib.py
 238 ./webapp/graphite/render/views.py
 261 ./contrib/memcache_whisper.py
 443 ./webapp/tests/test_render_glyph.py
 645 ./webapp/graphite/render/glyph.py
1110 ./webapp/graphite/render/functions.py
```

I'm only about one third of the way done ... please let me know whether you think this is a good idea or not :)