### PR TITLE
Better logs on invalid input

### DIFF
--- a/webapp/graphite/errors.py
+++ b/webapp/graphite/errors.py
@@ -1,4 +1,5 @@
 from django.http import HttpResponseBadRequest
+from graphite.logger import log
 
 
 class NormalizeEmptyResultError(Exception):
@@ -7,7 +8,71 @@ class NormalizeEmptyResultError(Exception):
 
 
 class InputParameterError(ValueError):
-    pass
+
+    def __init__(self, *args, **kwargs):
+        super(InputParameterError, self).__init__(*args, **kwargs)
+        self.context = {}
+
+    def setSourceIdHeaders(self, sourceIdHeaders):
+        if 'sourceIdHeaders' not in self.context:
+            self.context['sourceIdHeaders'] = {}
+
+        self.context['sourceIdHeaders'].update(sourceIdHeaders)
+
+    def setTarget(self, rawTarget):
+        self.context['target'] = rawTarget
+
+    def setFunction(self, function, args, kwargs):
+        self.context['function'] = function
+        self.context['args'] = args
+        self.context['kwargs'] = kwargs
+
+    def describe(self):
+        target = self.context.get('target', None)
+        source = ''
+        sourceIdHeaders = self.context.get('sourceIdHeaders', None)
+
+        # generate string describing query source
+        if sourceIdHeaders:
+            headers = list(sourceIdHeaders.keys())
+            headers.sort()
+            for name in headers:
+                if source:
+                    source += ', '
+                source += '{name}: {value}'.format(
+                    name=name,
+                    value=sourceIdHeaders[name])
+
+        func = self.context.get('function', None)
+
+        kwargs = self.context.get('kwargs', {})
+        kwargKeys = list(kwargs.keys())
+
+        # keep kwargs sorted in message, for consistency and testability
+        kwargKeys.sort()
+
+        # generate string of args and kwargs
+        args = ', '.join(
+            argList
+            for argList in [
+                ', '.join(repr(arg) for arg in self.context.get('args', [])),
+                ', '.join('{k}={v}'.format(k=str(k), v=repr(kwargs[k])) for k in kwargKeys),
+            ] if argList
+        )
+
+        msg = 'Invalid parameters ({msg})'.format(msg=str(self))
+        if target:
+            msg += '; target: "{target}"'.format(target=target)
+
+        if source:
+            msg += '; source: "{source}"'.format(source=source)
+
+        # needs to be last because the string "args" may potentially be thousands
+        # of chars long after expanding the globbing patterns
+        if func:
+            msg += '; func: "{func}({args})"'.format(func=func, args=args)
+
+        return msg
 
 
 # decorator which turns InputParameterExceptions into Django's HttpResponseBadRequest
@@ -16,6 +81,8 @@ def handleInputParameterError(f):
         try:
             return f(*args, **kwargs)
         except InputParameterError as e:
-            return HttpResponseBadRequest('Bad Request: {err}'.format(err=e))
+            msg = e.describe()
+            log.warning(msg)
+            return HttpResponseBadRequest(msg)
 
     return new_f

--- a/webapp/graphite/errors.py
+++ b/webapp/graphite/errors.py
@@ -19,8 +19,8 @@ class InputParameterError(ValueError):
 
         self.context['sourceIdHeaders'].update(sourceIdHeaders)
 
-    def setTarget(self, rawTarget):
-        self.context['target'] = rawTarget
+    def setTargets(self, targets):
+        self.context['targets'] = targets
 
     def setFunction(self, function, args, kwargs):
         self.context['function'] = function
@@ -28,7 +28,7 @@ class InputParameterError(ValueError):
         self.context['kwargs'] = kwargs
 
     def describe(self):
-        target = self.context.get('target', None)
+        targets = ', '.join(self.context.get('targets', []))
         source = ''
         sourceIdHeaders = self.context.get('sourceIdHeaders', None)
 
@@ -61,8 +61,8 @@ class InputParameterError(ValueError):
         )
 
         msg = 'Invalid parameters ({msg})'.format(msg=str(self))
