### PR TITLE
Introduce the term "node"

### DIFF
--- a/docs/terminology.rst
+++ b/docs/terminology.rst
@@ -18,6 +18,9 @@ terms mean in the context of Graphite.
 
     metric series
       See :term:`series`
+      
+    node
+      An element of the name of a :term:`series` separated by periods (``.``).
 
     precision
       See :term:`resolution`
@@ -35,7 +38,7 @@ terms mean in the context of Graphite.
 
     series
       A named set of datapoints. A series is identified by a unique name, which is composed of
-      elements separated by periods (``.``) which are used to display the collection of series
+      elements (each, a :term:`node`) separated by periods (``.``) which are used to display the collection of series
       into a hierarchical tree. A series storing system load average on a server called ``apache02``
       in datacenter ``metro_east`` might be named as ``metro_east.servers.apache02.system.load_average``
 


### PR DESCRIPTION
"Node" appears elsewhere throughout the documentation e.g. groupByNode. This PR adds a definition. I'm new to graphite and had to dig around to figure out what groupByNode meant - this definition I think would've been helpful. 