### PR TITLE
REsynthesize: New script forked from Synthesize to install Graphite on CentOS

### DIFF
--- a/docs/install-synthesize.rst
+++ b/docs/install-synthesize.rst
@@ -4,3 +4,12 @@ Installing From Synthesize
 `Synthesize <https://github.com/obfuscurity/synthesize/>`_ is a script dedicated to making Graphite easy to install. As of this writing, the default installation provides Graphite 1.1.7 for Ubuntu Linux 18.04 LTS with an experimental release candidate for tracking Graphite ``HEAD``. Users may run the installation script manually, or they can choose to use the provided Vagrantfile.
 
 For detailed instructions, please refer to the official project documentation on the `Synthesize <https://github.com/obfuscurity/synthesize/>`_ website.
+
+Installing From REsynthesize
+==========================
+
+`REsynthesize <https://github.com/deividgdt/resynthesize>`_ is a script forked from Synthesize to making Graphite easy to install in CentOS distributions. At the moment just working on CentOS 8.2. It provides Graphite 1.1.7 and Grafana 7.1.3. Users can run the installation script manually, executing:
+
+`./resynthesize -i`
+
+For more information, refer to `REsynthesize <https://github.com/deividgdt/resynthesize>`_

--- a/docs/install-synthesize.rst
+++ b/docs/install-synthesize.rst
@@ -1,6 +1,6 @@
 Installing From Synthesize
 ==========================
 
-`Synthesize <https://github.com/obfuscurity/synthesize/>`_ is a script dedicated to making Graphite easy to install. As of this writing, the default installation provides Graphite 0.9.15 for Ubuntu Linux 14.04 LTS with an experimental release candidate for tracking Graphite ``HEAD``. Users may run the installation script manually, or they can choose to use the provided Vagrantfile.
+`Synthesize <https://github.com/obfuscurity/synthesize/>`_ is a script dedicated to making Graphite easy to install. As of this writing, the default installation provides Graphite 1.1.7 for Ubuntu Linux 18.04 LTS with an experimental release candidate for tracking Graphite ``HEAD``. Users may run the installation script manually, or they can choose to use the provided Vagrantfile.
 
 For detailed instructions, please refer to the official project documentation on the `Synthesize <https://github.com/obfuscurity/synthesize/>`_ website.

--- a/docs/install-synthesize.rst
+++ b/docs/install-synthesize.rst
@@ -5,8 +5,8 @@ Installing From Synthesize
 
 For detailed instructions, please refer to the official project documentation on the `Synthesize <https://github.com/obfuscurity/synthesize/>`_ website.
 
-Installing From REsynthesize
-==========================
+Installing From RESynthesize
+============================
 
 `REsynthesize <https://github.com/deividgdt/resynthesize>`_ is a script forked from Synthesize to making Graphite easy to install in CentOS distributions. At the moment just working on CentOS 8.2. It provides Graphite 1.1.7 and Grafana 7.1.3. Users can run the installation script manually, executing:
 


### PR DESCRIPTION
I've forked the synthesize script in order to make it able to install Graphite and Grafana automatically on CentOS distributions. The installation is already completely functional. It would be really fine to provide this new script to all the community to make their lifes easier.