### PR TITLE
Fix `graphite.util.epoch` for Django 5

### DIFF
--- a/webapp/graphite/util.py
+++ b/webapp/graphite/util.py
@@ -59,7 +59,7 @@ def epoch(dt):
   if not dt.tzinfo:
     tb = traceback.extract_stack(None, 2)
     log.warning('epoch() called with non-timezone-aware datetime in %s at %s:%d' % (tb[0][2], tb[0][0], tb[0][1]))
-    return calendar.timegm(make_aware(dt, pytz.timezone(settings.TIME_ZONE)).astimezone(pytz.utc).timetuple())
+    return calendar.timegm(pytz.timezone(settings.TIME_ZONE).localize(dt, is_dst=None).astimezone(pytz.utc).timetuple())
   return calendar.timegm(dt.astimezone(pytz.utc).timetuple())
 
 


### PR DESCRIPTION
This PR fixes the `test_epoch_naive` failure that currently occurs when running the Graphite test suite with Django 5; as a specific reproducible example, here's the relevant `nix-build -A python3Packages.graphite-web` log snippet at NixOS/nixpkgs@40607652611853cc32c2eb55d13bbbe5c4cc4287:

```
FAIL: test_epoch_naive (tests.test_util.UtilTest.test_epoch_naive)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/nix/store/ccf31a4yhdqra20xb8yjcps9rlp42q5h-python3.13-mock-5.2.0/lib/python3.13/site-packages/mock/mock.py", line 1468, in patched
    return func(*newargs, **newkeywargs)
  File "/build/source/webapp/tests/test_util.py", line 40, in test_epoch_naive
    self.assertEqual(util.epoch(dt), 600)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
AssertionError: 1020 != 600
```

#2886 added support for Django 5, but this repo's CI didn't catch the test failure because the tox configuration forces Django 4:

https://github.com/graphite-project/graphite-web/blob/b5d272be6abdf358aebe56d12df777c2c97de4c3/.github/workflows/tests.yml#L72-L83

https://github.com/graphite-project/graphite-web/blob/b5d272be6abdf358aebe56d12df777c2c97de4c3/tox.ini#L37

The reason the test fails is because of [a change in Django 5](https://docs.djangoproject.com/en/5.0/releases/5.0/#features-removed-in-5-0):

> Support for `pytz` timezones is removed.

Specifically, django/django@e6f82438d4e3750e8d299bfd79dac98eebe9f1e0 removed the pytz-specific branch from `django.utils.timezone.make_aware`.

The fix is to replace this `make_aware` call with code equivalent to [what the Django 4 implementation of `make_aware` would have done](https://github.com/django/django/blob/4.2.30/django/utils/timezone.py#L272-L293). Note that the effect of `is_dst=None` is to [`raise` in some specific cases](https://github.com/stub42/pytz/blob/release_2026.1.post1/src/pytz/tzinfo.py#L115-L156); otherwise the `localize` method defaults to `is_dst=False`, which would silently use standard time in those cases.

The other `make_aware` call (in the `epoch_to_dt` function) does not need to change because the UTC timezone is unaffected by this Django behavior change.