### PR TITLE
more robust NaN/Infinite replacement for renderViewJson

### DIFF
--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -269,7 +269,7 @@ def renderViewJson(requestOptions, data):
 
   replace_nan(series_data)
   output = json.dumps(series_data, indent=(2 if requestOptions.get('pretty') else None))
-  output = re.sub(r'"(-?)%s"' % inf_placeholder, r'\1' + '1e9999', output)
+  output = re.sub(r'"(-?)%s"' % inf_placeholder, r'\g<1>1e9999', output)
 
   if 'jsonp' in requestOptions:
     response = HttpResponse(

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -203,6 +203,7 @@ def renderViewCsv(requestOptions, data):
 
 inf_placeholder = "Infinity-vsEGZrnIyKLHfteA"
 
+
 def replace_nan(obj):
     "replace NaN and Infinity which are non-standard and not accepted by browsers"
 
@@ -214,10 +215,11 @@ def replace_nan(obj):
         return
 
     for k, v in iterfunc(obj):
-        if math.isnan(v):
-            obj[k] = None
-        elif math.isinf(v):
-            obj[k] = inf_placeholder
+        if isinstance(v, float):
+            if math.isnan(v):
+                obj[k] = None
+            elif math.isinf(v):
+                obj[k] = inf_placeholder
         else:
             replace_nan(v)
 

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -11,6 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
+import re
 import csv
 import math
 from datetime import datetime
@@ -201,7 +202,7 @@ def renderViewCsv(requestOptions, data):
   return response
 
 
-inf_placeholder = "Infinity-vsEGZrnIyKLHfteA"
+inf_placeholder = "Infinity#vsEGZrnIyKLHfteA"  # random, unlikely
 
 
 def replace_nan(obj):
@@ -219,7 +220,7 @@ def replace_nan(obj):
             if math.isnan(v):
                 obj[k] = None
             elif math.isinf(v):
-                obj[k] = inf_placeholder
+                obj[k] = ('-' if v < 0 else '') + inf_placeholder
         else:
             if isinstance(v, tuple):
                 v = list(v)
@@ -268,7 +269,7 @@ def renderViewJson(requestOptions, data):
 
   replace_nan(series_data)
   output = json.dumps(series_data, indent=(2 if requestOptions.get('pretty') else None))
-  output = output.replace('"%s"' % inf_placeholder, '1e9999')
+  output = re.sub(r'"(-?)%s"' % inf_placeholder, r'\1' + '1e9999', output)
 
   if 'jsonp' in requestOptions:
     response = HttpResponse(

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -209,7 +209,7 @@ def replace_nan(obj):
 
     if isinstance(obj, dict):
         iterfunc = iteritems
-    elif isinstance(obj, (list, tuple)):
+    elif isinstance(obj, list):
         iterfunc = enumerate
     else:
         return
@@ -221,6 +221,9 @@ def replace_nan(obj):
             elif math.isinf(v):
                 obj[k] = inf_placeholder
         else:
+            if isinstance(v, tuple):
+                v = list(v)
+                obj[k] =  v
             replace_nan(v)
 
 


### PR DESCRIPTION
no longer possible to accidentally replace coincidental text
in the middle of string values, though that was already very
unlikely in this context

Inspired by #2609 although not actually fixing that yet. It was pointed out how the fix was done already for `renderViewJson()`, where that existing fix probably works perfectly well, but the implementation seems not quite generically robust enough for other uses. So I wanted to offer up an alternative idea of how to do this replacement.

This still needs some tests, in fact I have not run it at all, just threw it up here real quick for now ...