### PR TITLE
Optionally resolve right hand dip in sums because of lack of current minute in caches

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -252,15 +252,17 @@ def matchSeries(seriesList1, seriesList2):
 def trimRecent(seriesList):
   # trim right side of the graph to avoid dip when only part of most recent metrics has entered the system
   for s in seriesList:
-    if (s[-1] is None) and (s[-2] is not None):
-      for sl in seriesList:
-        sl[-1] = None
-      break
+    if len(s) > 1:
+      if (s[-1] is None) and (s[-2] is not None):
+        for sl in seriesList:
+          sl[-1] = None
+        break
   for s in seriesList:
-    if (s[-2] is None) and (s[-3] is not None):
-      for sl in seriesList:
-        sl[-2] = None
-      break
+    if len(s) > 2:
+      if (s[-2] is None) and (s[-3] is not None):
+        for sl in seriesList:
+          sl[-2] = None
+        break
   return (seriesList)
 
 

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -118,6 +118,9 @@ MAX_FETCH_RETRIES = 2
 METRICS_FIND_WARNING_THRESHOLD = float('Inf') # Print a warning if more than X metrics are returned
 METRICS_FIND_FAILURE_THRESHOLD = float('Inf') # Fail if more than X metrics are returned
 
+#Local rendering settings
+RENDER_TRIM_RECENT_IN_AGGREGATE = False #if True, set most recent datapoints to None if prior datapoint was not None
+
 #Remote rendering settings
 REMOTE_RENDERING = False #if True, rendering is delegated to RENDERING_HOSTS
 RENDERING_HOSTS = []


### PR DESCRIPTION
When not all data has been loaded in yet for the current minute, the right hand side of a sum can dip which causes some observers heartburn.

Optionally allow a feature that will trim the most recent datapoints if not all of them exist within aggregate().