### PR TITLE
[1.1.x] Fixing typo in documentation (apache) (#2777)

### DIFF
--- a/docs/config-webapp.rst
+++ b/docs/config-webapp.rst
@@ -323,7 +323,7 @@ Finally, configure the nginx vhost:
         listen 80;
 
         location /static/ {
-            alias /opt/graphite/webapp/content/;
+            alias /opt/graphite/webapp/content/
         }
 
         location / {


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.1.x`:
 - [Fixing typo in documentation (apache) (#2777)](https://github.com/graphite-project/graphite-web/pull/2777)

<!--- Backport version: 7.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)