### PR TITLE
[1.1.x] Fix issue with too small season length (#2780) (#2787)

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -4005,6 +4005,9 @@ def holtWintersAnalysis(series, seasonality='1d'):
   # season is currently one day
   seasonality_time = parseTimeOffset(seasonality)
   season_length = (seasonality_time.seconds + (seasonality_time.days * 86400)) // series.step
+  # season_length should be 2 or more
+  if season_length < 2:
+    season_length = 2
   intercept = 0
   slope = 0
   intercepts = list()


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.1.x`:
 - [Fix issue with too small season length (#2780) (#2787)](https://github.com/graphite-project/graphite-web/pull/2787)

<!--- Backport version: 7.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)