### PR TITLE
Depend on third-party scandir only for Python < 3.5

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -38,7 +38,7 @@ Basic Graphite requirements:
 * `Django`_ 1.8 - 2.2 (for Python3 - 1.11 and newer), 1.11.19 or newer is recommended 
 * `django-tagging`_ 0.4.6 (not `django-taggit` yet)
 * `pytz`_
-* `scandir`_
+* `scandir`_ (for Python older than 3.5)
 * `fontconfig`_ and at least one font package (a system package usually)
 * A WSGI server and web server. Popular choices are:
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,4 +5,4 @@ sphinx
 sphinx_rtd_theme
 pytz
 git+git://github.com/graphite-project/whisper.git#egg=whisper
-scandir
+scandir;python_version<"3.5"

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,6 @@ git+git://github.com/graphite-project/whisper.git#egg=whisper
 # Ceres is optional
 # git+git://github.com/graphite-project/ceres.git#egg=ceres
 whitenoise==4.1.4
-scandir
+scandir;python_version<"3.5"
 urllib3
 six

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ requires = Django => 1.8
            python-hashlib
            pytz
            pyparsing
-           scandir
+           scandir;python_version<"3.5"
 
 post-install = distro/redhat/misc/postinstall
 

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,8 @@ try:
       scripts=glob('bin/*'),
       data_files=list(webapp_content.items()) + storage_dirs + conf_files + examples,
       install_requires=['Django>=1.8,<3.1', 'django-tagging==0.4.3', 'pytz',
-                        'pyparsing', 'cairocffi', 'urllib3', 'scandir', 'six'],
+                        'pyparsing', 'cairocffi', 'urllib3',
+                        'scandir;python_version<"3.5"', 'six'],
       classifiers=[
           'Intended Audience :: Developers',
           'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ deps =
 	django111: Django>=1.11,<1.11.99
 	django22: Django>=2.2,<2.2.99
 	django30: Django>=3.0,<3.0.99
-	scandir
+	scandir; python_version<"3.5"
 	urllib3
 	redis
 	rrdtool
@@ -62,7 +62,6 @@ deps =
 	pyparsing
 	Sphinx<1.4
 	sphinx_rtd_theme
-	scandir
 	urllib3
 commands =
 	mkdir -p {envsitepackagesdir}/../storage/ceres


### PR DESCRIPTION
Fixes #2705 