### PR TITLE
[1.1.x] Replace another missed instance of Infinity in JSON (#2737)

### DIFF
--- a/webapp/graphite/functions/views.py
+++ b/webapp/graphite/functions/views.py
@@ -6,7 +6,7 @@ from graphite.functions import SeriesFunctions, SeriesFunction, PieFunctions, Pi
 
 class jsonInfinityEncoder(json.JSONEncoder):
     def encode(self, o):
-        return super(jsonInfinityEncoder, self).encode(o).replace('Infinity,', '1e9999,')
+        return super(jsonInfinityEncoder, self).encode(o).replace('Infinity,', '1e9999,').replace('Infinity}', '1e9999}')
 
     def default(self, o):
         if hasattr(o, 'toJSON'):


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.1.x`:
 - [Replace another missed instance of Infinity in JSON (#2737)](https://github.com/graphite-project/graphite-web/pull/2737)

<!--- Backport version: 7.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)