### PR TITLE
fix composer saved graphs target escaping

### DIFF
--- a/webapp/content/js/composer_widgets.js
+++ b/webapp/content/js/composer_widgets.js
@@ -515,7 +515,14 @@ var GraphDataWindow = {
       hideHeaders: true,
       width: 385,
       height: 140,
-      columns: [ {header: 'Graph Targets', width: 1.0, dataIndex: 'value'} ],
+      columns: [
+        {
+          header: 'Graph Targets',
+          width: 1.0,
+          dataIndex: 'value',
+          tpl: '{value:htmlEncode}'
+        }
+      ],
       listeners: {
         contextmenu: this.targetContextMenu,
         afterrender: this.targetChanged,

--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -1915,6 +1915,7 @@ function graphClicked(graphView, graphIndex, element, evt) {
           header: 'Target',
           dataIndex: 'target',
           width: gridWidth - 90,
+          renderer: 'htmlEncode',
           editor: {xtype: 'textfield'}
         },
         {

--- a/webapp/graphite/browser/views.py
+++ b/webapp/graphite/browser/views.py
@@ -24,7 +24,6 @@ from graphite.user_util import getProfile, getProfileByUsername
 from graphite.util import json
 from graphite.logger import log
 from hashlib import md5
-from six.moves.urllib.parse import urlencode, urlparse, parse_qsl
 
 
 def header(request):
@@ -138,19 +137,7 @@ def myGraphLookup(request):
       else:
         m = md5()
         m.update(name.encode('utf-8'))
-
-        # Sanitize target
-        urlEscaped = str(graph.url)
-        graphUrl = urlparse(urlEscaped)
-        graphUrlParams = {}
-        graphUrlParams['target'] = []
-        for param in parse_qsl(graphUrl.query):
-          if param[0] != 'target':
-            graphUrlParams[param[0]] = param[1]
-          else:
-            graphUrlParams[param[0]].append(escape(param[1]))
-        urlEscaped = graphUrl._replace(query=urlencode(graphUrlParams, True)).geturl()
-        node.update( { 'id' : str(userpath_prefix + m.hexdigest()), 'graphUrl' : urlEscaped } )
+        node.update( { 'id' : str(userpath_prefix + m.hexdigest()), 'graphUrl' : graph.url } )
         node.update(leafNode)
 
       nodes.append(node)
@@ -237,22 +224,10 @@ def userGraphLookup(request):
           m = md5()
           m.update(nodeName.encode('utf-8'))
 
-          # Sanitize target
-          urlEscaped = str(graph.url)
-          graphUrl = urlparse(urlEscaped)
-          graphUrlParams = {}
-          graphUrlParams['target'] = []
-          for param in parse_qsl(graphUrl.query):
-            if param[0] != 'target':
-              graphUrlParams[param[0]] = param[1]
-            else:
-              graphUrlParams[param[0]].append(escape(param[1]))
-          urlEscaped = graphUrl._replace(query=urlencode(graphUrlParams, True)).geturl()
-
           node = {
             'text' : escape(nodeName),
             'id' : username + '.' + prefix + m.hexdigest(),
-            'graphUrl' : urlEscaped,
+            'graphUrl' : graph.url,
           }
           node.update(leafNode)
 


### PR DESCRIPTION
saved graphs targets were html-escaped in the json response
to fix an XSS vulnerability in graphite-project/graphite-web#1662

... but that was not really the right place to escape the graph targets,
it broke targets using quotes: #1801 #2334

so effectively revert the original fix, and instead html-escape the
targets just before rendering them in the GraphDataWindow Ext.ListView

-----

TODO:
  - [x] ensure works with python-3 (`str(thing)` is never the right way :)
  - [x] check what the "dashboard" interface does (it doesn't have this problem, does it allow html injection though?)