### PR TITLE
functions view: Replace ANOTHER instance of Infinity in JSON

### DIFF
--- a/webapp/graphite/functions/views.py
+++ b/webapp/graphite/functions/views.py
@@ -6,7 +6,7 @@ from graphite.functions import SeriesFunctions, SeriesFunction, PieFunctions, Pi
 
 class jsonInfinityEncoder(json.JSONEncoder):
     def encode(self, o):
-        return super(jsonInfinityEncoder, self).encode(o).replace('Infinity,', '1e9999,')
+        return super(jsonInfinityEncoder, self).encode(o).replace('Infinity,', '1e9999,').replace('Infinity}', '1e9999}')
 
     def default(self, o):
         if hasattr(o, 'toJSON'):


### PR DESCRIPTION
This is a continuation of https://github.com/graphite-project/graphite-web/pull/2612 as it seems the target JSON may have changed structure slightly since the original patch was tested, meaning it misses replacing an instance of Infinity that comes last (does not have a trailing comma). This patch targets the trailing close brace also.

This patch fixes https://github.com/grafana/grafana/issues/45948