### PR TITLE
Update carbon-daemons.rst - rewrite-rules

### DIFF
--- a/docs/carbon-daemons.rst
+++ b/docs/carbon-daemons.rst
@@ -103,6 +103,11 @@ and whisper file sizes due to lower retention policies.
   interval, the values received are aggregated and published to
   ``carbon-cache.py`` as a single metric.
 
+:doc:`rewrite-rules.conf </config-carbon>`
+  Defines regular expression patterns that can be used to rewrite metric names
+  in a search & replace fashion, ``[pre]`` and ``[post]`` aggreagation.
+
+
 carbon-aggregator-cache.py
 --------------------------
 
@@ -120,4 +125,8 @@ overhead of running both daemons.
 
 :doc:`aggregation-rules.conf </config-carbon>`
   See `carbon-aggregator.py` section.
+
+:doc:`rewrite-rules.conf </config-carbon>`
+  See `carbon-aggregator.py` section.
+
 

--- a/docs/carbon-daemons.rst
+++ b/docs/carbon-daemons.rst
@@ -105,7 +105,7 @@ and whisper file sizes due to lower retention policies.
 
 :doc:`rewrite-rules.conf </config-carbon>`
   Defines regular expression patterns that can be used to rewrite metric names
-  in a search & replace fashion, ``[pre]`` and ``[post]`` aggreagation.
+  in a search & replace fashion, ``[pre]`` and ``[post]`` aggregation.
 
 
 carbon-aggregator-cache.py


### PR DESCRIPTION
Explicitly state and relate rewrite-rules.conf to carbon-aggregator in the same way that relay-rules.conf is only applied to carbon-relay making it clearer as to what evaluates and executes rewrite-rules.conf