-        if target:
-            msg += '; target: "{target}"'.format(target=target)
+        if targets:
+            msg += '; targets: "{targets}"'.format(targets=targets)
 
         if source:
             msg += '; source: "{source}"'.format(source=source)

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -20,37 +20,20 @@ def evaluateTarget(requestContext, targets):
 
   seriesList = []
 
-  # if target context has not already been set by a previous call to
-  # evaluateTarget() then we're going to create it now and reuse it in
-  # all sub-sequent calls to evaluateTarget() on a per target basis
-  setTargetContext = 'targetContext' not in requestContext
-
   for target in targets:
     if not target:
       continue
 
-    if setTargetContext:
-      # create new copy of requestContext specifically for this target,
-      # then add a target context to it
-      requestContext = requestContext.copy()
-      requestContext['targetContext'] = {}
-      targetContext = requestContext['targetContext']
-    else:
-      targetContext = requestContext['targetContext']
-
     if isinstance(target, six.string_types):
       if not target.strip():
         continue
-
-      if setTargetContext:
-        targetContext['rawTarget'] = target
 
       target = grammar.parseString(target)
 
     try:
       result = evaluateTokens(requestContext, target)
     except InputParameterError as e:
-      e.setTarget(targetContext.get('rawTarget', None))
+      e.setTargets(requestContext.get('targets', []))
       e.setSourceIdHeaders(requestContext.get('sourceIdHeaders', {}))
       raise
 
@@ -128,7 +111,7 @@ def evaluateTokens(requestContext, tokens, replacements=None, pipedArg=None):
         raise e
 
       if not getattr(handleInvalidParameters, 'alreadyLogged', False):
-        e.setTarget(requestContext.get('targetContext', {}).get('rawTarget', None))
+        e.setTargets(requestContext.get('targets', []))
         log.warning(e.describe())
 
         # only log invalid parameters once

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -105,14 +105,15 @@ def evaluateTokens(requestContext, tokens, replacements=None, pipedArg=None):
                    for kwarg in tokens.call.kwargs])
 
     def handleInvalidParameters(e):
+      e.setSourceIdHeaders(requestContext.get('sourceIdHeaders', {}))
+      e.setTargets(requestContext.get('targets', []))
       e.setFunction(tokens.call.funcname, args, kwargs)
 
       if settings.ENFORCE_INPUT_VALIDATION:
         raise e
 
       if not getattr(handleInvalidParameters, 'alreadyLogged', False):
-        e.setTargets(requestContext.get('targets', []))
-        log.warning(e.describe())
+        log.warning('%s', str(e))
 
         # only log invalid parameters once
         setattr(handleInvalidParameters, 'alreadyLogged', True)

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -73,6 +73,7 @@ def renderView(request):
     'prefetched' : {},
     'xFilesFactor' : requestOptions['xFilesFactor'],
     'maxDataPoints' : requestOptions.get('maxDataPoints', None),
+    'targets': requestOptions['targets'],
   }
   data = requestContext['data']
 

