### PR TITLE
fix expand_braces

### DIFF
--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -26,7 +26,7 @@ except ImportError:
 
 
 DATASOURCE_DELIMETER = '::RRD_DATASOURCE::'
-EXPAND_BRACES_RE = re.compile(r'.*(\{.*?[^\\]?\})')
+EXPAND_BRACES_RE = re.compile(r'(\{(.*[^\\])\})')
 
 
 class Store:
@@ -280,7 +280,7 @@ def expand_braces(s):
 
     m = EXPAND_BRACES_RE.search(s)
     if m is not None:
-        sub = m.group(1)
+        sub = m.group(2)
         open_brace, close_brace = m.span(1)
         if ',' in sub:
             for pat in sub.strip('{}').split(','):

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -26,7 +26,7 @@ except ImportError:
 
 
 DATASOURCE_DELIMETER = '::RRD_DATASOURCE::'
-EXPAND_BRACES_RE = re.compile(r'(\{(.*[^\\])\})')
+EXPAND_BRACES_RE = re.compile(r'(\{([^\}]*[^\\])\})')
 
 
 class Store:
@@ -271,24 +271,12 @@ def match_entries(entries, pattern):
 def expand_braces(s):
     res = list()
 
-    # Used instead of s.strip('{}') because strip is greedy.
-    # We want to remove only ONE leading { and ONE trailing }, if both exist
-    def remove_outer_braces(s):
-        if s[0] == '{' and s[-1] == '}':
-            return s[1:-1]
-        return s
-
     m = EXPAND_BRACES_RE.search(s)
     if m is not None:
         sub = m.group(2)
         open_brace, close_brace = m.span(1)
-        if ',' in sub:
-            for pat in sub.strip('{}').split(','):
-                res.extend(expand_braces(
-                    s[:open_brace] + pat + s[close_brace:]))
-        else:
-            res.extend(expand_braces(
-                s[:open_brace] + remove_outer_braces(sub) + s[close_brace:]))
+        for pat in sub.split(','):
+            res.extend(expand_braces(s[:open_brace] + pat + s[close_brace:]))
     else:
         res.append(s.replace('\\}', '}'))
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/5936 and https://github.com/grafana/grafana/issues/11274

graphite web v0.9.16 has a bug where curly braces {} in metrics name do not expand correctly. This update fixes it.