### PR TITLE
Fix Deserialization of user-controlled data on renderLocalView

### DIFF
--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -24,7 +24,7 @@ from six.moves.urllib.parse import urlencode, urlsplit, urlunsplit, parse_qs
 from graphite.compat import HttpResponse
 from graphite.errors import InputParameterError, handleInputParameterError
 from graphite.user_util import getProfileByUsername
-from graphite.util import json, unpickle, pickle, msgpack, BytesIO
+from graphite.util import json, msgpack, BytesIO  # Removed unpickle, pickle
 from graphite.storage import extractForwardHeaders
 from graphite.logger import log
 from graphite.render.evaluator import evaluateTarget
@@ -499,7 +499,7 @@ def delegateRendering(graphType, graphOptions, headers=None):
   if headers is None:
     headers = {}
   start = time()
-  postData = (graphType + '\n').encode() + pickle.dumps(graphOptions)
+  postData = (graphType + '\n').encode() + json.dumps(graphOptions).encode('utf-8')
   servers = settings.RENDERING_HOSTS[:] #make a copy so we can shuffle it safely
   shuffle(servers)
   connector_class = connector_class_selector(settings.INTRACLUSTER_HTTPS)
@@ -552,7 +552,7 @@ def renderLocalView(request):
     optionsPickle = reqParams.read()
     reqParams.close()
     graphClass = GraphTypes[graphType]
-    options = unpickle.loads(optionsPickle)
+    options = json.loads(optionsPickle.decode('utf-8'))
     image = doImageRender(graphClass, options)
     log.rendering("Delegated rendering request took %.6f seconds" % (time() -  start))
     response = buildResponse(image)


### PR DESCRIPTION
https://github.com/graphite-project/graphite-web/blob/c92e8c0a15cba3092c512c6fa991f955f9c23cce/webapp/graphite/render/views.py#L27
https://github.com/graphite-project/graphite-web/blob/c92e8c0a15cba3092c512c6fa991f955f9c23cce/webapp/graphite/render/views.py#L502

https://github.com/graphite-project/graphite-web/blob/c92e8c0a15cba3092c512c6fa991f955f9c23cce/webapp/graphite/render/views.py#L555


Deserializing untrusted data using any deserialization framework that allows the construction of arbitrary serializable objects is easily exploitable and in many cases allows an attacker to execute arbitrary code. Even before a deserialized object is returned to the caller of a deserialization method a lot of code may have been executed, including static initializers, constructors, and finalizers. Automatic deserialization of fields means that an attacker may craft a nested combination of objects on which the executed initialization code may have unforeseen effects, such as the execution of arbitrary code.



The safest way to fix this vulnerability is to avoid using Pickle for this endpoint and instead use a safe data serialization format, such as JSON, which does not allow arbitrary code execution on deserialization. Specifically:

- For any data taken from an HTTP request (i.e., from `request.body` in `renderLocalView`), parsing must be done using `json.loads`.
- Any remote code sending to this endpoint (such as in `delegateRendering`) should switch to using JSON serialization (`json.dumps` in place of `pickle.dumps`).
- The unpickling logic in `renderLocalView` should be replaced with JSON deserialization.
- Adjust the encoding/decoding steps to ensure everything is bytes and strings as appropriate, given HTTP bodies and the format expected.
- Update the code in both `delegateRendering` (request construction) and `renderLocalView` (request parsing).

Only the code snippets provided can be modified. Since the problematic use is in both `webapp/graphite/render/views.py` (logic for reading/parsing, and logic for sending), changes will be applied there only.


### References
[Deserialization of untrusted data](https://www.owasp.org/index.php/Deserialization_of_untrusted_data)
[objects Deserialization Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html)
Talks by Chris Frohoff & Gabriel Lawrence: [AppSecCali 2015: Marshalling Pickles - how deserializing objects will ruin your day](http://frohoff.github.io/appseccali-marshalling-pickles/)