### PR TITLE
Patch /static/ directory in Apache docs

### DIFF
--- a/docs/config-webapp.rst
+++ b/docs/config-webapp.rst
@@ -161,9 +161,9 @@ Finally, configure the apache vhost. (You can find example of Graphite vhost con
 
         WSGIScriptAlias / /opt/graphite/conf/graphite.wsgi
 
-        Alias /static/ /opt/graphite/static/
+        Alias /static/ /opt/graphite/webapp/content/;
 
-        <Directory /opt/graphite/static/>
+        <Directory /opt/graphite/webapp/content/>
                 <IfVersion < 2.4>
                         Order deny,allow
                         Allow from all


### PR DESCRIPTION
The Nginx config block had the correct alias to `webapp/content/`, but
it looks like the Apache example config was not updated.

We were updating from an old version, and found this bug in the docs. We just happened to search through and found the correct alias in the nginx example config block:
https://github.com/graphite-project/graphite-web/blame/master/docs/config-webapp.rst#L79

This is a very easy fix, and hopefully helps someone else out too.

CC @andyg0808