### PR TITLE
Implement upper lower case functions

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2617,6 +2617,7 @@ def toUpperCase(requestContext, seriesList, *pos):
     else:
       tmpName = list(series.name)
       for i in pos:
+        assert isinstance(i, int)
         try:
           tmpName[i] = tmpName[i].upper()
         except IndexError:
@@ -2650,6 +2651,7 @@ def toLowerCase(requestContext, seriesList, *pos):
     else:
       tmpName = list(series.name)
       for i in pos:
+        assert isinstance(i, int)
         try:
           tmpName[i] = tmpName[i].lower()
         except IndexError:

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2600,6 +2600,76 @@ legendValue.params = [
 ]
 
 
+def toUpperCase(requestContext, seriesList, *pos):
+  """
+  Takes one metric or a wildcard seriesList and uppers the case of each letter.
+
+  Optionally, a letter position to upper case can be specified, in which case
+  only the letter at the specified position gets upper-cased.
+  The position parameter may be given multiple times.
+  The position parameter may be negative to define a position relative to the
+  end of the metric name.
+  """
+
+  for series in seriesList:
+    if len(pos) == 0:
+      series.name = series.name.upper()
+    else:
+      for i in pos:
+        if (i >= 0 and i >= len(series.name)) or (i < 0 and i*-1 > len(series.name)):
+          continue
+
+        newName = series.name[:i] + series.name[i].upper()
+        if i != -1:
+          newName += series.name[i+1:]
+
+        series.name = newName
+
+  return seriesList
+
+
+toUpperCase.group = 'Alias'
+toUpperCase.params = [
+  Param('seriesList', ParamTypes.seriesList, required=True),
+  Param('pos', ParamTypes.integer, multiple=True)
+]
+
+
+def toLowerCase(requestContext, seriesList, *pos):
+  """
+  Takes one metric or a wildcard seriesList and lowers the case of each letter.
+
+  Optionally, a letter position to lower case can be specified, in which case
+  only the letter at the specified position gets lower-cased.
+  The position parameter may be given multiple times.
+  The position parameter may be negative to define a position relative to the
+  end of the metric name.
+  """
+
+  for series in seriesList:
+    if len(pos) == 0:
+      series.name = series.name.lower()
+    else:
+      for i in pos:
+        if (i >= 0 and i >= len(series.name)) or (i < 0 and i*-1 > len(series.name)):
+          continue
+
+        newName = series.name[:i] + series.name[i].lower()
+        if i != -1:
+          newName += series.name[i+1:]
+
+        series.name = newName
+
+  return seriesList
+
+
+toLowerCase.group = 'Alias'
+toLowerCase.params = [
+  Param('seriesList', ParamTypes.seriesList, required=True),
+  Param('pos', ParamTypes.integer, multiple=True)
+]
+
+
 def alpha(requestContext, seriesList, alpha):
   """
   Assigns the given alpha transparency setting to the series. Takes a float value between 0 and 1.
@@ -5779,6 +5849,8 @@ SeriesFunctions = {
   'aliasQuery': aliasQuery,
   'aliasSub': aliasSub,
   'legendValue': legendValue,
+  'upper': toUpperCase,
+  'lower': toLowerCase,
 
   # Graph functions
   'alpha': alpha,

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2615,15 +2615,13 @@ def toUpperCase(requestContext, seriesList, *pos):
     if len(pos) == 0:
       series.name = series.name.upper()
     else:
+      tmpName = list(series.name)
       for i in pos:
-        if (i >= 0 and i >= len(series.name)) or (i < 0 and i*-1 > len(series.name)):
-          continue
-
-        newName = series.name[:i] + series.name[i].upper()
-        if i != -1:
-          newName += series.name[i+1:]
-
-        series.name = newName
+        try:
+          tmpName[i] = tmpName[i].upper()
+        except IndexError:
+          pass
+      series.name = "".join(tmpName)
 
   return seriesList
 
@@ -2650,15 +2648,13 @@ def toLowerCase(requestContext, seriesList, *pos):
     if len(pos) == 0:
       series.name = series.name.lower()
     else:
+      tmpName = list(series.name)
       for i in pos:
-        if (i >= 0 and i >= len(series.name)) or (i < 0 and i*-1 > len(series.name)):
-          continue
-
-        newName = series.name[:i] + series.name[i].lower()
-        if i != -1:
-          newName += series.name[i+1:]
-
-        series.name = newName
+        try:
+          tmpName[i] = tmpName[i].lower()
+        except IndexError:
+          pass
+      series.name = "".join(tmpName)
 
   return seriesList
 

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -4199,6 +4199,134 @@ class FunctionsTest(TestCase):
         result = functions.legendValue({}, seriesList, "avg", "bogus")
         self.assertEqual(result, expectedResult)
 
+    def test_upper_without_positions(self):
+        seriesList = self._gen_series_list_with_data(
+            key=['', 'a', 'normal.metric.name.with.normal.length', '!@#$%^&*()_+'],
+            start=0,
+            end=4,
+            data=[[], [], [], []],
+        )
+        expectedResult = [
+            TimeSeries('', 0, 4, 1, []),
+            TimeSeries('A', 0, 4, 1, []),
+            TimeSeries('NORMAL.METRIC.NAME.WITH.NORMAL.LENGTH', 0, 4, 1, []),
+            TimeSeries('!@#$%^&*()_+', 0, 4, 1, []),
+        ]
+        result = functions.toUpperCase({}, seriesList)
+        self.assertEqual(result, expectedResult)
+
+    def test_upper_with_one_position(self):
+        seriesList = self._gen_series_list_with_data(
+            key=[
+                '',
+                'normal.metric.name.with.normal.length',
+            ],
+            start=0,
+            end=4,
+            data=[[], [], [], []],
+        )
+
+        expectedResult = [
+            TimeSeries('', 0, 4, 1, []),
+            TimeSeries('normal.metRic.name.with.normal.length', 0, 4, 1, []),
+        ]
+        seriesList = functions.toUpperCase({}, seriesList, 10)
+        self.assertEqual(seriesList, expectedResult)
+
+        expectedResult[1].name = 'Normal.metRic.name.with.normal.length'
+        seriesList = functions.toUpperCase({}, seriesList, 0)
+        self.assertEqual(seriesList, expectedResult)
+
+        expectedResult[1].name = 'Normal.metRic.name.with.normal.lengtH'
+        seriesList = functions.toUpperCase({}, seriesList, -1)
+        self.assertEqual(seriesList, expectedResult)
+
+        expectedResult[1].name = 'Normal.metRic.name.with.normal.lengtH'
+        seriesList = functions.toUpperCase({}, seriesList, 1000)
+        self.assertEqual(seriesList, expectedResult)
+
+    def test_upper_with_multiple_positions(self):
+        seriesList = self._gen_series_list_with_data(
+            key=[
+                '',
+                'normal.metric.name.with.normal.length',
+            ],
+            start=0,
+            end=4,
+            data=[[], [], [], []],
+        )
+
+        expectedResult = [
+            TimeSeries('', 0, 4, 1, []),
+            TimeSeries('Normal.metric.nAme.with.normal.lenGtH', 0, 4, 1, []),
+        ]
+        seriesList = functions.toUpperCase({}, seriesList, 0, 15, 100, -3, -1, -1000)
+        self.assertEqual(seriesList, expectedResult)
+
+    def test_lower_without_positions(self):
+        seriesList = self._gen_series_list_with_data(
+            key=['', 'A', 'NORMAL.METRIC.NAME.WITH.NORMAL.LENGTH', '!@#$%^&*()_+'],
+            start=0,
+            end=4,
+            data=[[], [], [], []],
+        )
+        expectedResult = [
+            TimeSeries('', 0, 4, 1, []),
+            TimeSeries('a', 0, 4, 1, []),
+            TimeSeries('normal.metric.name.with.normal.length', 0, 4, 1, []),
+            TimeSeries('!@#$%^&*()_+', 0, 4, 1, []),
+        ]
+        result = functions.toLowerCase({}, seriesList)
+        self.assertEqual(result, expectedResult)
+
+    def test_lower_with_one_position(self):
+        seriesList = self._gen_series_list_with_data(
+            key=[
+                '',
+                'NORMAL.METRIC.NAME.WITH.NORMAL.LENGTH',
+            ],
+            start=0,
+            end=4,
+            data=[[], [], [], []],
+        )
+
+        expectedResult = [
+            TimeSeries('', 0, 4, 1, []),
+            TimeSeries('NORMAL.METrIC.NAME.WITH.NORMAL.LENGTH', 0, 4, 1, []),
+        ]
+        seriesList = functions.toLowerCase({}, seriesList, 10)
+        self.assertEqual(seriesList, expectedResult)
+
+        expectedResult[1].name = 'nORMAL.METrIC.NAME.WITH.NORMAL.LENGTH'
+        seriesList = functions.toLowerCase({}, seriesList, 0)
+        self.assertEqual(seriesList, expectedResult)
+
+        expectedResult[1].name = 'nORMAL.METrIC.NAME.WITH.NORMAL.LENGTh'
+        seriesList = functions.toLowerCase({}, seriesList, -1)
+        self.assertEqual(seriesList, expectedResult)
+
+        expectedResult[1].name = 'nORMAL.METrIC.NAME.WITH.NORMAL.LENGTh'
+        seriesList = functions.toLowerCase({}, seriesList, 1000)
+        self.assertEqual(seriesList, expectedResult)
+
+    def test_lower_with_multiple_positions(self):
+        seriesList = self._gen_series_list_with_data(
+            key=[
+                '',
+                'NORMAL.METRIC.NAME.WITH.NORMAL.LENGTH',
+            ],
+            start=0,
+            end=4,
+            data=[[], [], [], []],
+        )
+
+        expectedResult = [
+            TimeSeries('', 0, 4, 1, []),
+            TimeSeries('nORMAL.METRIC.NaME.WITH.NORMAL.LENgTh', 0, 4, 1, []),
+        ]
+        seriesList = functions.toLowerCase({}, seriesList, 0, 15, 100, -3, -1, -1000)
+        self.assertEqual(seriesList, expectedResult)
+
     @patch('graphite.render.evaluator.prefetchData', lambda *_: None)
     def test_linearRegression(self):
         seriesList = self._gen_series_list_with_data(


### PR DESCRIPTION
This implements functions to upper/lower case metric names, or single letters of metric names. We've had users asking for this and I thought this might be useful to other people too.

If this gets accepted I should probably update the example custom function: https://graphite.readthedocs.io/en/latest/functions.html#function-plugins