### PR TITLE
Fixing typo in documentation (apache)

### DIFF
--- a/docs/config-webapp.rst
+++ b/docs/config-webapp.rst
@@ -323,7 +323,7 @@ Finally, configure the nginx vhost:
         listen 80;
 
         location /static/ {
-            alias /opt/graphite/webapp/content/;
+            alias /opt/graphite/webapp/content/
         }
 
         location / {


### PR DESCRIPTION
This PR will fix a typo error on apache configuration file