--- a/webapp/tests/test_errors.py
+++ b/webapp/tests/test_errors.py
@@ -1,0 +1,100 @@
+from .base import TestCase
+
+from graphite.errors import InputParameterError
+
+
+class ErrorTest(TestCase):
+    def test_input_parameter_error_basic(self):
+        e = InputParameterError('exception details')
+        self.assertEqual(
+            e.describe(),
+            'Invalid parameters (exception details)',
+        )
+
+    def test_input_parameter_error_with_func(self):
+        e = InputParameterError('exception details')
+        e.setFunction('test_func', [], {})
+        self.assertEqual(
+            e.describe(),
+            'Invalid parameters (exception details); func: "test_func()"',
+        )
+
+    def test_input_parameter_error_with_func_and_args(self):
+        e = InputParameterError('exception details')
+        e.setFunction('test_func', [1, 'a'], {})
+        self.assertEqual(
+            e.describe(),
+            'Invalid parameters (exception details); func: "test_func(1, \'a\')"',
+        )
+
+    def test_input_parameter_error_with_func_and_kwargs(self):
+        e = InputParameterError('exception details')
+        e.setFunction('test_func', [], {'a': 1, 'b': 'b'})
+        self.assertEqual(
+            e.describe(),
+            'Invalid parameters (exception details); func: "test_func(a=1, b=\'b\')"',
+        )
+
+    def test_input_parameter_error_with_func_args_kwargs(self):
+        e = InputParameterError('exception details')
+        e.setFunction('test_func', [3, 'd'], {'a': 1, 'b': 'b'})
+        self.assertEqual(
+            e.describe(),
+            'Invalid parameters (exception details); func: "test_func(3, \'d\', a=1, b=\'b\')"',
+        )
+
+    def test_input_parameter_error_with_target(self):
+        e = InputParameterError('exception details')
+        e.setTarget('some_func(a.b.c)')
+        self.assertEqual(
+            e.describe(),
+            'Invalid parameters (exception details); target: "some_func(a.b.c)"',
+        )
+
+    def test_input_parameter_error_with_grafana_org_id(self):
+        e = InputParameterError('exception details')
+        e.setSourceIdHeaders({'X-GRAFANA-ORG-ID': 3})
+        self.assertEqual(
+            e.describe(),
+            'Invalid parameters (exception details); source: "X-GRAFANA-ORG-ID: 3"',
+        )
+
+    def test_input_parameter_error_with_dashboard_id(self):
+        e = InputParameterError('exception details')
+        e.setSourceIdHeaders({'X-DASHBOARD-ID': 'abcde123'})
+        self.assertEqual(
+            e.describe(),
+            'Invalid parameters (exception details); source: "X-DASHBOARD-ID: abcde123"',
+        )
+
+    def test_input_parameter_error_with_panel_id(self):
+        e = InputParameterError('exception details')
+        e.setSourceIdHeaders({'X-PANEL-ID': 12})
+        self.assertEqual(
+            e.describe(),
+            'Invalid parameters (exception details); source: "X-PANEL-ID: 12"',
+        )
+
+    def test_input_parameter_error_with_all_source_id(self):
+        e = InputParameterError('exception details')
+        e.setSourceIdHeaders({'X-GRAFANA-ORG-ID': 25, 'X-DASHBOARD-ID': 12})
+        e.setSourceIdHeaders({'X-PANEL-ID': 3})
+        self.assertEqual(
+            e.describe(),
+            'Invalid parameters (exception details); source: "X-DASHBOARD-ID: 12, X-GRAFANA-ORG-ID: 25, X-PANEL-ID: 3"',
+        )
+
+    def test_input_parameter_error_with_all_properties(self):
+        e = InputParameterError('exception details')
+        e.setSourceIdHeaders({'X-DASHBOARD-ID': 'a'})
+        e.setSourceIdHeaders({'X-GRAFANA-ORG-ID': 'b'})
+        e.setSourceIdHeaders({'X-PANEL-ID': 'c'})
+        e.setTarget('some(target, extra="value")')
+        e.setFunction('some', ['target'], {'extra': 'value'})
+        self.assertEqual(
+            e.describe(),
+            'Invalid parameters (exception details)'
+            '; target: "some(target, extra="value")"'
+            '; source: "X-DASHBOARD-ID: a, X-GRAFANA-ORG-ID: b, X-PANEL-ID: c"'
+            '; func: "some(\'target\', extra=\'value\')"'
+        )

--- a/webapp/tests/test_errors.py
+++ b/webapp/tests/test_errors.py
@@ -45,10 +45,18 @@ class ErrorTest(TestCase):
 
     def test_input_parameter_error_with_target(self):
         e = InputParameterError('exception details')
-        e.setTarget('some_func(a.b.c)')
+        e.setTargets(['some_func(a.b.c)'])
         self.assertEqual(
             e.describe(),
-            'Invalid parameters (exception details); target: "some_func(a.b.c)"',
+            'Invalid parameters (exception details); targets: "some_func(a.b.c)"',
+        )
+
+    def test_input_parameter_error_with_multiple_targets(self):
+        e = InputParameterError('exception details')
+        e.setTargets(['some_func(a.b.c)', 'otherfunc(c.b.a)'])
+        self.assertEqual(
+            e.describe(),
+            'Invalid parameters (exception details); targets: "some_func(a.b.c), otherfunc(c.b.a)"',
         )
 
     def test_input_parameter_error_with_grafana_org_id(self):
