### PR TITLE
Fix expand braces

### DIFF
--- a/webapp/graphite/finders/__init__.py
+++ b/webapp/graphite/finders/__init__.py
@@ -2,7 +2,7 @@ import fnmatch
 import os.path
 import re
 
-EXPAND_BRACES_RE = re.compile(r'(\{([^\}]*[^\\])\})')
+EXPAND_BRACES_RE = re.compile(r'(\{([^\{\}]*)\})')
 
 
 def get_real_metric_path(absolute_path, metric_path):
@@ -63,6 +63,6 @@ def expand_braces(s):
         for pat in sub.split(','):
             res.extend(expand_braces(s[:open_brace] + pat + s[close_brace:]))
     else:
-        res.append(s.replace('\\}', '}'))
+        res.append(s)
 
     return list(set(res))

--- a/webapp/graphite/finders/__init__.py
+++ b/webapp/graphite/finders/__init__.py
@@ -2,7 +2,7 @@ import fnmatch
 import os.path
 import re
 
-EXPAND_BRACES_RE = re.compile(r'.*(\{.*?[^\\]?\})')
+EXPAND_BRACES_RE = re.compile(r'(\{([^\}]*[^\\])\})')
 
 
 def get_real_metric_path(absolute_path, metric_path):
@@ -56,24 +56,12 @@ def match_entries(entries, pattern):
 def expand_braces(s):
     res = list()
 
-    # Used instead of s.strip('{}') because strip is greedy.
-    # We want to remove only ONE leading { and ONE trailing }, if both exist
-    def remove_outer_braces(s):
-        if s[0] == '{' and s[-1] == '}':
-            return s[1:-1]
-        return s
-
     m = EXPAND_BRACES_RE.search(s)
     if m is not None:
-        sub = m.group(1)
+        sub = m.group(2)
         open_brace, close_brace = m.span(1)
-        if ',' in sub:
-            for pat in sub.strip('{}').split(','):
-                res.extend(expand_braces(
-                    s[:open_brace] + pat + s[close_brace:]))
-        else:
-            res.extend(expand_braces(
-                s[:open_brace] + remove_outer_braces(sub) + s[close_brace:]))
+        for pat in sub.split(','):
+            res.extend(expand_braces(s[:open_brace] + pat + s[close_brace:]))
     else:
         res.append(s.replace('\\}', '}'))
 

--- a/webapp/tests/test_finders.py
+++ b/webapp/tests/test_finders.py
@@ -158,6 +158,17 @@ class StandardFinderTest(TestCase):
             self.assertEqual(len(list(nodes)), 1)
             self.assertEqual(scandir_mock.call_count, 0)
 
+            # test for https://github.com/grafana/grafana/issues/5936
+            scandir_mock.call_count = 0
+            nodes = finder.find_nodes(FindQuery('foo.{bar}.baz', None, None))
+            self.assertEqual(len(list(nodes)), 1)
+            self.assertEqual(scandir_mock.call_count, 0)
+
+            scandir_mock.call_count = 0
+            nodes = finder.find_nodes(FindQuery('foo.{bar,}.baz', None, None))
+            self.assertEqual(len(list(nodes)), 1)
+            self.assertEqual(scandir_mock.call_count, 0)
+
             scandir_mock.call_count = 0
             nodes = finder.find_nodes(FindQuery('*.ba?.{baz,foo}', None, None))
             self.assertEqual(len(list(nodes)), 2)


### PR DESCRIPTION
Fixes grafana/grafana#5936, grafana/grafana#11274, and #2154

Adding test to PR #2655 

Before 0.9.16 `foo.{bar}.baz` was matching to `foo.bar.baz`, but 0.9.16 breaks that. This update fixes it.