### PR TITLE
Fix dependency issue for usage as Grafana data source.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ txAMQP==0.8
 django-tagging==0.4.6
 gunicorn
 pytz
-pyparsing>=2.3.0
+pyparsing>=2.3.0,<3.0.0
 cairocffi
 git+git://github.com/graphite-project/whisper.git#egg=whisper
 # Ceres is optional

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ deps =
 	mock
 	git+git://github.com/graphite-project/whisper.git#egg=whisper
 	git+git://github.com/graphite-project/ceres.git#egg=ceres
-	pyparsing2: pyparsing
+	pyparsing2: pyparsing>=2.3.0,<3.0.0
 	django111: Django>=1.11,<1.11.99
 	django22: Django>=2.2,<2.2.99
 	django30: Django>=3.0,<3.0.99
@@ -59,7 +59,7 @@ deps =
 	git+git://github.com/graphite-project/whisper.git#egg=whisper
 	git+git://github.com/graphite-project/ceres.git#egg=ceres
 	Django<3.1
-	pyparsing
+	pyparsing: pyparsing>=2.3.0,<3.0.0
 	Sphinx<1.4
 	sphinx_rtd_theme
 	urllib3


### PR DESCRIPTION
Pyparsing v3 was recently released, breaking compatibility of graphite-web for usage as Grafana data source. This was observed in Grafana v6.7.x and v8.0.3.

Until compatibility with pyparsing v3 is implemented, this change prevents breaking future deployments of graphite-web as grafana datasource.