@@ -89,12 +97,12 @@ class ErrorTest(TestCase):
         e.setSourceIdHeaders({'X-DASHBOARD-ID': 'a'})
         e.setSourceIdHeaders({'X-GRAFANA-ORG-ID': 'b'})
         e.setSourceIdHeaders({'X-PANEL-ID': 'c'})
-        e.setTarget('some(target, extra="value")')
+        e.setTargets(['some(target, extra="value")'])
         e.setFunction('some', ['target'], {'extra': 'value'})
         self.assertEqual(
             e.describe(),
             'Invalid parameters (exception details)'
-            '; target: "some(target, extra="value")"'
+            '; targets: "some(target, extra="value")"'
             '; source: "X-DASHBOARD-ID: a, X-GRAFANA-ORG-ID: b, X-PANEL-ID: c"'
             '; func: "some(\'target\', extra=\'value\')"'
         )

--- a/webapp/tests/test_errors.py
+++ b/webapp/tests/test_errors.py
@@ -7,7 +7,7 @@ class ErrorTest(TestCase):
     def test_input_parameter_error_basic(self):
         e = InputParameterError('exception details')
         self.assertEqual(
-            e.describe(),
+            str(e),
             'Invalid parameters (exception details)',
         )
 
@@ -15,7 +15,7 @@ class ErrorTest(TestCase):
         e = InputParameterError('exception details')
         e.setFunction('test_func', [], {})
         self.assertEqual(
-            e.describe(),
+            str(e),
             'Invalid parameters (exception details); func: "test_func()"',
         )
 
@@ -23,7 +23,7 @@ class ErrorTest(TestCase):
         e = InputParameterError('exception details')
         e.setFunction('test_func', [1, 'a'], {})
         self.assertEqual(
-            e.describe(),
+            str(e),
             'Invalid parameters (exception details); func: "test_func(1, \'a\')"',
         )
 
@@ -31,7 +31,7 @@ class ErrorTest(TestCase):
         e = InputParameterError('exception details')
         e.setFunction('test_func', [], {'a': 1, 'b': 'b'})
         self.assertEqual(
-            e.describe(),
+            str(e),
             'Invalid parameters (exception details); func: "test_func(a=1, b=\'b\')"',
         )
 
@@ -39,7 +39,7 @@ class ErrorTest(TestCase):
         e = InputParameterError('exception details')
         e.setFunction('test_func', [3, 'd'], {'a': 1, 'b': 'b'})
         self.assertEqual(
-            e.describe(),
+            str(e),
             'Invalid parameters (exception details); func: "test_func(3, \'d\', a=1, b=\'b\')"',
         )
 
@@ -47,7 +47,7 @@ class ErrorTest(TestCase):
         e = InputParameterError('exception details')
         e.setTargets(['some_func(a.b.c)'])
         self.assertEqual(
-            e.describe(),
+            str(e),
             'Invalid parameters (exception details); targets: "some_func(a.b.c)"',
         )
 
@@ -55,7 +55,7 @@ class ErrorTest(TestCase):
         e = InputParameterError('exception details')
         e.setTargets(['some_func(a.b.c)', 'otherfunc(c.b.a)'])
         self.assertEqual(
-            e.describe(),
+            str(e),
             'Invalid parameters (exception details); targets: "some_func(a.b.c), otherfunc(c.b.a)"',
         )
 
@@ -63,7 +63,7 @@ class ErrorTest(TestCase):
         e = InputParameterError('exception details')
         e.setSourceIdHeaders({'X-GRAFANA-ORG-ID': 3})
         self.assertEqual(
-            e.describe(),
+            str(e),
             'Invalid parameters (exception details); source: "X-GRAFANA-ORG-ID: 3"',
         )
 
@@ -71,7 +71,7 @@ class ErrorTest(TestCase):
         e = InputParameterError('exception details')
         e.setSourceIdHeaders({'X-DASHBOARD-ID': 'abcde123'})
         self.assertEqual(
-            e.describe(),
+            str(e),
             'Invalid parameters (exception details); source: "X-DASHBOARD-ID: abcde123"',
         )
 
