### PR TITLE
Sync Django version with requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ try:
       package_data={'graphite': ['templates/*', 'local_settings.py.example']},
       scripts=glob('bin/*'),
       data_files=list(webapp_content.items()) + storage_dirs + conf_files + examples,
-      install_requires=['Django>=3.2,<4', 'django-tagging==0.5.0', 'pytz',
+      install_requires=['Django>=4.2,<5', 'django-tagging', 'pytz',
                         'pyparsing', 'cairocffi', 'urllib3', 'six'],
       classifiers=[
           'Intended Audience :: Developers',


### PR DESCRIPTION
This fixes a dependency issue when installing with pip from a tarball. Found using Python 3.13, which removed the 'cgi' module, required for Django 3.2.