### PR TITLE
If max(series) returns None then the test with > throws an error

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -3803,8 +3803,11 @@ def useSeriesAbove(requestContext, seriesList, value, search, replace):
 
   for series in seriesList:
     newname = re.sub(search, replace, series.name)
-    if max(series) > value:
-      newNames.append(newname)
+    try:
+      if max(series) > value:
+        newNames.append(newname)
+    except TypeError:
+        continue
 
   if not newNames:
     return []


### PR DESCRIPTION
This probably should _never_ happen, but i'm randomly seeing it happen with the following stack trace.  In python2, this would not cause an exception.

```
Traceback (most recent call last):
  File "/opt/graphite/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/opt/graphite/lib/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/graphite/webapp/graphite/errors.py", line 121, in new_f
    return f(*args, **kwargs)
  File "/opt/graphite/webapp/graphite/render/views.py", line 130, in renderView
    data.extend(evaluateTarget(requestContext, targets))
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 34, in evaluateTarget
    result = evaluateTokens(requestContext, target)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 67, in evaluateTokens
    return evaluateTokens(requestContext, tokens.expression, replacements)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 102, in evaluateTokens
    args = [evaluateTokens(requestContext, arg, replacements) for arg in rawArgs]
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 102, in <listcomp>
    args = [evaluateTokens(requestContext, arg, replacements) for arg in rawArgs]
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 67, in evaluateTokens
    return evaluateTokens(requestContext, tokens.expression, replacements)
  File "/opt/graphite/webapp/graphite/render/evaluator.py", line 120, in evaluateTokens
    return func(requestContext, *args, **kwargs)
  File "/opt/graphite/webapp/graphite/render/functions.py", line 3806, in useSeriesAbove
    if max(series) > value:
TypeError: '>' not supported between instances of 'NoneType' and 'float'

```