@@ -79,7 +79,7 @@ class ErrorTest(TestCase):
         e = InputParameterError('exception details')
         e.setSourceIdHeaders({'X-PANEL-ID': 12})
         self.assertEqual(
-            e.describe(),
+            str(e),
             'Invalid parameters (exception details); source: "X-PANEL-ID: 12"',
         )
 
@@ -88,7 +88,7 @@ class ErrorTest(TestCase):
         e.setSourceIdHeaders({'X-GRAFANA-ORG-ID': 25, 'X-DASHBOARD-ID': 12})
         e.setSourceIdHeaders({'X-PANEL-ID': 3})
         self.assertEqual(
-            e.describe(),
+            str(e),
             'Invalid parameters (exception details); source: "X-DASHBOARD-ID: 12, X-GRAFANA-ORG-ID: 25, X-PANEL-ID: 3"',
         )
 
@@ -100,7 +100,7 @@ class ErrorTest(TestCase):
         e.setTargets(['some(target, extra="value")'])
         e.setFunction('some', ['target'], {'extra': 'value'})
         self.assertEqual(
-            e.describe(),
+            str(e),
             'Invalid parameters (exception details)'
             '; targets: "some(target, extra="value")"'
             '; source: "X-DASHBOARD-ID: a, X-GRAFANA-ORG-ID: b, X-PANEL-ID: c"'

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -3704,7 +3704,7 @@ class FunctionsTest(TestCase):
             ]
         )
 
-        with self.assertRaisesRegexp(ValueError, '^Unsupported aggregation function: bad$'):
+        with self.assertRaisesRegexp(ValueError, '^Invalid parameters \\(Unsupported aggregation function: bad\\)$'):
             functions.aggregateLine(
                 self._build_requestContext(
                     startTime=datetime(1970,1,1,1,0,0,0,pytz.timezone(settings.TIME_ZONE)),
@@ -4332,7 +4332,7 @@ class FunctionsTest(TestCase):
             )
 
         with patch('graphite.render.functions.evaluateTarget', mock_evaluateTarget):
-            with self.assertRaisesRegexp(ValueError, '^Unsupported aggregation function: invalid$'):
+            with self.assertRaisesRegexp(ValueError, '^Invalid parameters \\(Unsupported aggregation function: invalid\\)$'):
                 functions.movingWindow(request_context, seriesList, 5, 'invalid')
 
     def test_movingWindow_xFilesFactor(self):

--- a/webapp/tests/test_metrics.py
+++ b/webapp/tests/test_metrics.py
@@ -107,7 +107,7 @@ class MetricsTester(TestCase):
         #
         response = self.client.post(url, {})
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.content, b"Bad Request: Missing required parameter 'query'")
+        self.assertEqual(response.content, b"Invalid parameters (Missing required parameter 'query')")
 
         #
         # invalid from/until params
@@ -119,8 +119,9 @@ class MetricsTester(TestCase):
         })
         self.assertEqual(response.status_code, 400)
         # response contains timestamps such as:
-        # Bad Request: Failed to instantiate find query: Invalid interval start=1582801589 end=1582797989
-        self.assertRegex(response.content, b"^Bad Request: Failed to instantiate find query: Invalid interval start=[0-9]+ end=[0-9]+$")
+        # Invalid parameters (Failed to instantiate find query:
+        # Invalid interval start=1582801589 end=1582797989)
+        self.assertRegex(response.content, b"^Invalid parameters \\(Failed to instantiate find query: Invalid interval start=[0-9]+ end=[0-9]+\\)$")
 
         #
         # Wrong type for param 'wildcards'
@@ -131,7 +132,7 @@ class MetricsTester(TestCase):
         })
         self.assertEqual(response.status_code, 400)
         # the output in Python 2/3 slightly varies because repr() shows unicode strings differently, that's why the "u?"
-        self.assertRegex(response.content, b"^Bad Request: Invalid int value u?'123a' for param wildcards: invalid literal for int\\(\\) with base 10: u?'123a'$")
+        self.assertRegex(response.content, b"^Invalid parameters \\(Invalid int value u?'123a' for param wildcards: invalid literal for int\\(\\) with base 10: u?'123a'\\)$")
 
         #
         # Invalid 'from' timestamp
