### PR TITLE
return empty result list for empty series

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -585,6 +585,10 @@ def movingMedian(requestContext, seriesList, windowSize):
     &target=movingMedian(Server.instance*.threads.idle,'5min')
 
   """
+
+  if not seriesList:
+    return []
+
   windowInterval = None
   if type(windowSize) is str:
     delta = parseTimeOffset(windowSize)
@@ -722,6 +726,10 @@ def movingAverage(requestContext, seriesList, windowSize):
     &target=movingAverage(Server.instance*.threads.idle,'5min')
 
   """
+
+  if not seriesList:
+    return []
+
   windowInterval = None
   if type(windowSize) is str:
     delta = parseTimeOffset(windowSize)


### PR DESCRIPTION
Backport from master. Fixes https://github.com/graphite-project/graphite-web/issues/788. 
Return empty result list for empty series in movingMedian and movingAverage functions.