### PR TITLE
[1.1.x] Pinning alabaster to 0.7.12 (#2805)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,8 @@ deps =
 	git+https://github.com/graphite-project/ceres.git#egg=ceres
 	Django<3.2.99
 	pyparsing: pyparsing>=2.3.0,<3.0.0
-	Sphinx<1.4
+	alabaster==0.7.12
+	Sphinx==1.3.6
 	jinja2<3.1.0
 	sphinx_rtd_theme
 	urllib3


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.1.x`:
 - [Pinning alabaster to 0.7.12 (#2805)](https://github.com/graphite-project/graphite-web/pull/2805)

<!--- Backport version: 7.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)