### PR TITLE
[1.1.x] Сheck applyByNode nodeNum arg (#2792)

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -5100,7 +5100,10 @@ def applyByNode(requestContext, seriesList, nodeNum, templateFunction, newName=N
   """
   prefixes = set()
   for series in seriesList:
-    prefix = '.'.join(series.name.split('.')[:nodeNum + 1])
+    nodes = series.name.split('.')
+    if nodeNum >= len(nodes):
+        raise InputParameterError("{} do not contans {} nodes".format(series.name, nodeNum))
+    prefix = '.'.join(nodes[:nodeNum + 1])
     prefixes.add(prefix)
   results = []
   newContext = requestContext.copy()

--- a/webapp/tests/test_readers_multi.py
+++ b/webapp/tests/test_readers_multi.py
@@ -86,8 +86,9 @@ class MultiReaderTests(TestCase):
         reader = MultiReader([node1, node2])
         intervals = reader.get_intervals()
         for interval in intervals:
-            self.assertEqual(int(interval.start), self.start_ts - 60)
+            self.assertIn(int(interval.start), [self.start_ts - 60, self.start_ts - 60 - 1])
             self.assertIn(int(interval.end), [self.start_ts, self.start_ts - 1])
+            self.assertIn(int(interval.end - interval.start), [59,60])
 
     # Confirm fetch works.
     def test_MultiReader_fetch(self):


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.1.x`:
 - [Сheck applyByNode nodeNum arg (#2792)](https://github.com/graphite-project/graphite-web/pull/2792)

<!--- Backport version: 7.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)