### PR TITLE
Resolves #2692 can't unpickle Interval/IntervalSet

### DIFF
--- a/webapp/graphite/intervals.py
+++ b/webapp/graphite/intervals.py
@@ -3,7 +3,6 @@ NEGATIVE_INFINITY = -INFINITY
 
 
 class IntervalSet:
-    __slots__ = ('intervals', 'size')
 
     def __init__(self, intervals, disjoint=False):
         self.intervals = intervals
@@ -74,7 +73,6 @@ class IntervalSet:
 
 
 class Interval:
-    __slots__ = ('start', 'end', 'tuple', 'size')
 
     def __init__(self, start, end):
         if end - start < 0:


### PR DESCRIPTION
* removes `__slots__` definition from `Interval` and `IntervalSet`

It took me a minute to figure this one out. So, the original code uses "old style" classes which means that the `__slots__` definition is a noop on python2, but on python3 you automatically get new style classes. Really this should be updated to use "new style" classes, but that would suddenly create compatibility issues between older versions of graphite-web AND also software such as carbonapi which works by mimicking the existing graphite-web behavior. By removing the `__slots__` we get identical behavior on python2 and python3 which is a vanilla unslotted class instance that unpickles fine in both pyhton2 and python3 and works with carbonapi too.