### PR TITLE
asPercent may be used as an aggregator

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -871,6 +871,7 @@ asPercent.params = [
   Param('total', ParamTypes.any),
   Param('nodes', ParamTypes.nodeOrTag, multiple=True),
 ]
+asPercent.aggregator = True
 
 
 def divideSeriesLists(requestContext, dividendSeriesList, divisorSeriesList):


### PR DESCRIPTION
we have customer using `asPercent` as an aggregator and that seems to be working, so we should allow it to be used as aggregator in the input parameter validation.