### PR TITLE
Lock whitenoise dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ cairocffi
 git+git://github.com/graphite-project/whisper.git#egg=whisper
 # Ceres is optional
 # git+git://github.com/graphite-project/ceres.git#egg=ceres
-whitenoise
+whitenoise==4.1.4
 scandir
 urllib3
 six


### PR DESCRIPTION
Whitenoise starting at 5.0.0 (10/12/2019) does not support python2.7 anymore and fails building. Locking to latest version that supports python2.7

https://pypi.org/project/whitenoise/5.0/