### PR TITLE
Fix TypeError in _nonNegativeDelta when val is None and maxValue is set

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2427,15 +2427,15 @@ nonNegativeDerivative.params = [
 
 
 def _nonNegativeDelta(val, prev, maxValue, minValue):
+  # first reading or None value
+  if None in (prev, val):
+    return None, val
+
   # ignore values larger than maxValue
   if maxValue is not None and val > maxValue:
     return None, None
   if minValue is not None and val < minValue:
     return None, None
-
-  # first reading
-  if None in (prev, val):
-    return None, val
 
   # counter increased, use the difference
   if val >= prev:

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2427,15 +2427,18 @@ nonNegativeDerivative.params = [
 
 
 def _nonNegativeDelta(val, prev, maxValue, minValue):
-  # first reading or None value
-  if None in (prev, val):
-    return None, val
+  if val is None:
+    return None, None
 
   # ignore values larger than maxValue
   if maxValue is not None and val > maxValue:
     return None, None
   if minValue is not None and val < minValue:
     return None, None
+
+  # first reading
+  if prev is None:
+    return None, val
 
   # counter increased, use the difference
   if val >= prev:

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -1798,6 +1798,10 @@ class FunctionsTest(TestCase):
         result = functions.scaleToSeconds({}, functions.nonNegativeDerivative({}, seriesList), 1)
         self.assertEqual(list(expected[0]), list(result[0]))
 
+        # None values should not raise TypeError when maxValue is set
+        result = functions.perSecond({}, seriesList, maxValue=1000)
+        self.assertEqual(list(expected[0]), list(result[0]))
+
     def test_perSecond_max(self):
         seriesList = self._gen_series_list_with_data(key='test',start=0,end=600,step=60,data=[0, 120, 240, 480, 960, 900, 120, 240, 119, 479])
         expected = [TimeSeries('perSecond(test)', 0, 600, 60, [None, 2, 2, 4, None, None, None, 2, 6, 6])]


### PR DESCRIPTION
`_nonNegativeDelta` compared `val` against `maxValue`/`minValue` before checking whether `val` is `None`, causing a `TypeError` when a series contains `None` values and `maxValue` (or `minValue`) is provided.

Fix: move the `None in (prev, val)` early-return before the comparisons. This also makes semantic sense — on the first reading or a `None` value there is no delta to compute, regardless of bounds.

The added test case reproduces the issue, and fails without the fix:

```python
  ======================================================================
     ERROR: test_perSecond_nones (tests.test_functions.FunctionsTest.test_perSecond_nones)
     ----------------------------------------------------------------------
     Traceback (most recent call last):
       File "/home/nicolas/code/graphite-web/webapp/tests/test_functions.py", line 1802, in test_perSecond_nones
         result = functions.perSecond({}, seriesList, maxValue=1000)
       File "/home/nicolas/code/graphite-web/webapp/graphite/render/functions.py", line 2230, in perSecond
         delta, prev = _nonNegativeDelta(val, prev, maxValue, minValue)
                       ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       File "/home/nicolas/code/graphite-web/webapp/graphite/render/functions.py", line 2431, in _nonNegativeDelta
         if maxValue is not None and val > maxValue:
                                     ^^^^^^^^^^^^^^
     TypeError: '>' not supported between instances of 'NoneType' and 'int'

     ----------------------------------------------------------------------
     Ran 1 test in 0.003s
```