### PR TITLE
[1.1.x] Avoid infinite loop on summarize() (#2784)

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -5391,6 +5391,9 @@ summarize.params = [
 
 
 def _summarizeValues(series, func, interval, newStart=None, newEnd=None):
+  if interval == 0:
+    raise InputParameterError("_summarizeValues(): interval parsed to 0")
+
   if newStart is None:
     newStart = series.start
   if newEnd is None:


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.1.x`:
 - [Avoid infinite loop on summarize() (#2784)](https://github.com/graphite-project/graphite-web/pull/2784)

<!--- Backport version: 7.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)