### PR TITLE
feat: replace python-memcached  with pymemcache

### DIFF
--- a/check-dependencies.py
+++ b/check-dependencies.py
@@ -117,12 +117,12 @@ if django and django.VERSION[:2] < (4,2):
     required += 1
 
 
-# Test for python-memcached
+# Test for pymemcache
 try:
-    import memcache
+    import pymemcache
 except ImportError:
-    sys.stderr.write("[OPTIONAL] Unable to import the 'memcache' module, "
-                     "do you have python-memcached installed for python %s? "
+    sys.stderr.write("[OPTIONAL] Unable to import the 'pymemcache' module, "
+                     "do you have pymemcache installed for python %s? "
                      "This feature is not required but greatly improves performance.\n" % sys.version_info.major)
     optional += 1
 
@@ -193,7 +193,7 @@ __all__ = [
     'pytz',
     'pyparsing',
     'tagging',
-    'memcache',
+    'pymemcache',
     'ldap',
     'txamqp',
     'rrdtool',

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -53,7 +53,7 @@ is part of the Graphite project.
 
 There are also several other dependencies required for additional features:
 
-* Render caching: `memcached`_ and `python-memcache`_
+* Render caching: `memcached`_ and `pymemcache`_
 * LDAP authentication: `python-ldap`_ (for LDAP authentication support in the webapp)
 * AMQP support: `txamqp`_ (version 0.8 is required)
 * RRD support: `python-rrdtool`_

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -145,7 +145,7 @@ Initial Configuration
 
 .. toctree::
    :maxdepth: 2
-   
+
    config-database-setup
    config-webapp
    config-local-settings
@@ -204,7 +204,7 @@ Unfortunately, native Graphite on Windows is completely unsupported, but you can
 .. _NOT Python 3: https://python3wos.appspot.com/
 .. _pip: https://pip.pypa.io/
 .. _python-ldap: https://www.python-ldap.org/
-.. _python-memcache: https://www.tummy.com/software/python-memcached/
+.. _pymemcache: https://github.com/pinterest/pymemcache
 .. _python-rrdtool: http://oss.oetiker.ch/rrdtool/prog/rrdpython.en.html
 .. _python-sqlite2: https://github.com/ghaering/pysqlite
 .. _pytz: https://pypi.python.org/pypi/pytz/

--- a/webapp/graphite/settings.py
+++ b/webapp/graphite/settings.py
@@ -323,7 +323,7 @@ if 'sqlite3' in DATABASES.get('default',{}).get('ENGINE','') \
 # Caching shortcuts
 if MEMCACHE_HOSTS:
     CACHES['default'] = {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
         'LOCATION': MEMCACHE_HOSTS,
         'TIMEOUT': DEFAULT_CACHE_DURATION,
         'KEY_PREFIX': MEMCACHE_KEY_PREFIX,


### PR DESCRIPTION
python-memcached is deprecated in django 4.x

https://github.com/graphite-project/graphite-web/issues/2877