### PR TITLE
Add aggregateSeriesLists() and aliases for diffSeriesLists(), sumSeriesLists(), multiplySeriesLists()

### DIFF
--- a/webapp/content/js/composer_widgets.js
+++ b/webapp/content/js/composer_widgets.js
@@ -1081,8 +1081,10 @@ function createFunctionsMenu() {
       text: 'Combine',
       menu: [
         {text: 'Sum', handler: applyFuncToAll('sumSeries')},
+        {text: 'Sum (of series lists)', handler: applyFuncToAll('sumSeriesLists')},
         {text: 'Average', handler: applyFuncToAll('averageSeries')},
         {text: 'Product', handler: applyFuncToAll('multiplySeries')},
+        {text: 'Product (of series lists)', handler: applyFuncToAll('multiplySeriesLists')},
         {text: 'Min Values', handler: applyFuncToAll('minSeries')},
         {text: 'Max Values', handler: applyFuncToAll('maxSeries')},
         {text: 'Group', handler: applyFuncToAll('group')},
@@ -1134,6 +1136,7 @@ function createFunctionsMenu() {
         {text: 'Linear Regression', handler: applyFuncToEachWithInput('linearRegression', 'Start source of regression at (example: 14:57 20150115)', {quote: true})},
         {text: 'As Percent', handler: applyFuncToEachWithInput('asPercent', 'Please enter the value that corresponds to 100% or leave blank to use the total', {allowBlank: true})},
         {text: 'Difference (of 2 series)', handler: applyFuncToAll('diffSeries')},
+        {text: 'Difference (of series lists)', handler: applyFuncToAll('diffSeriesLists')},
         {text: 'Ratio (of 2 series)', handler: applyFuncToAll('divideSeries')},
         {text: 'Ratio (of series lists)', handler: applyFuncToAll('divideSeriesLists')},
         {text: 'Exponential Moving Average', handler: applyFuncToEachWithInput('exponentialMovingAverage', 'EMA for the last __ data points')}

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -240,9 +240,14 @@ def aggregateSeriesLists(requestContext, seriesListFirstPos, seriesListSecondPos
   results = []
 
   for i in range(0, len(seriesListFirstPos)):
-    bothSeries = (seriesListFirstPos[i], seriesListSecondPos[i])
-    results.extend(aggregate(requestContext, bothSeries, func, xFilesFactor=xFilesFactor))
-
+    firstSeries = seriesListFirstPos[i]
+    secondSeries = seriesListSecondPos[i]
+    aggregated = aggregate(requestContext, (firstSeries, secondSeries), func, xFilesFactor=xFilesFactor)
+    if not aggregated: # empty list, no data found
+      continue
+    result = aggregated[0]  # aggregate() can only return len 1 list
+    result.name = result.name[:result.name.find('Series(')] + 'Series(%s,%s)' % (firstSeries.name, secondSeries.name)
+    results.append(result)
   return results
 
 aggregateSeriesLists.group = 'Combine'
@@ -5838,6 +5843,7 @@ SeriesFunctions = {
   'stddevSeries': stddevSeries,
   'sum': sumSeries,
   'sumSeries': sumSeries,
+  'sumSeriesLists': sumSeriesLists,
   'sumSeriesWithWildcards': sumSeriesWithWildcards,
   'weightedAverage': weightedAverage,
 

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -5696,6 +5696,7 @@ PieFunctions = {
 SeriesFunctions = {
   # Combine functions
   'aggregate': aggregate,
+  'aggregateLists': aggregateLists,
   'aggregateWithWildcards': aggregateWithWildcards,
   'applyByNode': applyByNode,
   'asPercent': asPercent,

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -204,6 +204,40 @@ aggregate.params = [
   Param('xFilesFactor', ParamTypes.float),
 ]
 
+def aggregateLists(
+        requestContext, seriesListFirstPos,
+        seriesListSecondPos, func, xFilesFactor=None
+):
+  """
+  Iterates over a two lists and aggregates using specified function
+  list1[0] by list2[0], list1[1] by list2[1] and so on.
+  The lists will need to be the same length
+
+  Position of seriesList matters. For example using "diff" function
+  aggregateSeriesLists(list1, list2, "diff") it would find diff `list1 - list2`.
+  """
+
+  if len(seriesListFirstPos) != len(seriesListSecondPos):
+    raise InputParameterError(
+      "dividendSeriesList and divisorSeriesList argument must have equal length")
+  results = []
+
+  for i in range(0, len(seriesListFirstPos)):
+    firstSeries = seriesListFirstPos[i]
+    secondSeries = seriesListSecondPos[i]
+    bothSeries = (firstSeries, secondSeries)
+    results.append(aggregate(requestContext, bothSeries, func, xFilesFactor=xFilesFactor))
+
+  return results
+
+aggregateLists.group = 'Combine'
+aggregateLists.params = [
+  Param('seriesListFirstPos', ParamTypes.seriesList, required=True),
+  Param('seriesListSecondPos', ParamTypes.seriesList, required=True),
+  Param('func', ParamTypes.aggFunc, required=True),
+  Param('xFilesFactor', ParamTypes.float),
+]
+
 
 def sumSeries(requestContext, *seriesLists):
   """

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -226,6 +226,7 @@ def aggregateLists(
     firstSeries = seriesListFirstPos[i]
     secondSeries = seriesListSecondPos[i]
     bothSeries = (firstSeries, secondSeries)
+
     results.append(aggregate(requestContext, bothSeries, func, xFilesFactor=xFilesFactor))
 
   return results
@@ -237,7 +238,6 @@ aggregateLists.params = [
   Param('func', ParamTypes.aggFunc, required=True),
   Param('xFilesFactor', ParamTypes.float),
 ]
-aggregateLists.aggregator = True
 
 def sumSeries(requestContext, *seriesLists):
   """

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -237,7 +237,7 @@ aggregateLists.params = [
   Param('func', ParamTypes.aggFunc, required=True),
   Param('xFilesFactor', ParamTypes.float),
 ]
-
+aggregateLists.aggregator = True
 
 def sumSeries(requestContext, *seriesLists):
   """

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -204,35 +204,49 @@ aggregate.params = [
   Param('xFilesFactor', ParamTypes.float),
 ]
 
-def aggregateLists(
-        requestContext, seriesListFirstPos,
-        seriesListSecondPos, func, xFilesFactor=None
-):
+def aggregateSeriesLists(requestContext, seriesListFirstPos, seriesListSecondPos, func, xFilesFactor=None):
   """
   Iterates over a two lists and aggregates using specified function
-  list1[0] by list2[0], list1[1] by list2[1] and so on.
+  list1[0] to list2[0], list1[1] to list2[1] and so on.
   The lists will need to be the same length
 
-  Position of seriesList matters. For example using "diff" function
-  aggregateSeriesLists(list1, list2, "diff") it would find diff `list1 - list2`.
+  Position of seriesList matters. For example using "sum" function
+  aggregateSeriesLists(list1[0..n], list2[0..n], "sum")
+   it would find sum for each member
+   r of the list ``list1[0] + list2[0], list1[1] + list2[1], list1[n] + list2[n]``.
+
+    This function can be used with aggregation functions ``average`` (or ``avg``), ``avg_zero``,
+  ``median``, ``sum`` (or ``total``), ``min``, ``max``, ``diff``, ``stddev``, ``count``,
+  ``range`` (or ``rangeOf``) , ``multiply`` & ``last`` (or ``current``).
+
+    Example:
+
+  .. code-block:: none
+
+    &target=aggregateSeriesLists(mining.{carbon,graphite,diamond}.extracted,mining.{carbon,graphite,diamond}.shipped, 'sum')
+
+  An example above would be the same as running :py:func:`aggregate <aggregate>` for each member of the list:
+
+  .. code-block:: none
+
+    ?target=aggregate(mining.carbon.extracted,mining.carbon.shipped, 'sum')
+    &target=aggregate(mining.graphite.extracted,mining.graphite.shipped, 'sum')
+    &target=aggregate(mining.diamond.extracted,mining.diamond.shipped, 'sum')
   """
 
   if len(seriesListFirstPos) != len(seriesListSecondPos):
     raise InputParameterError(
-      "dividendSeriesList and divisorSeriesList argument must have equal length")
+      "seriesListFirstPos and seriesListSecondPos argument must have equal length")
   results = []
 
   for i in range(0, len(seriesListFirstPos)):
-    firstSeries = seriesListFirstPos[i]
-    secondSeries = seriesListSecondPos[i]
-    bothSeries = (firstSeries, secondSeries)
-
-    results.append(aggregate(requestContext, bothSeries, func, xFilesFactor=xFilesFactor))
+    bothSeries = (seriesListFirstPos[i], seriesListSecondPos[i])
+    results.extend(aggregate(requestContext, bothSeries, func, xFilesFactor=xFilesFactor))
 
   return results
 
-aggregateLists.group = 'Combine'
-aggregateLists.params = [
+aggregateSeriesLists.group = 'Combine'
+aggregateSeriesLists.params = [
   Param('seriesListFirstPos', ParamTypes.seriesList, required=True),
   Param('seriesListSecondPos', ParamTypes.seriesList, required=True),
   Param('func', ParamTypes.aggFunc, required=True),
@@ -268,6 +282,37 @@ sumSeries.params = [
 ]
 sumSeries.aggregator = True
 
+def sumSeriesLists(requestContext, seriesListFirstPos, seriesListSecondPos):
+  """
+  Iterates over a two lists and subtracts series lists 2 through n from series 1
+  list1[0] to list2[0], list1[1] to list2[1] and so on.
+  The lists will need to be the same length
+
+  Example:
+
+  .. code-block:: none
+
+    &target=sumSeriesLists(mining.{carbon,graphite,diamond}.extracted,mining.{carbon,graphite,diamond}.shipped)
+
+  An example above would be the same as running :py:func:`sumSeries <sumSeries>` for each member of the list:
+
+  .. code-block:: none
+
+    ?target=sumSeries(mining.carbon.extracted,mining.carbon.shipped)
+    &target=sumSeries(mining.graphite.extracted,mining.graphite.shipped)
+    &target=sumSeries(mining.diamond.extracted,mining.diamond.shipped)
+
+  This is an alias for :py:func:`aggregateSeriesLists <aggregateSeriesLists>` with aggregation ``sum``.
+  """
+  return aggregateSeriesLists(requestContext, seriesListFirstPos, seriesListSecondPos, 'sum')
+
+
+sumSeriesLists.group = 'Combine'
+sumSeriesLists.params = [
+  Param('seriesListFirstPos', ParamTypes.seriesList, required=True),
+  Param('seriesListSecondPos', ParamTypes.seriesList, required=True),
+]
+sumSeriesLists.aggregator = True
 
 def sumSeriesWithWildcards(requestContext, seriesList, *position): #XXX
   """
@@ -443,6 +488,39 @@ diffSeries.params = [
   Param('seriesLists', ParamTypes.seriesList, required=True, multiple=True),
 ]
 diffSeries.aggregator = True
+
+def diffSeriesLists(requestContext, seriesListFirstPos, seriesListSecondPos):
+  """
+  Iterates over a two lists and subtracts series lists 2 through n from series 1
+  list1[0] to list2[0], list1[1] to list2[1] and so on.
+  The lists will need to be the same length
+
+  Example:
+
+  .. code-block:: none
+
+    &target=diffSeriesLists(mining.{carbon,graphite,diamond}.extracted,mining.{carbon,graphite,diamond}.shipped)
+
+  An example above would be the same as running :py:func:`diffSeries <diffSeries>` for each member of the list:
+
+  .. code-block:: none
+
+    ?target=diffSeries(mining.carbon.extracted,mining.carbon.shipped)
+    &target=diffSeries(mining.graphite.extracted,mining.graphite.shipped)
+    &target=diffSeries(mining.diamond.extracted,mining.diamond.shipped)
+
+
+  This is an alias for :py:func:`aggregateSeriesLists <aggregateSeriesLists>` with aggregation ``diff``.
+  """
+  return aggregateSeriesLists(requestContext, seriesListFirstPos, seriesListSecondPos, 'diff')
+
+
+diffSeriesLists.group = 'Combine'
+diffSeriesLists.params = [
+  Param('seriesListFirstPos', ParamTypes.seriesList, required=True),
+  Param('seriesListSecondPos', ParamTypes.seriesList, required=True),
+]
+diffSeriesLists.aggregator = True
 
 
 def averageSeries(requestContext, *seriesLists):
@@ -1038,6 +1116,38 @@ multiplySeries.params = [
   Param('seriesLists', ParamTypes.seriesList, required=True, multiple=True),
 ]
 multiplySeries.aggregator = True
+
+def multiplySeriesLists(requestContext, seriesListFirstPos, seriesListSecondPos):
+  """
+  Iterates over a two lists and subtracts series lists 2 through n from series 1
+  list1[0] to list2[0], list1[1] to list2[1] and so on.
+  The lists will need to be the same length
+
+  Example:
+
+  .. code-block:: none
+
+    &target=multiplySeriesLists(mining.{carbon,graphite,diamond}.extracted,mining.{carbon,graphite,diamond}.shipped)
+
+  An example above would be the same as running :py:func:`multiplySeries <multiplySeries>` for each member of the list:
+
+  .. code-block:: none
+
+    ?target=multiplySeries(mining.carbon.extracted,mining.carbon.shipped)
+    &target=multiplySeries(mining.graphite.extracted,mining.graphite.shipped)
+    &target=multiplySeries(mining.diamond.extracted,mining.diamond.shipped)
+
+  This is an alias for :py:func:`aggregateSeriesLists <aggregateSeriesLists>` with aggregation ``multiply``.
+  """
+  return aggregateSeriesLists(requestContext, seriesListFirstPos, seriesListSecondPos, 'multiply')
+
+
+multiplySeriesLists.group = 'Combine'
+multiplySeriesLists.params = [
+  Param('seriesListFirstPos', ParamTypes.seriesList, required=True),
+  Param('seriesListSecondPos', ParamTypes.seriesList, required=True),
+]
+multiplySeriesLists.aggregator = True
 
 
 def weightedAverage(requestContext, seriesListAvg, seriesListWeight, *nodes):
@@ -5696,7 +5806,7 @@ PieFunctions = {
 SeriesFunctions = {
   # Combine functions
   'aggregate': aggregate,
-  'aggregateLists': aggregateLists,
+  'aggregateSeriesLists': aggregateSeriesLists,
   'aggregateWithWildcards': aggregateWithWildcards,
   'applyByNode': applyByNode,
   'asPercent': asPercent,
@@ -5705,6 +5815,7 @@ SeriesFunctions = {
   'avg': averageSeries,
   'countSeries': countSeries,
   'diffSeries': diffSeries,
+  'diffSeriesLists': diffSeriesLists,
   'divideSeries': divideSeries,
   'divideSeriesLists': divideSeriesLists,
   'group': group,
@@ -5717,6 +5828,7 @@ SeriesFunctions = {
   'maxSeries': maxSeries,
   'minSeries': minSeries,
   'multiplySeries': multiplySeries,
+  'multiplySeriesLists': multiplySeriesLists,
   'multiplySeriesWithWildcards': multiplySeriesWithWildcards,
   'pct': asPercent,
   'percentileOfSeries': percentileOfSeries,

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -204,6 +204,7 @@ aggregate.params = [
   Param('xFilesFactor', ParamTypes.float),
 ]
 
+
 def aggregateSeriesLists(requestContext, seriesListFirstPos, seriesListSecondPos, func, xFilesFactor=None):
   """
   Iterates over a two lists and aggregates using specified function
@@ -212,12 +213,8 @@ def aggregateSeriesLists(requestContext, seriesListFirstPos, seriesListSecondPos
 
   Position of seriesList matters. For example using "sum" function
   aggregateSeriesLists(list1[0..n], list2[0..n], "sum")
-   it would find sum for each member
-   r of the list ``list1[0] + list2[0], list1[1] + list2[1], list1[n] + list2[n]``.
-
-    This function can be used with aggregation functions ``average`` (or ``avg``), ``avg_zero``,
-  ``median``, ``sum`` (or ``total``), ``min``, ``max``, ``diff``, ``stddev``, ``count``,
-  ``range`` (or ``rangeOf``) , ``multiply`` & ``last`` (or ``current``).
+  it would find sum for each member
+  r of the list ``list1[0] + list2[0], list1[1] + list2[1], list1[n] + list2[n]``.
 
     Example:
 
@@ -232,6 +229,10 @@ def aggregateSeriesLists(requestContext, seriesListFirstPos, seriesListSecondPos
     ?target=aggregate(mining.carbon.extracted,mining.carbon.shipped, 'sum')
     &target=aggregate(mining.graphite.extracted,mining.graphite.shipped, 'sum')
     &target=aggregate(mining.diamond.extracted,mining.diamond.shipped, 'sum')
+
+    This function can be used with aggregation functions ``average`` (or ``avg``), ``avg_zero``,
+  ``median``, ``sum`` (or ``total``), ``min``, ``max``, ``diff``, ``stddev``, ``count``,
+  ``range`` (or ``rangeOf``) , ``multiply`` & ``last`` (or ``current``).
   """
 
   if len(seriesListFirstPos) != len(seriesListSecondPos):
@@ -250,6 +251,7 @@ def aggregateSeriesLists(requestContext, seriesListFirstPos, seriesListSecondPos
     results.append(result)
   return results
 
+
 aggregateSeriesLists.group = 'Combine'
 aggregateSeriesLists.params = [
   Param('seriesListFirstPos', ParamTypes.seriesList, required=True),
@@ -257,6 +259,7 @@ aggregateSeriesLists.params = [
   Param('func', ParamTypes.aggFunc, required=True),
   Param('xFilesFactor', ParamTypes.float),
 ]
+
 
 def sumSeries(requestContext, *seriesLists):
   """
@@ -286,6 +289,7 @@ sumSeries.params = [
   Param('seriesLists', ParamTypes.seriesList, required=True, multiple=True),
 ]
 sumSeries.aggregator = True
+
 
 def sumSeriesLists(requestContext, seriesListFirstPos, seriesListSecondPos):
   """
@@ -318,6 +322,7 @@ sumSeriesLists.params = [
   Param('seriesListSecondPos', ParamTypes.seriesList, required=True),
 ]
 sumSeriesLists.aggregator = True
+
 
 def sumSeriesWithWildcards(requestContext, seriesList, *position): #XXX
   """
@@ -493,6 +498,7 @@ diffSeries.params = [
   Param('seriesLists', ParamTypes.seriesList, required=True, multiple=True),
 ]
 diffSeries.aggregator = True
+
 
 def diffSeriesLists(requestContext, seriesListFirstPos, seriesListSecondPos):
   """
@@ -1121,6 +1127,7 @@ multiplySeries.params = [
   Param('seriesLists', ParamTypes.seriesList, required=True, multiple=True),
 ]
 multiplySeries.aggregator = True
+
 
 def multiplySeriesLists(requestContext, seriesListFirstPos, seriesListSecondPos):
   """

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -212,11 +212,11 @@ def aggregateSeriesLists(requestContext, seriesListFirstPos, seriesListSecondPos
   The lists will need to be the same length
 
   Position of seriesList matters. For example using "sum" function
-  aggregateSeriesLists(list1[0..n], list2[0..n], "sum")
+  ``aggregateSeriesLists(list1[0..n], list2[0..n], "sum")``
   it would find sum for each member
-  r of the list ``list1[0] + list2[0], list1[1] + list2[1], list1[n] + list2[n]``.
+  of the list ``list1[0] + list2[0], list1[1] + list2[1], list1[n] + list2[n]``.
 
-    Example:
+  Example:
 
   .. code-block:: none
 
@@ -230,11 +230,10 @@ def aggregateSeriesLists(requestContext, seriesListFirstPos, seriesListSecondPos
     &target=aggregate(mining.graphite.extracted,mining.graphite.shipped, 'sum')
     &target=aggregate(mining.diamond.extracted,mining.diamond.shipped, 'sum')
 
-    This function can be used with aggregation functions ``average`` (or ``avg``), ``avg_zero``,
+  This function can be used with aggregation functions ``average`` (or ``avg``), ``avg_zero``,
   ``median``, ``sum`` (or ``total``), ``min``, ``max``, ``diff``, ``stddev``, ``count``,
   ``range`` (or ``rangeOf``) , ``multiply`` & ``last`` (or ``current``).
   """
-
   if len(seriesListFirstPos) != len(seriesListSecondPos):
     raise InputParameterError(
       "seriesListFirstPos and seriesListSecondPos argument must have equal length")

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -1390,9 +1390,8 @@ class FunctionsTest(TestCase):
             for k, v in enumerate(series):
                 if type(v) is float:
                     series[k] = round(v,2)
-
         self.assertEqual(result, expectedResult)
-        
+
     def _get_aggregateSeriesLists_input_data(self):
         seriesList1 = self._gen_series_list_with_data(
             key=[

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -1461,7 +1461,7 @@ class FunctionsTest(TestCase):
         expectedResult = [
             TimeSeries('multiplySeries(mining.other.shipped,mining.other.extracted)',0,1,1, [1,4,9,16,25,36,49,64,81,100,121,144,169,196,225,256,289,324,361,400]),
             TimeSeries('multiplySeries(mining.diamond.shipped,mining.diamond.extracted)',0,1,1, [0,-1,1,4,-9,-25,64,169,-441,-1156,3025,7921,-20736,-54289,142129]),
-            TimeSeries('multiplySeries(mining.graphite.shipped,mining.graphite.extracted)',0,1,1, [None,20.7,None,None,None,None,None,-26.7,None,None,None,12.13,None,-42.45,None,80.85,None,None,None,181.89,None,]),
+            TimeSeries('multiplySeries(mining.graphite.shipped,mining.graphite.extracted)',0,1,1, [None,20.7,None,None,None,None,None,-26.7,None,None,None,12.13,None,-42.45,None,80.85,None,None,None,181.89,None]),
             TimeSeries('multiplySeries(mining.carbon.shipped,mining.carbon.extracted)',0,1,1, [22.68,None,7.39,None,16.95,None,-40.82,-21.42,None,-72.06,None,49.51]),
         ]
         result = functions.multiplySeriesLists({}, seriesList1, seriesList2)
@@ -1471,7 +1471,42 @@ class FunctionsTest(TestCase):
                     series[k] = round(v,2)
         self.assertEqual(result, expectedResult)
 
+    def test_aggregateSeriesLists_max(self):
+        seriesList1, seriesList2 = self._get_aggregateSeriesLists_input_data()
+        expectedResult = [
+            TimeSeries('maxSeries(mining.other.shipped,mining.other.extracted)',0,1,1, [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]),
+            TimeSeries('maxSeries(mining.diamond.shipped,mining.diamond.extracted)',0,1,1, [0,1,-1,2,3,5,-8,13,21,34,-55,89,144,233,-377]),
+            TimeSeries('maxSeries(mining.graphite.shipped,mining.graphite.extracted)',0,1,1, [None,9,8,-4.5,6,6.7,4,3,2,10.111,0,-1,None,14.15,-4,-5,None,18.19,-8,-9,-10]),
+            TimeSeries('maxSeries(mining.carbon.shipped,mining.carbon.extracted)',0,1,1, [7.22,None,2.718,6.022,6.674,-1.234,6.626,1.602,2.067,9.274,0.128,8.912]),
+        ]
+        result = functions.aggregateSeriesLists({}, seriesList1, seriesList2, 'max')
+        self.assertEqual(result, expectedResult)
 
+    def test_aggregateSeriesLists_min(self):
+        seriesList1, seriesList2 = self._get_aggregateSeriesLists_input_data()
+        expectedResult = [
+            TimeSeries('minSeries(mining.other.shipped,mining.other.extracted)',0,1,1, [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]),
+            TimeSeries('minSeries(mining.diamond.shipped,mining.diamond.extracted)',0,1,1, [0,-1,-1,2,-3,-5,-8,13,-21,-34,-55,89,-144,-233,-377]),
+            TimeSeries('minSeries(mining.graphite.shipped,mining.graphite.extracted)',0,1,1, [None,2.3,8,-4.5,6,6.7,4,-8.9,2,10.111,0,-12.13,None,-3,-4,-16.17,None,18.19,-8,-20.21,-10]),
+            TimeSeries('minSeries(mining.carbon.shipped,mining.carbon.extracted)',0,1,1, [3.141,None,2.718,6.022,2.54,-1.234,-6.16,-13.37,2.067,-7.77,0.128,5.555]),
+        ]
+        result = functions.aggregateSeriesLists({}, seriesList1, seriesList2, 'min')
+        self.assertEqual(result, expectedResult)
+
+    def test_aggregateSeriesLists_avg(self):
+        seriesList1, seriesList2 = self._get_aggregateSeriesLists_input_data()
+        expectedResult = [
+            TimeSeries('avgSeries(mining.other.shipped,mining.other.extracted)',0,1,1, [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]),
+            TimeSeries('avgSeries(mining.diamond.shipped,mining.diamond.extracted)',0,1,1, [0.0,0.0,-1.0,2.0,0.0,0.0,-8.0,13.0,0.0,0.0,-55.0,89.0,0.0,0.0,-377.0]),
+            TimeSeries('avgSeries(mining.graphite.shipped,mining.graphite.extracted)',0,1,1, [None,5.65,8.0,-4.5,6.0,6.7,4.0,-2.95,2.0,10.11,0.0,-6.57,None,5.58,-4.0,-10.59,None,18.19,-8.0,-14.61,-10.0]),
+            TimeSeries('avgSeries(mining.carbon.shipped,mining.carbon.extracted)',0,1,1, [5.18,None,2.72,6.02,4.61,-1.23,0.23,-5.88,2.07,0.75,0.13,7.23]),
+        ]
+        result = functions.aggregateSeriesLists({}, seriesList1, seriesList2, 'avg')
+        for i, series in enumerate(result):
+            for k, v in enumerate(series):
+                if type(v) is float:
+                    series[k] = round(v,2)
+        self.assertEqual(result, expectedResult)
 
     def test_multiplySeries_single(self):
         seriesList = [

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -1354,6 +1354,7 @@ class FunctionsTest(TestCase):
 
         self.assertEqual(result, expectedResult)
 
+    # seriesLists tests
     def test_divideSeriesLists(self):
         seriesList1 = self._gen_series_list_with_data(
             key=[
@@ -1385,13 +1386,92 @@ class FunctionsTest(TestCase):
         ]
 
         result = functions.divideSeriesLists({}, seriesList1, seriesList2)
-
         for i, series in enumerate(result):
             for k, v in enumerate(series):
                 if type(v) is float:
                     series[k] = round(v,2)
 
         self.assertEqual(result, expectedResult)
+        
+    def _get_aggregateSeriesLists_input_data(self):
+        seriesList1 = self._gen_series_list_with_data(
+            key=[
+                'mining.other.shipped',
+                'mining.diamond.shipped',
+                'mining.graphite.shipped',
+                'mining.carbon.shipped',
+            ],
+            end=1,
+            data=[
+                [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20],
+                [0,-1,-1,2,3,-5,-8,13,21,-34,-55,89,144,-233,-377],
+                [None,2.3,None,-4.5,None,6.7,None,-8.9,None,10.111,None,-12.13,None,14.15,None,-16.17,None,18.19,None,-20.21],
+                [3.141,None,2.718,6.022,6.674,None,6.626,1.602,2.067,9.274,None,5.555]
+            ]
+        )
+        seriesList2 = self._gen_series_list_with_data(
+            key=[
+                'mining.other.extracted',
+                'mining.diamond.extracted',
+                'mining.graphite.extracted',
+                'mining.carbon.extracted',
+            ],
+            end=1,
+            data=[
+                [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20],
+                [0,1,-1,2,-3,5,-8,13,-21,34,-55,89,-144,233,-377],
+                [None,9,8,None,6,None,4,3,2,None,0,-1,None,-3,-4,-5,None,None,-8,-9,-10],
+                [7.22,None,2.718,None,2.54,-1.234,-6.16,-13.37,None,-7.77,0.128,8.912]
+            ]
+        )
+        return seriesList1, seriesList2
+
+    def test_sumSeriesLists(self):
+        seriesList1, seriesList2 = self._get_aggregateSeriesLists_input_data()
+        expectedResult = [
+            TimeSeries('sumSeries(mining.other.shipped,mining.other.extracted)',0,1,1, [2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40]),
+            TimeSeries('sumSeries(mining.diamond.shipped,mining.diamond.extracted)',0,1,1, [0,0,-2,4,0,0,-16,26,0,0,-110,178,0,0,-754]),
+            TimeSeries('sumSeries(mining.graphite.shipped,mining.graphite.extracted)',0,1,1, [None,11.3,8,-4.5,6,6.7,4,-5.9,2,10.11,0,-13.13,None,11.15,-4,-21.17,None,18.19,-8,-29.21,-10]),
+            TimeSeries('sumSeries(mining.carbon.shipped,mining.carbon.extracted)',0,1,1, [10.36,None,5.44,6.02,9.21,-1.23,0.47,-11.77,2.07,1.5,0.13,14.47]),
+        ]
+        result = functions.sumSeriesLists({}, seriesList1, seriesList2)
+        for i, series in enumerate(result):
+            for k, v in enumerate(series):
+                if type(v) is float:
+                    series[k] = round(v, 2)
+        self.assertEqual(result, expectedResult)
+
+    def test_diffSeriesLists(self):
+        seriesList1, seriesList2 = self._get_aggregateSeriesLists_input_data()
+        expectedResult = [
+            TimeSeries('diffSeries(mining.other.shipped,mining.other.extracted)',0,1,1, [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]),
+            TimeSeries('diffSeries(mining.diamond.shipped,mining.diamond.extracted)',0,1,1, [0,-2,0,0,6,-10,0,0,42,-68,0,0,288,-466,0]),
+            TimeSeries('diffSeries(mining.graphite.shipped,mining.graphite.extracted)',0,1,1, [None,-6.7,8,-4.5,6,6.7,4,-11.9,2,10.11,0,-11.13,None,17.15,-4,-11.17,None,18.19,-8,-11.21,-10]),
+            TimeSeries('diffSeries(mining.carbon.shipped,mining.carbon.extracted)',0,1,1, [-4.08,None,0.0,6.02,4.13,-1.23,12.79,14.97,2.07,17.04,0.13,-3.36]),
+        ]
+        result = functions.diffSeriesLists({}, seriesList1, seriesList2)
+        for i, series in enumerate(result):
+            for k, v in enumerate(series):
+                if type(v) is float:
+                    series[k] = round(v,2)
+        self.assertEqual(result, expectedResult)
+
+    def test_multiplySeriesLists(self):
+        seriesList1, seriesList2 = self._get_aggregateSeriesLists_input_data()
+        expectedResult = [
+            TimeSeries('multiplySeries(mining.other.shipped,mining.other.extracted)',0,1,1, [1,4,9,16,25,36,49,64,81,100,121,144,169,196,225,256,289,324,361,400]),
+            TimeSeries('multiplySeries(mining.diamond.shipped,mining.diamond.extracted)',0,1,1, [0,-1,1,4,-9,-25,64,169,-441,-1156,3025,7921,-20736,-54289,142129]),
+            TimeSeries('multiplySeries(mining.graphite.shipped,mining.graphite.extracted)',0,1,1, [None,20.7,None,None,None,None,None,-26.7,None,None,None,12.13,None,-42.45,None,80.85,None,None,None,181.89,None,]),
+            TimeSeries('multiplySeries(mining.carbon.shipped,mining.carbon.extracted)',0,1,1, [22.68,None,7.39,None,16.95,None,-40.82,-21.42,None,-72.06,None,49.51]),
+        ]
+        result = functions.multiplySeriesLists({}, seriesList1, seriesList2)
+        for i, series in enumerate(result):
+            for k, v in enumerate(series):
+                if type(v) is float:
+                    series[k] = round(v,2)
+        self.assertEqual(result, expectedResult)
+
+
 
     def test_multiplySeries_single(self):
         seriesList = [


### PR DESCRIPTION
Closes: #2645  see for more information. 

Decided to use `aggregate()` as base function when implementing `diffSeriesLists(), sumSeriesLists(), multiplySeriesLists()` as aliases using `aggregateSeriesLists()`. 
Side effect of course is that other functions that are supported by `aggregate()` are also supported by `aggregateSeriesLists()`.  

