### PR TITLE
[1.1.x] Remove old comment (#2781)

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -4002,7 +4002,6 @@ def holtWintersDeviation(gamma,actual,prediction,last_seasonal_dev):
 def holtWintersAnalysis(series, seasonality='1d'):
   alpha = gamma = 0.1
   beta = 0.0035
-  # season is currently one day
   seasonality_time = parseTimeOffset(seasonality)
   season_length = (seasonality_time.seconds + (seasonality_time.days * 86400)) // series.step
   intercept = 0


### PR DESCRIPTION
# Backport

This will backport the following commits from `refs/heads/master` to `1.1.x`:
 - [Remove old comment (#2781)](https://github.com/graphite-project/graphite-web/pull/2781)

<!--- Backport version: 7.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)