### PR TITLE
Fix pyparsing > 3.0 compatibility issue.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ txAMQP==0.8
 django-tagging==0.4.6
 gunicorn
 pytz
-pyparsing>=2.3.0,<3.0.0
+pyparsing>=2.3.0
 cairocffi
 git+git://github.com/graphite-project/whisper.git#egg=whisper
 # Ceres is optional

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ python =
 [tox]
 envlist =
   py{27,py}-django111-pyparsing2{,-msgpack,-pyhash},
-  py{36,37,38,39}-django{111,22,30}-pyparsing2{,-msgpack},
+  py{36,37,38,39}-django{111,22,30}-pyparsing{2,3}{,-msgpack},
   lint, docs
 
 [testenv]
@@ -36,7 +36,8 @@ deps =
 	mock
 	git+git://github.com/graphite-project/whisper.git#egg=whisper
 	git+git://github.com/graphite-project/ceres.git#egg=ceres
-	pyparsing2: pyparsing>=2.3.0
+	pyparsing2: pyparsing==2.4.7
+	pyparsing3: pyparsing>=3.0.6
 	django111: Django>=1.11,<1.11.99
 	django22: Django>=2.2,<2.2.99
 	django30: Django>=3.0,<3.0.99

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ deps =
 	mock
 	git+git://github.com/graphite-project/whisper.git#egg=whisper
 	git+git://github.com/graphite-project/ceres.git#egg=ceres
-	pyparsing2: pyparsing>=2.3.0,<3.0.0
+	pyparsing2: pyparsing>=2.3.0
 	django111: Django>=1.11,<1.11.99
 	django22: Django>=2.2,<2.2.99
 	django30: Django>=3.0,<3.0.99

--- a/webapp/graphite/render/evaluator.py
+++ b/webapp/graphite/render/evaluator.py
@@ -58,7 +58,7 @@ def evaluateTokens(requestContext, tokens, replacements=None, pipedArg=None):
     return evaluateTokens(requestContext, tokens.template, arglist)
 
   if tokens.expression:
-    if tokens.expression.pipedCalls:
+    if tokens.expression.pipedCalls.asList():
       # when the expression has piped calls, we pop the right-most call and pass the remaining
       # expression into it via pipedArg, to get the same result as a nested call
       rightMost = tokens.expression.pipedCalls.pop()

--- a/webapp/graphite/render/grammar_unsafe.py
+++ b/webapp/graphite/render/grammar_unsafe.py
@@ -80,7 +80,11 @@ kwargs = delimitedList(kwarg)
 
 
 def setRaw(s, loc, toks):
-    toks[0].raw = s[toks[0].start:toks[0].end]
+    try:
+        toks[0]['raw'] = s[toks[0].start:toks[0].end]
+    except AttributeError:
+        # Accommodate version < 3 of the PyParsing API.
+        toks[0].raw = s[toks[0].start:toks[0].end]
 
 
 call = Group(

--- a/webapp/graphite/render/grammar_unsafe.py
+++ b/webapp/graphite/render/grammar_unsafe.py
@@ -80,11 +80,7 @@ kwargs = delimitedList(kwarg)
 
 
 def setRaw(s, loc, toks):
-    try:
-        toks[0]['raw'] = s[toks[0].start:toks[0].end]
-    except AttributeError:
-        # Accommodate version < 3 of the PyParsing API.
-        toks[0].raw = s[toks[0].start:toks[0].end]
+    toks[0]['raw'] = s[toks[0].start:toks[0].end]
 
 
 call = Group(


### PR DESCRIPTION
Addresses issue raised in https://github.com/graphite-project/graphite-web/issues/2726 plus one other compatibility issue I came across with a failing piped query test.

I've checked that tests pass but haven't tested this in a live environment. Is it worth adding something to the tox matrix to check multiple pyparsing versions? It's been a while since I've used tox, so I left this part out as I'm not setup to test it properly.