### PR TITLE
functions view: replace Infinity in json response

### DIFF
--- a/webapp/graphite/functions/views.py
+++ b/webapp/graphite/functions/views.py
@@ -1,14 +1,20 @@
+import json
+
 from graphite.util import jsonResponse, HttpResponse, HttpError
 from graphite.functions import SeriesFunctions, SeriesFunction, PieFunctions, PieFunction, functionInfo
 
 
-def jsonEncoder(obj):
-    if hasattr(obj, 'toJSON'):
-        return obj.toJSON()
-    return obj.__dict__
+class jsonInfinityEncoder(json.JSONEncoder):
+    def encode(self, o):
+        return super(jsonInfinityEncoder, self).encode(o).replace('Infinity,', '1e9999,')
+
+    def default(self, o):
+        if hasattr(o, 'toJSON'):
+            return o.toJSON()
+        return o.__dict__
 
 
-@jsonResponse(default=jsonEncoder)
+@jsonResponse(encoder=jsonInfinityEncoder)
 def functionList(request, queryParams):
     if request.method != 'GET':
         return HttpResponse(status=405)
@@ -37,7 +43,7 @@ def functionList(request, queryParams):
     return result
 
 
-@jsonResponse(default=jsonEncoder)
+@jsonResponse(encoder=jsonInfinityEncoder)
 def functionDetails(request, queryParams, name):
     if request.method != 'GET':
         return HttpResponse(status=405)

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -239,7 +239,8 @@ def renderViewJson(requestOptions, data):
 
       series_data.append(dict(target=series.name, tags=dict(series.tags), datapoints=datapoints))
 
-  output = json.dumps(series_data, indent=(2 if requestOptions.get('pretty') else None)).replace('None,', 'null,').replace('NaN,', 'null,').replace('Infinity,', '1e9999,')
+  output = json.dumps(series_data, indent=(2 if requestOptions.get('pretty') else None)) \
+      .replace('NaN,', 'null,').replace('Infinity,', '1e9999,')
 
   if 'jsonp' in requestOptions:
     response = HttpResponse(

--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -360,7 +360,7 @@ def _jsonResponse(data, queryParams, status=200, encoder=None, default=None):
       sort_keys=bool(queryParams.get('pretty')),
       cls=encoder,
       default=default
-    ) if data is not None else 'null',
+    ),
     content_type='application/json',
     status=status
   )


### PR DESCRIPTION
Infinity is not valid json for browsers or nodejs, but 1e9999 seems to work (already used by render endpoint)

fixes #2609

(in the same hacky way as the render endpoint handles this issue, which is not 100% robust, but may be close enough, see #2610)