@@ -142,7 +143,7 @@ class MetricsTester(TestCase):
         })
         self.assertEqual(response.status_code, 400)
         # the output in Python 2/3 slightly varies because repr() shows unicode strings differently, that's why the "u?"
-        self.assertRegex(response.content, b"^Bad Request: Invalid value u?'now-1mmminute' for param from: Invalid offset unit u?'mmminute'$")
+        self.assertRegex(response.content, b"^Invalid parameters \\(Invalid value u?'now-1mmminute' for param from: Invalid offset unit u?'mmminute'\\)$")
 
         #
         # format=invalid_format

--- a/webapp/tests/test_render.py
+++ b/webapp/tests/test_render.py
@@ -12,7 +12,7 @@ from mock import patch
 
 from graphite.render.datalib import TimeSeries
 from graphite.render.hashing import ConsistentHashRing, hashRequest, hashData
-from graphite.render.evaluator import evaluateTarget, extractPathExpressions, evaluateScalarTokens, invalidParamLogMsg
+from graphite.render.evaluator import evaluateTarget, extractPathExpressions, evaluateScalarTokens
 from graphite.render.functions import NormalizeEmptyResultError
 from graphite.render.grammar import grammar
 from graphite.render.views import renderViewJson
@@ -924,65 +924,6 @@ class RenderTest(TestCase):
         })
         data = json.loads(response.content)[0]
         self.assertEqual(data['target'], 'sumSeries(hosts.worker*.cpu)')
-
-    def test_invalid_parameter_log_message(self):
-        # first testing without source headers
-        requestContext = {}
-        exception = 'exception details'
-        func = 'test_func'
-        args = ['arg1']
-        kwargs = {}
-
-        msg = invalidParamLogMsg(requestContext, exception, func, args, kwargs)
-        self.assertEqual(
-            msg,
-            'Received invalid parameters (exception details): test_func (\'arg1\')'
-        )
-
-        args = []
-        kwargs = {'arg': 'testvalue'}
-        msg = invalidParamLogMsg(requestContext, exception, func, args, kwargs)
-        self.assertEqual(
-            msg,
-            'Received invalid parameters (exception details): test_func (arg=\'testvalue\')'
-        )
-
-        kwargs = {'arg': '3.3'}
-        msg = invalidParamLogMsg(requestContext, exception, func, args, kwargs)
-        self.assertEqual(
-            msg,
-            'Received invalid parameters (exception details): test_func (arg=\'3.3\')'
-        )
-
-        args = [float('INF')]
-        kwargs = {'kwarg1': True}
-        msg = invalidParamLogMsg(requestContext, exception, func, args, kwargs)
-        self.assertEqual(
-            msg,
-            'Received invalid parameters (exception details): test_func (inf, kwarg1=True)'
-        )
-
-        args = [1]
-        kwargs = {}
-        requestContext['sourceIdHeaders'] = {
-            'grafana-org-id': 123,
-        }
-        msg = invalidParamLogMsg(requestContext, exception, func, args, kwargs)
-        self.assertEqual(
-            msg,
-            'Received invalid parameters (exception details): test_func (1); source: (grafana-org-id: 123)'
-        )
-
-        requestContext['sourceIdHeaders'] = {
-            'grafana-org-id': 123,
-            'dashboard-id': 9,
-            'panel-id': 38,
-        }
-        msg = invalidParamLogMsg(requestContext, exception, func, args, kwargs)
-        self.assertEqual(
-            msg,
-            'Received invalid parameters (exception details): test_func (1); source: (dashboard-id: 9, grafana-org-id: 123, panel-id: 38)'
-        )
 
 
 class ConsistentHashRingTest(TestCase):


### PR DESCRIPTION
This refactors the generation of the log message describing invalid input parameters and moves it into the `InputParameterError` Exception. It makes more sense to have it there, as this exception may be raised and handled in multiple different places. Now the exception can return a useful description of itself based on the context that has been set on it.
It also creates a `targetContext` which gets passed through to other functions via the `requestContext`. This is necessary to make the original raw target string available everywhere where we might want to log an error due to a bad target specification.