### PR TITLE
fix dashboard metric completion on backspace in Firefox

### DIFF
--- a/webapp/content/js/dashboard.js
+++ b/webapp/content/js/dashboard.js
@@ -374,8 +374,7 @@ function initDashboard () {
       enableKeyEvents: true,
       cls: 'completer-input-field',
       listeners: {
-        keypress: completerKeyPress,
-        specialkey: completerKeyPress,
+        keydown: completerKeyPress,
         afterrender: focusCompleter
       }
     });


### PR DESCRIPTION
Firefox does not seem to trigger the 'keypress' or 'keyspecial' events for the backspace key, all seems to work correctly with the 'keydown' event. (Chrome does seem to trigger 'keyspecial' for the backspace key.)

Apparently 'keypress' is deprecated: https://developer.mozilla.org/en-US/docs/Web/API/Document/keypress_event and 'keyspecial' does not seem to be documented, while 'keydown' is well supported: https://developer.mozilla.org/en-US/docs/Web/API/Document/keydown_event

Looking just above in the code we can see that backspace is intended to trigger completion:

```js
    function completerKeyPress(thisField, e) {
      var charCode = e.getCharCode();
      if (charCode == 8 ||  //backspace
          charCode >= 46 || //delete and all printables
          charCode == 36 || //home
          charCode == 35) { //end
        autocompleteTask.delay(AUTOCOMPLETE_DELAY);
      }
    }
````